### PR TITLE
Explicitly deal with empty environments or service accounts

### DIFF
--- a/backend/dacha-api/dacha-api.yaml
+++ b/backend/dacha-api/dacha-api.yaml
@@ -67,10 +67,14 @@ components:
         - COMPLETE
     PublishAction:
       type: string
+      description: "Indicates what type of update this is. If CREATE, it is a new record, if UPDATE it updates an existing one,
+          if DELETE you should delete the record. If EMPTY then it indicates there are no records of this type and you shouldn't
+          expect to see any further. EMPTY is used to indicate that the Master process is complete."
       enum:
         - CREATE
         - UPDATE
         - DELETE
+        - EMPTY
     EnvironmentCacheItem:
       properties:
         environment:

--- a/e2e/pubspec.yaml
+++ b/e2e/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   rxdart: 0.22.0
-  ogurets: ^3.1.5
+  ogurets: ^3.1.10
 #  ogurets:
 #    path: /Users/richard/projects/dart/ogurets
   mrapi:

--- a/e2e/test/features/dacha.feature
+++ b/e2e/test/features/dacha.feature
@@ -1,0 +1,14 @@
+@dacha
+Feature: this feature is designed to be run on an empty system and trigger the creation of a single environment
+  to ensure the Dacha populates correctly.
+
+
+  Scenario Outline: A single portfolio with a single application and implicit production environment settles dacha.
+    Given The superuser is the user
+    And I ensure a portfolio named "<portfolio>" with description "<portfolio_desc>" exists
+    When I ensure an application with the name "<appName>" with description "<appDesc>" in the portfolio "<portfolio>" exists
+    Then I am able to find application called "<appName>" in the portfolio "<portfolio>"
+
+    Examples:
+      | appName   | appDesc                 | portfolio       | portfolio_desc  |
+      | Dacha App | Sample Dacha Applicaton | Dacha Portfolio | Dacha Portfolio |


### PR DESCRIPTION
# Description

The Dacha Server was not able to determine that
there were no service accounts or environments, which
is typical of a new server. This would lead to
it continually trying to become master and timing
out.

This change includes the server publishing explicity
that the service accounts or environments are empty
so the cache will settle.

This has been tested with multiple Dacha servers and
they continue to negotiate between each other and
recognize the empty cache.
Fixes #7 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

e2e test plus extensive starting of the app and running single and concurrent Dacha servers.

