### PR TITLE
Login double call and permission issue bugfix

### DIFF
--- a/admin-frontend/app_singleapp/lib/api/client_api.dart
+++ b/admin-frontend/app_singleapp/lib/api/client_api.dart
@@ -402,7 +402,7 @@ class ManagementRepositoryClientBloc implements Bloc {
     window.console.error(s?.toString());
   }
 
-  Future login(String email, String password) async {
+  Future<void> login(String email, String password) async {
     await authServiceApi
         .login(UserCredentials()
           ..email = email

--- a/admin-frontend/app_singleapp/lib/widgets/user/signin/signin_widget.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/user/signin/signin_widget.dart
@@ -23,6 +23,7 @@ class _SigninState extends State<SigninWidget> {
   final _formKey = GlobalKey<FormState>(debugLabel: 'signin_widget');
   ManagementRepositoryClientBloc bloc;
   bool displayError = false;
+  bool loggingIn = false;
 
   @override
   void didChangeDependencies() {
@@ -40,18 +41,31 @@ class _SigninState extends State<SigninWidget> {
   }
 
   void _handleSubmitted() {
-    if (_formKey.currentState.validate()) {
-      bloc.login(_email.text, _password.text).catchError((e, s) => {
-            if (e is ApiException && e.code == 404)
-              {
-                setState(() {
-                  displayError = true;
-                })
-              }
-            else
-              bloc.dialogError(e, s)
-          });
+    if (!loggingIn) {
+      if (_formKey.currentState.validate()) {
+        _login();
+      }
     }
+  }
+
+  void _login() {
+    setState(() {
+      loggingIn = true;
+    });
+    bloc.login(_email.text, _password.text).then((_) {
+      setState(() {
+        loggingIn = false;
+      });
+    }).catchError((e, s) => {
+          if (e is ApiException && e.code == 404)
+            {
+              setState(() {
+                displayError = true;
+              })
+            }
+          else
+            bloc.dialogError(e, s)
+        });
   }
 
   @override

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/AuthenticationSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/AuthenticationSqlApi.java
@@ -50,7 +50,7 @@ public class AuthenticationSqlApi implements AuthenticationApi {
         if (passwordSalter.validatePassword(password, p.getPassword())) {
           updateLastAuthenticated(p);
 
-          return convertUtils.toPerson(p, Opts.opts(FillOpts.Groups))
+          return convertUtils.toPerson(p, Opts.opts(FillOpts.Groups, FillOpts.Acls))
             .passwordRequiresReset(p.isPasswordRequiresReset());
         } else {
           return null;


### PR DESCRIPTION
# Description

When login occurs, the Acls are not passed back. This fixes this issue, and ensures that all of the application level roles
are immediately available to a user. 

In the process was also discovered a double login call, which has also been addressed.

Fixes #119

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual front end testing. Integration test in back end.

Without fix:
(1) start front end app in IDE
(2) login as superuser
(3) attempt to create a feature. This dialog will pop because you are superuser, but as you have no roles it will only show a cancel button.

During this process watch the network calls on login. There will be 3 - one OPTION and two to login.

