### PR TITLE
Ensure promotion order for each new environment

### DIFF
--- a/admin-frontend/app_singleapp/lib/widgets/features/features_overview_table_widget.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/features_overview_table_widget.dart
@@ -2,7 +2,6 @@ import 'package:app_singleapp/api/client_api.dart';
 import 'package:app_singleapp/api/router.dart';
 import 'package:app_singleapp/widgets/common/fh_card.dart';
 import 'package:app_singleapp/widgets/common/fh_flat_button_transparent.dart';
-import 'package:app_singleapp/widgets/common/fh_link.dart';
 import 'package:app_singleapp/widgets/features/feature_value_row_boolean.dart';
 import 'package:app_singleapp/widgets/features/feature_value_row_generic.dart';
 import 'package:app_singleapp/widgets/features/feature_value_row_json.dart';
@@ -188,17 +187,6 @@ class _FeatureHeader extends StatelessWidget {
             children: <Widget>[
               Text(efv.environmentName,
                   style: Theme.of(context).textTheme.bodyText1),
-              if (index != 0 && efv.priorEnvironmentId == null)
-                FHLink(
-                  tooltip:
-                      efv.environmentName + " is not ordered - tap to order",
-                  href: '/manage-app',
-                  child: Icon(
-                    Icons.report_problem,
-                    size: 24.0,
-                    color: Colors.red,
-                  ),
-                ),
               SDKDetailsWidget(bloc: bloc, envId: efv.environmentId)
             ],
           )),
@@ -590,13 +578,11 @@ class NoEnvironmentMessage extends StatelessWidget {
                 return FHFlatButtonTransparent(
                     title: 'Manage application',
                     keepCase: true,
-                    onPressed: () =>
-                        ManagementRepositoryClientBloc.router.navigateTo(
-                            context,
-                            '/manage-app',
-                            replace: true,
-                            transition: TransitionType.material,
-                            params: {
+                    onPressed: () => ManagementRepositoryClientBloc.router
+                            .navigateTo(context, '/manage-app',
+                                replace: true,
+                                transition: TransitionType.material,
+                                params: {
                               "id": [bloc.applicationId],
                               "tab-name": ["environments"]
                             }));

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/DbArchiveStrategy.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/DbArchiveStrategy.java
@@ -68,12 +68,14 @@ public class DbArchiveStrategy implements ArchiveStrategy {
     database.save(environment);
     cacheSource.deleteEnvironment(environment.getId());
     new QDbEnvironment().priorEnvironment.eq(environment).findList().forEach(e -> {
-      if (e.getId().equals(environment.getPriorEnvironment().getId())) {
-        e.setPriorEnvironment(null);
-      } else {
-        e.setPriorEnvironment(environment.getPriorEnvironment());
+      if (environment.getPriorEnvironment() != null) {
+        if (e.getId().equals(environment.getPriorEnvironment().getId())) {
+          e.setPriorEnvironment(null);
+        } else {
+          e.setPriorEnvironment(environment.getPriorEnvironment());
+        }
+        database.save(e);
       }
-      database.save(e);
     });
   }
 

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
@@ -20,6 +20,7 @@ import io.featurehub.db.model.query.QDbEnvironment;
 import io.featurehub.db.model.query.QDbEnvironmentFeatureStrategy;
 import io.featurehub.db.model.query.QDbGroup;
 import io.featurehub.db.publish.CacheSource;
+import io.featurehub.db.utils.EnvironmentUtils;
 import io.featurehub.mr.model.ApplicationFeatureValues;
 import io.featurehub.mr.model.EnvironmentFeatureValues;
 import io.featurehub.mr.model.EnvironmentFeaturesResult;
@@ -514,9 +515,9 @@ public class FeatureSqlApi implements FeatureApi {
           final DbEnvironment env1 = environmentOrderingMap.get(o1.getEnvironmentId());
           final DbEnvironment env2 = environmentOrderingMap.get(o2.getEnvironmentId());
 
-          Integer w = walkAndCompare(env1, env2);
+          Integer w = EnvironmentUtils.walkAndCompare(env1, env2);
           if (w == null) {
-            w = walkAndCompare(env2, env1);
+            w = EnvironmentUtils.walkAndCompare(env2, env1);
             if (w == null) {
               if (env1.getPriorEnvironment() == null && env2.getPriorEnvironment() == null) {
                 return 0;
@@ -550,26 +551,7 @@ public class FeatureSqlApi implements FeatureApi {
     return null;
   }
 
-  Integer walkAndCompare(DbEnvironment env1, DbEnvironment env2) {
-    if (env1.getPriorEnvironment() == null) {
-      return null;
-    }
 
-    // env1's prior environment can't be env2
-    if (env2 == null) {
-      return null;
-    }
-
-    if (env1.getPriorEnvironment() == env2) {
-      return 1;
-    }
-
-    if (env2.getPriorEnvironment() == env1) {
-      return -1;
-    }
-
-    return walkAndCompare(env1, env2.getPriorEnvironment());
-  }
 
 
   // todo: I hate this API, its way way too ICBM

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/utils/EnvironmentUtils.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/utils/EnvironmentUtils.java
@@ -1,0 +1,26 @@
+package io.featurehub.db.utils;
+
+import io.featurehub.db.model.DbEnvironment;
+
+public class EnvironmentUtils {
+  public static Integer walkAndCompare(DbEnvironment env1, DbEnvironment env2) {
+    if (env1.getPriorEnvironment() == null) {
+      return null;
+    }
+
+    // env1's prior environment can't be env2
+    if (env2 == null) {
+      return null;
+    }
+
+    if (env1.getPriorEnvironment() == env2) {
+      return 1;
+    }
+
+    if (env2.getPriorEnvironment() == env1) {
+      return -1;
+    }
+
+    return walkAndCompare(env1, env2.getPriorEnvironment());
+  }
+}

--- a/e2e/test/features/environments.feature
+++ b/e2e/test/features/environments.feature
@@ -73,11 +73,17 @@ Feature: Environments exist under features and should be able to be managed only
     Given The superuser is the user
     And I ensure a portfolio named "<portfolio>" with description "<desc>" exists
     And I ensure an application with the name "<appName>" with description "<appDesc>" in the portfolio "<portfolio>" exists
+    And I delete all existing environments
     And I ensure that an environments exist:
       | name | desc    |
       | dev  | devenv  |
       | test | testenv |
       | staging | testenv |
+    And I check that environment ordering:
+      | parent  | child   |
+      | dev        | test    |
+      | test       | staging |
+      | staging    |         |
     And I ensure that environment "dev" is before environment "test"
     And I ensure that environment "test" is before environment "staging"
     And I check to see that the prior environment for "test" is "dev"

--- a/e2e/test/steps/EnvironmentStepdefs.dart
+++ b/e2e/test/steps/EnvironmentStepdefs.dart
@@ -3,48 +3,52 @@ import 'package:app_singleapp/user_common.dart';
 import 'package:mrapi/api.dart';
 import 'package:ogurets/ogurets.dart';
 
-
 class EnvironmentStepdefs {
   final UserCommon common;
   final Shared shared;
 
   EnvironmentStepdefs(this.common, this.shared);
 
-  Future<Application> _findApplication(String portfolioName, String appName) async {
+  Future<Application> _findApplication(
+      String portfolioName, String appName) async {
     Portfolio p = await common.findExactPortfolio(portfolioName);
     assert(p != null, 'Cannot find portfolio $portfolioName');
 
     Application a = await common.findExactApplication(appName, p.id);
-    assert(a != null, 'Cannot find application $appName inside portfolio $portfolioName');
+    assert(a != null,
+        'Cannot find application $appName inside portfolio $portfolioName');
 
     return a;
   }
 
-  Future<Group> _findGroup(String portfolioName, String groupName, bool includeEnvironmentGroupRoles) async {
+  Future<Group> _findGroup(String portfolioName, String groupName,
+      bool includeEnvironmentGroupRoles) async {
     Portfolio p = await common.findExactPortfolio(portfolioName);
     assert(p != null, 'Cannot find portfolio $portfolioName');
 
     Group g = includeEnvironmentGroupRoles
-      ?  await common.findExactGroupWithPerms(groupName, p.id )
-      : await common.findExactGroup(groupName, p.id );
+        ? await common.findExactGroupWithPerms(groupName, p.id)
+        : await common.findExactGroup(groupName, p.id);
 
-    assert(g != null, 'Cannot find group $groupName inside portfolio $portfolioName');
+    assert(g != null,
+        'Cannot find group $groupName inside portfolio $portfolioName');
 
     return g;
   }
 
-  @And(r'I ensure that an environment {string} with description {string} exists in the app {string} in the portfolio {string}')
+  @And(
+      r'I ensure that an environment {string} with description {string} exists in the app {string} in the portfolio {string}')
   void iEnsureThatAnEnvironmentWithDescriptionExistsInTheAppInThePortfolio(
-    String name, String desc, String appName, String portfolioName) async {
-
+      String name, String desc, String appName, String portfolioName) async {
     Application application = await _findApplication(portfolioName, appName);
 
     var exists = await common.findExactEnvironment(name, application.id);
     if (exists == null) {
-      exists = await common.environmentService.createEnvironment(application.id,
-        new Environment()
-         ..name = name
-         ..description = desc);
+      exists = await common.environmentService.createEnvironment(
+          application.id,
+          new Environment()
+            ..name = name
+            ..description = desc);
     }
 
     assert(exists != null, 'Could not create environment $name');
@@ -56,7 +60,8 @@ class EnvironmentStepdefs {
   @And(r'I can find environment {string} in the application')
   void iCanFindEnvironmentInTheApplication(String name) async {
     Application app = shared.application;
-    assert(app != null, 'You have missed a step storing the selected application');
+    assert(
+        app != null, 'You have missed a step storing the selected application');
 
     var env = await common.findExactEnvironment(name, app.id);
 
@@ -66,60 +71,81 @@ class EnvironmentStepdefs {
   @And(r'I cannot find environment {string} in the application')
   void iCannotFindEnvironmentInTheApplication(String name) async {
     Application app = shared.application;
-    assert(app != null, 'You have missed a step storing the selected application');
+    assert(
+        app != null, 'You have missed a step storing the selected application');
 
     var env = await common.findExactEnvironment(name, app.id);
 
-    assert(env == null, 'Could find environment $name in app ${app.name} and should not be allowed to.');
+    assert(env == null,
+        'Could find environment $name in app ${app.name} and should not be allowed to.');
   }
 
-  @And(r'I ensure the permission {string} is added to the group {string} for the env {string} for app {string} for portfolio {string}')
-  void iEnsureThePermissionIsAddedToTheGroupForTheEnvForAppForPortfolio(String perm, String groupName,
-    String environmentName, String appName, String portfolioName) async {
-
+  @And(
+      r'I ensure the permission {string} is added to the group {string} for the env {string} for app {string} for portfolio {string}')
+  void iEnsureThePermissionIsAddedToTheGroupForTheEnvForAppForPortfolio(
+      String perm,
+      String groupName,
+      String environmentName,
+      String appName,
+      String portfolioName) async {
     Application application = await _findApplication(portfolioName, appName);
     Group group = await _findGroup(portfolioName, groupName, true);
-    var environment = await common.findExactEnvironment(environmentName, application.id);
+    var environment =
+        await common.findExactEnvironment(environmentName, application.id);
     EnvironmentGroupRole egr = EnvironmentGroupRole();
     egr.groupId = group.id;
     egr.environmentId = environment.id;
-    perm=="READ" ?  egr.roles.add(RoleType.READ):{};
-    perm=="EDIT" ?  egr.roles.add(RoleType.EDIT):{};
-    perm=="LOCK" ?  egr.roles.add(RoleType.LOCK):{};
-    perm=="UNLOCK" ?  egr.roles.add(RoleType.UNLOCK):{};
+    perm == "READ" ? egr.roles.add(RoleType.READ) : {};
+    perm == "EDIT" ? egr.roles.add(RoleType.EDIT) : {};
+    perm == "LOCK" ? egr.roles.add(RoleType.LOCK) : {};
+    perm == "UNLOCK" ? egr.roles.add(RoleType.UNLOCK) : {};
 
     group.environmentRoles.add(egr);
 
-    await common.groupService.updateGroup(group.id, group, includeGroupRoles: true, updateEnvironmentGroupRoles: true, updateApplicationGroupRoles: true);
+    await common.groupService.updateGroup(group.id, group,
+        includeGroupRoles: true,
+        updateEnvironmentGroupRoles: true,
+        updateApplicationGroupRoles: true);
 
     shared.application = application;
-
   }
 
-  @And(r'I can find perm {string} in the group {string} for the env {string} for app {string} for portfolio {string}')
-  void iCanFindPermissionInTheGroupForTheEnvForAppForPortfolio(String perm, String groupName, String envName,
-    String appName, String portfolioName) async {
+  @And(
+      r'I can find perm {string} in the group {string} for the env {string} for app {string} for portfolio {string}')
+  void iCanFindPermissionInTheGroupForTheEnvForAppForPortfolio(
+      String perm,
+      String groupName,
+      String envName,
+      String appName,
+      String portfolioName) async {
     Group group = await _findGroup(portfolioName, groupName, true);
     Application application = await _findApplication(portfolioName, appName);
-    Environment environment = await common.findExactEnvironment(envName, application.id);
-    EnvironmentGroupRole egr = group.environmentRoles.firstWhere((environmentRole){
+    Environment environment =
+        await common.findExactEnvironment(envName, application.id);
+    EnvironmentGroupRole egr =
+        group.environmentRoles.firstWhere((environmentRole) {
       return environmentRole.environmentId == environment.id;
     });
     RoleType compareTo = RoleType.READ;
-    perm=="EDIT" ?  compareTo = RoleType.EDIT:{};
-    perm=="LOCK" ?  compareTo = RoleType.LOCK:{};
-    perm=="UNLOCK" ?  compareTo = RoleType.UNLOCK:{};
+    perm == "EDIT" ? compareTo = RoleType.EDIT : {};
+    perm == "LOCK" ? compareTo = RoleType.LOCK : {};
+    perm == "UNLOCK" ? compareTo = RoleType.UNLOCK : {};
 
-    assert(egr.roles.contains(compareTo), "Permission ${perm} not found in Group" );
+    assert(
+        egr.roles.contains(compareTo), "Permission ${perm} not found in Group");
   }
 
-  @And(r'I ensure all permissions added to the group {string} for the env {string} for app {string} for portfolio {string}')
+  @And(
+      r'I ensure all permissions added to the group {string} for the env {string} for app {string} for portfolio {string}')
   void iEnsureAllPermissionsAddedToTheGroupForTheEnvForAppForPortfolio(
-    String groupName, String envName,
-    String appName, String portfolioName) async {
+      String groupName,
+      String envName,
+      String appName,
+      String portfolioName) async {
     Application application = await _findApplication(portfolioName, appName);
     Group group = await _findGroup(portfolioName, groupName, true);
-    var environment = await common.findExactEnvironment(envName, application.id);
+    var environment =
+        await common.findExactEnvironment(envName, application.id);
     EnvironmentGroupRole egr = EnvironmentGroupRole();
     egr.groupId = group.id;
     egr.environmentId = environment.id;
@@ -129,19 +155,23 @@ class EnvironmentStepdefs {
     egr.roles.add(RoleType.UNLOCK);
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroup(group.id, group, includeGroupRoles: true, updateEnvironmentGroupRoles: true);
+    await common.groupService.updateGroup(group.id, group,
+        includeGroupRoles: true, updateEnvironmentGroupRoles: true);
     shared.application = application;
-    }
+  }
 
-  @And(r'I ensure that an environment {string} with description {string} exists')
-  void iEnsureThatAnEnvironmentWithDescription(String envName,
-      String envDesc) async {
+  @And(
+      r'I ensure that an environment {string} with description {string} exists')
+  void iEnsureThatAnEnvironmentWithDescription(
+      String envName, String envDesc) async {
     assert(shared.portfolio != null, 'must have portfolio');
     assert(shared.application != null, 'must have application');
 
-    var exists = await common.findExactEnvironment(envName, shared.application.id);
+    var exists =
+        await common.findExactEnvironment(envName, shared.application.id);
     if (exists == null) {
-      exists = await common.environmentService.createEnvironment(shared.application.id,
+      exists = await common.environmentService.createEnvironment(
+          shared.application.id,
           new Environment()
             ..name = envName
             ..description = envDesc);
@@ -159,9 +189,12 @@ class EnvironmentStepdefs {
     assert(shared.group != null, 'must have a group');
     assert(shared.environment != null, 'must have an environment');
 
-    final updatedGroup = await common.groupService.getGroup(shared.group.id, includeGroupRoles: true);
+    final updatedGroup = await common.groupService
+        .getGroup(shared.group.id, includeGroupRoles: true);
     final roleType = RoleTypeTypeTransformer.fromJson(perm);
-    var eRoles = updatedGroup.environmentRoles.firstWhere((er) => er.environmentId == shared.environment.id, orElse: () => null);
+    var eRoles = updatedGroup.environmentRoles.firstWhere(
+        (er) => er.environmentId == shared.environment.id,
+        orElse: () => null);
     if (eRoles == null) {
       eRoles = EnvironmentGroupRole()
         ..roles = [roleType]
@@ -172,7 +205,8 @@ class EnvironmentStepdefs {
       eRoles.roles.add(roleType);
     }
 
-    await common.groupService.updateGroup(shared.group.id, updatedGroup, updateEnvironmentGroupRoles: true);
+    await common.groupService.updateGroup(shared.group.id, updatedGroup,
+        updateEnvironmentGroupRoles: true);
   }
 
   @And(r'I ensure that an environments exist:')
@@ -180,52 +214,101 @@ class EnvironmentStepdefs {
     assert(shared.portfolio != null, 'Portfolio exists');
     assert(shared.application != null, 'Application exists');
 
-    for(var g in table) {
+    for (var g in table) {
       final envName = g["name"];
       final envDesc = g["desc"];
-      final foundEnv = await common.findExactEnvironment(envName, shared.application.id);
+      final foundEnv =
+          await common.findExactEnvironment(envName, shared.application.id);
       if (foundEnv == null) {
-        await common.environmentService.createEnvironment(shared.application.id,
+        await common.environmentService.createEnvironment(
+            shared.application.id,
             Environment()
               ..name = envName
               ..description = envDesc
-              ..applicationId = shared.application.id
-        );
+              ..applicationId = shared.application.id);
       }
     }
   }
 
   @And(r'I ensure that environment {string} is before environment {string}')
-  void iEnsureThatEnvironmentIsBeforeEnvironment(String envFindName,
-      String envUpdatePriorName) async {
-
+  void iEnsureThatEnvironmentIsBeforeEnvironment(
+      String envFindName, String envUpdatePriorName) async {
     assert(shared.application != null, 'Application exists');
     final appId = shared.application.id;
     Environment envFind = await common.findExactEnvironment(envFindName, appId);
-    Environment envUpdatePrior = await common.findExactEnvironment(envUpdatePriorName, appId);
+    Environment envUpdatePrior =
+        await common.findExactEnvironment(envUpdatePriorName, appId);
 
-    await common.environmentService.updateEnvironment(envUpdatePrior.id,
-        envUpdatePrior..priorEnvironmentId = envFind.id);
+    await common.environmentService.updateEnvironment(
+        envUpdatePrior.id, envUpdatePrior..priorEnvironmentId = envFind.id);
   }
 
   @And(r'I check to see that the prior environment for {string} is {string}')
-  void iCheckToSeeThatThePriorEnvironmentForIs(String envThatHasPriorName, String envThatIsPriorName) async {
-
+  void iCheckToSeeThatThePriorEnvironmentForIs(
+      String envThatHasPriorName, String envThatIsPriorName) async {
     assert(shared.application != null, 'Application exists');
     final appId = shared.application.id;
-    Environment envThatHasPrior = await common.findExactEnvironment(envThatHasPriorName, appId);
-    Environment envThatIsPrior = await common.findExactEnvironment(envThatIsPriorName, appId);
+    Environment envThatHasPrior =
+        await common.findExactEnvironment(envThatHasPriorName, appId);
+    Environment envThatIsPrior =
+        await common.findExactEnvironment(envThatIsPriorName, appId);
 
-    assert(envThatHasPrior.priorEnvironmentId == envThatIsPrior.id, 'Does not match!');
+    assert(envThatHasPrior.priorEnvironmentId == envThatIsPrior.id,
+        'Does not match!');
   }
 
   @And(r'I check to see that the prior environment for {string} is empty')
   void iCheckToSeeThatThePriorEnvironmentForIsEmpty(String priorEnvName) async {
-
     assert(shared.application != null, 'Application exists');
     final appId = shared.application.id;
     Environment env = await common.findExactEnvironment(priorEnvName, appId);
 
     assert(env.priorEnvironmentId == null, 'Prior environment id is empty!');
+  }
+
+  @And(r'I delete all existing environments')
+  void iDeleteAllExistingEnvironments() async {
+    assert(shared.application != null, 'Application does not exist');
+
+    shared.application = await common.applicationService
+        .getApplication(shared.application.id, includeEnvironments: true);
+
+    for (var e in shared.application.environments) {
+      await common.environmentService.deleteEnvironment(e.id);
+    }
+
+    shared.application = await common.applicationService
+        .getApplication(shared.application.id, includeEnvironments: true);
+
+    assert(shared.application.environments.length == 0, 'did not delete all environments! ${shared.application.environments}');
+  }
+
+  @And(r'I check that environment ordering:')
+  void iCheckThatEnvironmentOrdering(GherkinTable table) async {
+    assert(shared.application != null, 'Application does not exist');
+
+    shared.application = await common.applicationService
+        .getApplication(shared.application.id, includeEnvironments: true);
+
+    for (var e in table) {
+      final parent = shared.application.environments
+          .firstWhere((en) => en.name == e['parent']);
+      final child = e['child'].toString().isEmpty
+          ? null
+          : shared.application.environments
+              .firstWhere((en) => en.name == e['child']);
+
+      if (child == null) {
+        assert(
+            shared.application.environments.firstWhere(
+                    (element) => element.priorEnvironmentId == parent.id,
+                    orElse: () => null) ==
+                null,
+            'Environment ${e["parent"]} is a parent and should not be');
+      } else {
+        assert(child.priorEnvironmentId == parent.id,
+            'Environment child ${child.name} has parent ${shared.application.environments.firstWhere((en) => en.id == child.priorEnvironmentId, orElse: () => null)?.name} which is wrong - should be ${parent.name}');
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

An application once created is given a new
production environment. All subsequent
environments should insert themselves before
the first one.

This adds that functionality, it adds e2e testing
to ensure all that works.

The code that shows the user things were not
yet ordered has been removed as it is no longer
necessary.

During this phase it
was discovered that some of the tree graph
requests to get data were not operational, they
would return deleted data. This was fixed in a number
of places.

All e2e and unit and integration tests have been
run to ensure everything is still operational.

fixes issue #3 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All unit, integration and e2e tests run. New e2e tests added.

