### PR TITLE
a bunch of changes around groups

### DIFF
--- a/admin-frontend/app_singleapp/lib/routes/manage_group_route.dart
+++ b/admin-frontend/app_singleapp/lib/routes/manage_group_route.dart
@@ -64,31 +64,30 @@ class _ManageGroupRouteState extends State<ManageGroupRoute> {
             Flexible(
               flex: 4,
               child: bloc.mrClient
-                  .isPortfolioOrSuperAdmin(bloc.mrClient.currentPid)
+                      .isPortfolioOrSuperAdmin(bloc.mrClient.currentPid)
                   ? Padding(
-                padding: const EdgeInsets.only(top: 24.0, left: 16),
-                child: Row(
-                  children: [
-                    Flexible(flex: 1, child: _getAdminActions(bloc)),
-                    Flexible(
-                      flex: 4,
-                      child: Container(
-                          child: FHIconTextButton(
-                            iconData: Icons.add,
-                            keepCase: true,
-                            label: 'Create new group',
-                            onPressed: () =>
-                                bloc.mrClient
-                                    .addOverlay((BuildContext context) {
-                                  return GroupUpdateDialogWidget(
-                                    bloc: bloc,
-                                  );
-                                }),
-                          )),
-                    ),
-                  ],
-                ),
-              )
+                      padding: const EdgeInsets.only(top: 24.0, left: 16),
+                      child: Row(
+                        children: [
+                          Flexible(flex: 1, child: _getAdminActions(bloc)),
+                          Flexible(
+                            flex: 4,
+                            child: Container(
+                                child: FHIconTextButton(
+                              iconData: Icons.add,
+                              keepCase: true,
+                              label: 'Create new group',
+                              onPressed: () => bloc.mrClient
+                                  .addOverlay((BuildContext context) {
+                                return GroupUpdateDialogWidget(
+                                  bloc: bloc,
+                                );
+                              }),
+                            )),
+                          ),
+                        ],
+                      ),
+                    )
                   : Container(),
             )
           ],
@@ -129,37 +128,30 @@ class _ManageGroupRouteState extends State<ManageGroupRoute> {
               return Row(children: <Widget>[
                 FHIconButton(
                     icon:
-                    Icon(Icons.edit, color: Theme
-                        .of(context)
-                        .buttonColor),
-                    onPressed: () =>
-                        bloc.mrClient.addOverlay(
-                                (BuildContext context) =>
-                                GroupUpdateDialogWidget(
-                                  bloc: bloc,
-                                  group: bloc.group,
-                                ))),
+                        Icon(Icons.edit, color: Theme.of(context).buttonColor),
+                    onPressed: () => bloc.mrClient.addOverlay(
+                        (BuildContext context) => GroupUpdateDialogWidget(
+                              bloc: bloc,
+                              group: bloc.group,
+                            ))),
                 //hide the delete button for Admin groups
                 snapshot.data.admin
                     ? Container()
                     : FHIconButton(
-                    icon: Icon(Icons.delete,
-                        color: Theme
-                            .of(context)
-                            .buttonColor),
-                    onPressed: () =>
-                        bloc.mrClient.addOverlay((BuildContext context) {
-                          return GroupDeleteDialogWidget(
-                            bloc: bloc,
-                            group: bloc.group,
-                          );
-                        }))
+                        icon: Icon(Icons.delete,
+                            color: Theme.of(context).buttonColor),
+                        onPressed: () =>
+                            bloc.mrClient.addOverlay((BuildContext context) {
+                              return GroupDeleteDialogWidget(
+                                bloc: bloc,
+                                group: bloc.group,
+                              );
+                            }))
               ]);
             } else {
               return Container();
             }
           }),
-
     ]);
   }
 
@@ -173,10 +165,7 @@ class _ManageGroupRouteState extends State<ManageGroupRoute> {
               children: <Widget>[
                 Text(
                   'Portfolio groups',
-                  style: Theme
-                      .of(context)
-                      .textTheme
-                      .caption,
+                  style: Theme.of(context).textTheme.caption,
                 ),
                 Container(
                   constraints: BoxConstraints(maxWidth: 200),
@@ -186,15 +175,13 @@ class _ManageGroupRouteState extends State<ManageGroupRoute> {
                     items: groups.map((Group group) {
                       return DropdownMenuItem<String>(
                           value: group.id,
-                          child: Text(
-                              group.name, overflow: TextOverflow.ellipsis
-                          ));
+                          child: Text(group.name,
+                              overflow: TextOverflow.ellipsis));
                     }).toList(),
-                    hint: Text('Select group',
-                      style: Theme
-                          .of(context)
-                          .textTheme
-                          .subtitle2,),
+                    hint: Text(
+                      'Select group',
+                      style: Theme.of(context).textTheme.subtitle2,
+                    ),
                     onChanged: (value) {
                       setState(() {
                         bloc.getGroup(value);
@@ -214,17 +201,15 @@ class _ManageGroupRouteState extends State<ManageGroupRoute> {
     return Container(
       padding: const EdgeInsets.fromLTRB(8, 10, 30, 10),
       decoration: BoxDecoration(
-          color: Theme
-              .of(context)
-              .cardColor,
+          color: Theme.of(context).cardColor,
           border: Border(bottom: bs, left: bs, right: bs, top: bs)),
       child: Row(
         children: <Widget>[
           Container(
             child: bloc.mrClient.isPortfolioOrSuperAdmin(group.portfolioId)
                 ? FHIconTextButton(
-              iconData: Icons.add,
-              label: 'Add members',
+                    iconData: Icons.add,
+                    label: 'Add members',
                     onPressed: () =>
                         bloc.mrClient.addOverlay((BuildContext context) {
                       return AddMembersDialogWidget(
@@ -335,13 +320,11 @@ class _AddMembersDialogWidgetState extends State<AddMembersDialogWidget> {
                 group.members = List.from(group.members)..addAll(membersToAdd);
                 // remove duplicates
                 group.members = group.members.toSet().toList();
-                try {
-                  await widget.bloc.updateGroup(group);
+                final success = await widget.bloc.updateGroup(group);
+                if (success) {
                   widget.bloc.mrClient.removeOverlay();
                   widget.bloc.mrClient
                       .addSnackbar(Text("Group '${group.name}' updated!"));
-                } catch (e, s) {
-                  widget.bloc.mrClient.dialogError(e, s);
                 }
               })
         ],

--- a/admin-frontend/app_singleapp/lib/widgets/apps/service_account_permissions_widget.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/apps/service_account_permissions_widget.dart
@@ -94,7 +94,7 @@ class _ServiceAccountPermissionState
                       padding: const EdgeInsets.only(left: 16.0),
                       child: FHInfoCardWidget(
                           message:
-                          '''The 'Lock/Unlock' and 'Change value' permissions
+                              '''The 'Lock/Unlock' and 'Change value' permissions
 are so you can change these states through the API's
 e.g., when running tests. \n
 We strongly recommend setting production environments
@@ -119,10 +119,7 @@ with only 'Read' permission for service accounts.'''),
               value: serviceAccount.id,
               child: Text(
                 serviceAccount.name,
-                style: Theme
-                    .of(context)
-                    .textTheme
-                    .bodyText2,
+                style: Theme.of(context).textTheme.bodyText2,
                 overflow: TextOverflow.ellipsis,
               ));
         }).toList(),
@@ -136,7 +133,11 @@ with only 'Read' permission for service accounts.'''),
             bloc.selectServiceAccount(value);
           });
         },
-        value: selectedServiceAccount,
+        value: serviceAccounts
+                .firstWhere((sa) => sa.id == selectedServiceAccount,
+                    orElse: () => null)
+                ?.id ??
+            serviceAccounts[0].id,
       ),
     );
   }
@@ -225,16 +226,13 @@ class _ServiceAccountPermissionDetailState
                     Container(
                         padding: EdgeInsets.fromLTRB(0, 24, 0, 16),
                         child: Center(
-                          child:
-                          Text(
+                          child: Text(
                               'Set the service account access to features for each environment',
-                              style: Theme
-                                  .of(context)
+                              style: Theme.of(context)
                                   .textTheme
                                   .subtitle1
-                                  .copyWith(color: Theme
-                                  .of(context)
-                                  .hintColor)),
+                                  .copyWith(
+                                      color: Theme.of(context).hintColor)),
                         )),
                     table,
                     FHButtonBar(children: [

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/DuplicateUsersException.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/DuplicateUsersException.java
@@ -1,0 +1,4 @@
+package io.featurehub.db.api;
+
+public class DuplicateUsersException extends Exception {
+}

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/GroupApi.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/GroupApi.java
@@ -44,7 +44,8 @@ public interface GroupApi {
 
   Group deletePersonFromGroup(String gid, String id, Opts opts);
 
-  Group updateGroup(String gid, Group group, boolean updateMembers, boolean updateApplicationGroupRoles, boolean updateEnvironmentGroupRoles, Opts opts) throws OptimisticLockingException, DuplicateGroupException;
+  Group updateGroup(String gid, Group group, boolean updateMembers, boolean updateApplicationGroupRoles, boolean updateEnvironmentGroupRoles, Opts opts)
+    throws OptimisticLockingException, DuplicateGroupException, DuplicateUsersException;
 
   List<Group> findGroups(String portfolioId, String filter, SortOrder order, Opts opts);
 

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
@@ -330,7 +330,9 @@ public class ConvertUtils {
     }
 
     if (opts.contains(FillOpts.Members)) {
-      group.setMembers(dbg.getPeopleInGroup().stream().map(p -> this.toPerson(p, opts.minus(FillOpts.Members, FillOpts.Acls))).collect(Collectors.toList()));
+      group.setMembers(
+        new QDbPerson().order().name.asc().whenArchived.isNull().groupsPersonIn.eq(dbg).findList().stream()
+        .map(p -> this.toPerson(p, opts.minus(FillOpts.Members, FillOpts.Acls))).collect(Collectors.toList()));
     }
 
     if (opts.contains(FillOpts.Acls)) {

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/GroupResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/GroupResource.java
@@ -1,5 +1,6 @@
 package io.featurehub.mr.resources;
 
+import io.featurehub.db.api.DuplicateUsersException;
 import io.featurehub.db.api.FillOpts;
 import io.featurehub.db.api.GroupApi;
 import io.featurehub.db.api.OptimisticLockingException;
@@ -213,7 +214,7 @@ public class GroupResource implements GroupServiceDelegate {
             new Opts().add(FillOpts.Members, holder.includeMembers).add(FillOpts.Acls, holder.includeGroupRoles));
         } catch (OptimisticLockingException e) {
           throw new WebApplicationException(422);
-        } catch (GroupApi.DuplicateGroupException e) {
+        } catch (GroupApi.DuplicateGroupException | DuplicateUsersException e) {
           throw new WebApplicationException(Response.Status.CONFLICT);
         }
       });

--- a/sdks/client-java-jersey/src/main/java/io/featurehub/client/jersey/JerseyClient.java
+++ b/sdks/client-java-jersey/src/main/java/io/featurehub/client/jersey/JerseyClient.java
@@ -67,7 +67,7 @@ public class JerseyClient {
       }
     } catch (Exception e) {
       log.error("Failed to connect to {}", sdkUrl, e);
-      clientFeatureRepository.notify(SSEResultState.ERROR, "unable to connect");
+      clientFeatureRepository.notify(SSEResultState.FAILURE, "unable to connect");
     }
 
     log.warn("connection failed, reconnecting");


### PR DESCRIPTION
# Description

- ordering results of members for groups list
- more sensible error (not 500) when you try and
add a duplicate user to a group
- first group is selected one going into the group
screen and will detect if you are on the group screen
and swap portfolios and re-choose the new first group
- picked up an error service group where the selected
service group wasn't the right one if you swapped
portfolios while resting on that service account
- chips input had major state bugs and i believe still
does - the input stream controller never gets closed
so i think thats a memory leak which we can't fix
- rearranged stream valley to have all sources in one
place so they can be easily found

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Hand tested.