### PR TITLE
Setup with stack running as separate layers

### DIFF
--- a/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
@@ -20,6 +20,7 @@ public class Application {
 
   public static void main(String[] args) {
     try {
+      init();
       ApplicationLifecycleManager.updateStatus(LifecycleStatus.STARTED);
 
       log.info("Cache has started");

--- a/backend/tile-app/tile.xml
+++ b/backend/tile-app/tile.xml
@@ -10,8 +10,7 @@
   <properties>
     <app.entrypoint>io.featurehub.Application</app.entrypoint>
     <app.port>8903</app.port>
-    <build.version>1.1</build.version>
-    <docker.repository>gcr.io</docker.repository>
+    <build.version>0.0.1</build.version>
     <app.baseimage>adoptopenjdk:11-jre-hotspot</app.baseimage>
   </properties>
 
@@ -39,7 +38,7 @@
                   <goal>babysaur</goal>
                 </goals>
                 <configuration>
-                  <fullImageName>${docker.repository}/featurehub/${project.artifactId}:${build.version}</fullImageName>
+                  <fullImageName>featurehub/${project.artifactId}:${build.version}</fullImageName>
                   <baseImageName>featurehub/${project.artifactId}:${build.version}</baseImageName>
                 </configuration>
               </execution>
@@ -63,7 +62,7 @@
                 <image>${app.baseimage}</image>
               </from>
               <to>
-                <image>${docker.repository}/featurehub/${project.artifactId}:${build.version}</image>
+                <image>featurehub/${project.artifactId}:${build.version}</image>
               </to>
               <container>
                 <mainClass>bathe.BatheBooter</mainClass>

--- a/run-configurations/all-separate-postgres/app-config/application.properties
+++ b/run-configurations/all-separate-postgres/app-config/application.properties
@@ -1,0 +1,4 @@
+db.url=jdbc:postgresql://db:5432/featurehub
+db.username=featurehub
+db.password=featurehub
+nats.urls=nats://nats:4222

--- a/run-configurations/all-separate-postgres/common-config/log4j2.xml
+++ b/run-configurations/all-separate-postgres/common-config/log4j2.xml
@@ -1,0 +1,25 @@
+<Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <ConnectJsonLayout/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <AsyncLogger name="io.featurehub" level="debug"/>
+    <AsyncLogger name="io.ebean.SQL" level="trace"/>
+    <AsyncLogger name="io.ebean.TXN" level="trace"/>
+    <AsyncLogger name="io.ebean.SUM" level="trace"/>
+    <AsyncLogger name="io.ebean.DDL" level="trace"/>
+    <AsyncLogger name="io.ebean.cache.QUERY" level="trace"/>
+    <AsyncLogger name="io.ebean.cache.BEAN" level="trace"/>
+    <AsyncLogger name="io.ebean.cache.COLL" level="trace"/>
+    <AsyncLogger name="io.ebean.cache.NATKEY" level="trace"/>
+
+    <AsyncLogger name="jersey-logging" level="trace" />
+
+    <AsyncRoot level="info">
+      <AppenderRef ref="STDOUT"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/run-configurations/all-separate-postgres/dacha-config/application.properties
+++ b/run-configurations/all-separate-postgres/dacha-config/application.properties
@@ -1,0 +1,2 @@
+cache.name=default
+nats.urls=nats://nats:4222

--- a/run-configurations/all-separate-postgres/docker-compose.yaml
+++ b/run-configurations/all-separate-postgres/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: '3.1'
+
+services:
+  nats:
+    image: nats:2.1.7-alpine
+    restart: always
+    ports:
+    - 4222:4222
+  mr-server:
+    image: featurehub/mr:0.0.1
+    restart: always
+    volumes:
+      - ./app-config:/etc/app-config
+    ports:
+      - 8085:8085
+    depends_on:
+      - "db"
+      - "nats"
+  dacha:
+    image: featurehub/dacha:0.0.1
+    restart: always
+    volumes:
+      - ./dacha-config:/etc/app-config
+      - ./common-config:/etc/common-config
+    depends_on:
+      - "mr-server"
+      - "nats"
+  edge:
+    image: featurehub/edge:0.0.1
+    restart: always
+    volumes:
+      - ./edge-config:/etc/app-config
+      - ./common-config:/etc/common-config
+    ports:
+      - 8553:8553
+    depends_on:
+      - "nats"
+  db:
+    image: postgres:12-alpine
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: mypassword
+    volumes:
+      - ./initdb:/docker-entrypoint-initdb.d
+      - featurehub-ps1-db:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+volumes:
+  featurehub-ps1-db:

--- a/run-configurations/all-separate-postgres/edge-config/application.properties
+++ b/run-configurations/all-separate-postgres/edge-config/application.properties
@@ -1,0 +1,3 @@
+server.port=8553
+maxSlots=60
+nats.urls=nats://nats:4222

--- a/run-configurations/all-separate-postgres/initdb/initdb.sh
+++ b/run-configurations/all-separate-postgres/initdb/initdb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+CREATE USER featurehub PASSWORD 'featurehub';
+CREATE DATABASE featurehub;
+GRANT ALL PRIVILEGES ON DATABASE featurehub TO featurehub;
+EOSQL


### PR DESCRIPTION
# Description

This showcases each of the different pieces
running separately against a postgres database.
It includes the NATs, postgres, dacha, MR, Edge
apps with their dependencies ordered.

There is still an ongoing issue with the empty
cache realizing it is filled.

Fixes #4 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Docker running and starting and using the server.

