### PR TITLE
Fixes bug where after a new app is created, you don't have any access to it.

### DIFF
--- a/admin-frontend/app_singleapp/lib/api/client_api.dart
+++ b/admin-frontend/app_singleapp/lib/api/client_api.dart
@@ -288,12 +288,14 @@ class ManagementRepositoryClientBloc implements Bloc {
 
   // ask for my own details and if there are some, set the person and transition
   // to logged in, otherwise ask them to log in.
-  void requestOwnDetails() {
+  Future requestOwnDetails() async {
     personServiceApi
         .getPerson('self', includeAcls: true, includeGroups: true)
         .then((p) {
       setPerson(p);
-      _initializedSource.add(InitializedCheckState.zombie);
+      if (_initializedSource.value != InitializedCheckState.zombie) {
+        _initializedSource.add(InitializedCheckState.zombie);
+      }
     }).catchError((_) {
       setBearerToken(null);
       _initializedSource.add(InitializedCheckState.initialized);

--- a/admin-frontend/app_singleapp/lib/widgets/apps/apps_bloc.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/apps/apps_bloc.dart
@@ -42,6 +42,7 @@ class AppsBloc implements Bloc {
     application.description = appDescription;
     final newApp = await _applicationServiceApi.createApplication(
         mrClient.currentPid, application);
+    await mrClient.requestOwnDetails();
     await _refreshApplications();
     mrClient.setCurrentAid(newApp.id);
   }


### PR DESCRIPTION
# Description

When a new app is created, the user's roles don't include any acls which grant permissions to that app. So they
end up having the Create Feature button, but no actual ability to create a feature.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

