### PR TITLE
bugfix: portfolio permissions

### DIFF
--- a/admin-frontend/app_singleapp/lib/api/client_api.dart
+++ b/admin-frontend/app_singleapp/lib/api/client_api.dart
@@ -283,10 +283,11 @@ class ManagementRepositoryClientBloc implements Bloc {
   }
 
   void setCurrentPid(String pid) {
+    // do this first so that the permissions are set up
+    personState.currentPortfolioOrSuperAdminUpdateState(pid, groupList);
     streamValley.currentPortfolioId = pid;
     _setAidSharedPrefs(null);
     _setPidSharedPrefs(pid);
-    personState.currentPortfolioOrSuperAdminUpdateState(pid, groupList);
   }
 
   String getCurrentPid() {

--- a/admin-frontend/app_singleapp/lib/common/stream_valley.dart
+++ b/admin-frontend/app_singleapp/lib/common/stream_valley.dart
@@ -55,20 +55,22 @@ class StreamValley {
   String get currentPortfolioId => _currentPortfolioIdSource.value;
 
   set currentPortfolioId(String value) {
-    currentAppId = null;
+    if (_currentPortfolioIdSource.value != value) {
+      currentAppId = null;
 
-    // figure out which one we are
-    _currentPortfolioSource.add(
-        _portfoliosSource.value.firstWhere((element) => element.id == value));
-    _currentPortfolioIdSource.add(value);
+      // figure out which one we are
+      _currentPortfolioSource.add(
+          _portfoliosSource.value.firstWhere((element) => element.id == value));
+      _currentPortfolioIdSource.add(value);
 
-    // now load the applications for this portfolio, which may trigger selecting one
-    getCurrentPortfolioApplications();
+      // now load the applications for this portfolio, which may trigger selecting one
+      getCurrentPortfolioApplications();
 
-    // if we are an admin, load the groups and service accounts
-    if (_isCurrentPortfolioAdminOrSuperAdmin) {
-      getCurrentPortfolioGroups();
-      getCurrentPortfolioServiceAccounts();
+      // if we are an admin, load the groups and service accounts
+      if (_isCurrentPortfolioAdminOrSuperAdmin) {
+        getCurrentPortfolioGroups();
+        getCurrentPortfolioServiceAccounts();
+      }
     }
   }
 


### PR DESCRIPTION
# Description

This fix ensures that the portfolio permissions
are corrected before we swap the actual portfolio.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

You can now see the group request being made for a portfolio when portfolios are changed.

