### PR TITLE
cleanup tasks allocated to me

### DIFF
--- a/admin-frontend/app_singleapp/lib/widgets/features/feature_names_left_panel.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/feature_names_left_panel.dart
@@ -149,7 +149,11 @@ class _FeatureListenForUpdatedFeatureValues extends StatelessWidget {
               ),
               FHFlatButtonTransparent(
                 title: 'Save',
-                onPressed: () => featureBloc.updateDirtyStates(),
+                onPressed: () async {
+                  if ((await featureBloc.updateDirtyStates())) {
+                    bloc.hideOrShowFeature(feature);
+                  }
+                },
               )
             ],
           );

--- a/admin-frontend/app_singleapp/lib/widgets/features/feature_value_row_number.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/feature_value_row_number.dart
@@ -70,16 +70,18 @@ class _FeatureValueNumberEnvironmentCellState
                         ? 'Not a valid number'
                         : null,
                   ),
+                  onChanged: (value) {
+                    print("on changed");
+                    widget.fvBloc.dirty(
+                      widget.environmentFeatureValue.environmentId,
+                      (originalFv) {
+                        return (value?.isEmpty ? null : value) !=
+                            originalFv?.valueNumber?.toString();
+                      },
+                    );
+                  },
                   onEditingComplete: () {
-                    if (validateNumber(tec.text) == null) {
-                      if (tec.text.isEmpty) {
-                        snap.data.valueNumber = null;
-                      } else {
-                        snap.data.valueNumber = double.parse(tec.text);
-                      }
-                      widget.fvBloc.updatedFeature(
-                          widget.environmentFeatureValue.environmentId);
-                    }
+                    _handleChanged(tec.text, snap.data);
                   },
                   inputFormatters: [
                     DecimalTextInputFormatter(
@@ -88,6 +90,19 @@ class _FeatureValueNumberEnvironmentCellState
                 )),
           );
         });
+  }
+
+  void _handleChanged(String val, FeatureValue fv) {
+    if (validateNumber(val) == null) {
+      if (val.isEmpty) {
+        fv.valueNumber = null;
+      } else {
+        fv.valueNumber = double.parse(val);
+      }
+
+      widget.fvBloc
+          .updatedFeature(widget.environmentFeatureValue.environmentId);
+    }
   }
 }
 

--- a/admin-frontend/app_singleapp/lib/widgets/features/feature_value_row_string.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/feature_value_row_string.dart
@@ -47,33 +47,45 @@ class _FeatureValueStringEnvironmentCellState
                 width: 160,
                 height: 40,
                 child: TextField(
-                    style: Theme.of(context).textTheme.bodyText1,
-                    enabled: enabled,
-                    controller: tec,
-                    decoration: InputDecoration(
-                        contentPadding: EdgeInsets.only(left: 4.0, top: 4.0),
-                        enabledBorder: OutlineInputBorder(
-                            borderSide: BorderSide(
-                          color: Theme.of(context).buttonColor,
-                        )),
-                        disabledBorder: OutlineInputBorder(
-                            borderSide: BorderSide(
-                          color: Colors.grey,
-                        )),
-                        hintText: canEdit
-                            ? 'Enter string value'
-                            : 'No editing permissions',
-                        hintStyle: Theme.of(context).textTheme.caption),
-                    onChanged: (value) {
-                      snap.data.valueString = tec.text?.trim();
-                      if (snap.data.valueString.isEmpty) {
-                        snap.data.valueString = null;
-                      }
-                      widget.fvBloc.updatedFeature(
-                          widget.environmentFeatureValue.environmentId);
-                    })),
+                  style: Theme.of(context).textTheme.bodyText1,
+                  enabled: enabled,
+                  controller: tec,
+                  decoration: InputDecoration(
+                      contentPadding: EdgeInsets.only(left: 4.0, top: 4.0),
+                      enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                        color: Theme.of(context).buttonColor,
+                      )),
+                      disabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                        color: Colors.grey,
+                      )),
+                      hintText: canEdit
+                          ? 'Enter string value'
+                          : 'No editing permissions',
+                      hintStyle: Theme.of(context).textTheme.caption),
+                  onChanged: (value) {
+                    widget.fvBloc.dirty(
+                      widget.environmentFeatureValue.environmentId,
+                      (originalFv) =>
+                          (value?.isEmpty ? null : value) !=
+                          originalFv?.valueString,
+                    );
+                  },
+                  onEditingComplete: () {
+                    _handleChanged(tec.text, snap.data);
+                  },
+                )),
           );
         });
+  }
+
+  void _handleChanged(String val, FeatureValue fv) {
+    fv.valueString = val?.trim();
+    if (fv.valueString.isEmpty) {
+      fv.valueString = null;
+    }
+    widget.fvBloc.updatedFeature(widget.environmentFeatureValue.environmentId);
   }
 }
 

--- a/admin-frontend/app_singleapp/lib/widgets/features/feature_values_bloc.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/feature_values_bloc.dart
@@ -8,6 +8,8 @@ import 'package:rxdart/rxdart.dart';
 import 'feature_status_bloc.dart';
 import 'feature_value_status_tags.dart';
 
+typedef DirtyCallback = bool Function(FeatureValue original);
+
 class FeatureValuesBloc implements Bloc {
   final Feature feature;
   final String applicationId;
@@ -54,8 +56,8 @@ class FeatureValuesBloc implements Bloc {
     _fvUpdates[envId].add(_newFeatureValues[envId]);
   }
 
-  void dirty(String envId, bool value) {
-    _dirty[envId] = value;
+  void dirty(String envId, DirtyCallback originalCheck) {
+    _dirty[envId] = originalCheck(_originalFeatureValues[envId]);
     _dirtyBS.add(_dirty.values.any((d) => d == true));
   }
 
@@ -81,7 +83,11 @@ class FeatureValuesBloc implements Bloc {
   }
 
   @override
-  void dispose() {}
+  void dispose() {
+    _fvUpdates.values.forEach((element) {
+      element.close();
+    });
+  }
 
   bool hasValue(FeatureEnvironment fe) {
     return _newFeatureValues[fe.environment.id]?.valueBoolean != null ||


### PR DESCRIPTION
# Description

Reset on strings and numbers doesn’t reset
When saving, show snack bar and close the line
Save & cancel should appear as soon as you start typing text for strings and numbers

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
