### PR TITLE
person name is required on create

### DIFF
--- a/e2e/test/steps/AdminPersonStepdefs.dart
+++ b/e2e/test/steps/AdminPersonStepdefs.dart
@@ -19,6 +19,7 @@ class AdminPersonStepdefs {
     shared.registrationUrl =
         await common.personService.createPerson(CreatePersonDetails()
           ..email = email
+          ..name = email
           ..groupIds = []);
   }
 
@@ -30,6 +31,7 @@ class AdminPersonStepdefs {
     shared.registrationUrl =
         await common.personService.createPerson(CreatePersonDetails()
           ..email = email
+          ..name = email
           ..groupIds = [common.superuserGroupId]);
   }
 
@@ -37,8 +39,10 @@ class AdminPersonStepdefs {
   void iRegisterANewUserWithEmail(String email) async {
     await common.initialize();
 
-    shared.registrationUrl = await common.personService
-        .createPerson(CreatePersonDetails()..email = email);
+    shared.registrationUrl =
+        await common.personService.createPerson(CreatePersonDetails()
+          ..email = email
+          ..name = email);
   }
 
   @When(r'the first superuser is used for authentication')


### PR DESCRIPTION
# Description

The e2e tests were not setting the person's name as per recent change this fixes this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

