### PR TITLE
change license for SDK + Examples to MIT

### DIFF
--- a/examples/todo-api/pom.xml
+++ b/examples/todo-api/pom.xml
@@ -8,4 +8,12 @@
   <artifactId>todo-api</artifactId>
 	<version>1.1-SNAPSHOT</version>
 
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
+    </license>
+  </licenses>
+
 </project>

--- a/examples/todo-backend-java/pom.xml
+++ b/examples/todo-backend-java/pom.xml
@@ -42,6 +42,14 @@
     </dependency>
   </dependencies>
 
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
+    </license>
+  </licenses>
+
   <build>
     <plugins>
       <plugin>

--- a/examples/todo-frontend-react-typescript/pom.xml
+++ b/examples/todo-frontend-react-typescript/pom.xml
@@ -10,11 +10,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>cd.connect</groupId>
+      <groupId>io.featurehub.examples</groupId>
       <artifactId>todo-api</artifactId>
       <version>1.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
+    </license>
+  </licenses>
 
   <build>
     <finalName>app</finalName>

--- a/sdks/README.adoc
+++ b/sdks/README.adoc
@@ -8,6 +8,10 @@ This overview seeks to indicate the capabilities of the SDKs and explain what th
 considering helping us by writing a new SDK for your favourite language, or expand on an existing library, this
 table of capability indicates what each different language can support and where extra work is helpful.
 
+== Licenses
+
+All SDKs are MIT licensed, as they reside in the client codebase.
+
 == Capabilities overview
 
 [options="header]

--- a/sdks/client-dart-api/pom.xml
+++ b/sdks/client-dart-api/pom.xml
@@ -31,8 +31,9 @@
 
   <licenses>
     <license>
-      <name>Apache 2 with Commons Clause</name>
-      <url>https://github.com/featurehub-io/featurehub/blob/master/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
     </license>
   </licenses>
 

--- a/sdks/client-java-core/pom.xml
+++ b/sdks/client-java-core/pom.xml
@@ -30,8 +30,9 @@
 
   <licenses>
     <license>
-      <name>Apache 2 with Commons Clause</name>
-      <url>https://github.com/featurehub-io/featurehub/blob/master/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
     </license>
   </licenses>
 

--- a/sdks/client-java-jersey/pom.xml
+++ b/sdks/client-java-jersey/pom.xml
@@ -30,8 +30,9 @@
 
   <licenses>
     <license>
-      <name>Apache 2 with Commons Clause</name>
-      <url>https://github.com/featurehub-io/featurehub/blob/master/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
     </license>
   </licenses>
 

--- a/sdks/client-typescript-core/pom.xml
+++ b/sdks/client-typescript-core/pom.xml
@@ -30,8 +30,9 @@
 
   <licenses>
     <license>
-      <name>Apache 2 with Commons Clause</name>
-      <url>https://github.com/featurehub-io/featurehub/blob/master/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
     </license>
   </licenses>
 

--- a/sdks/client-typescript-eventsource/pom.xml
+++ b/sdks/client-typescript-eventsource/pom.xml
@@ -30,8 +30,9 @@
 
   <licenses>
     <license>
-      <name>Apache 2 with Commons Clause</name>
-      <url>https://github.com/featurehub-io/featurehub/blob/master/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <comments>This code resides in the customer's codebase and therefore has an MIT license.</comments>
     </license>
   </licenses>
 


### PR DESCRIPTION
All SDKs should have MIT licenses as they are used in client codebase and aren't what we are trying to protect against. Same with Examples.