### PR TITLE
Wrong password prevents correction

### DIFF
--- a/admin-frontend/app_singleapp/lib/routes/landing_route.dart
+++ b/admin-frontend/app_singleapp/lib/routes/landing_route.dart
@@ -42,10 +42,8 @@ class LandingRouteState extends State<LandingRoute> {
           Widget widget;
 
           if (snapshot.hasError) {
-            client.customError(
-                messageTitle:
-                    'Error getting initial state'); //return FailureWidget(error: snapshot.error);
-            widget = Text('Error MF!');
+            client.customError(messageTitle: 'Error getting initial state');
+            widget = Text('Error!');
           } else if (snapshot.data == InitializedCheckState.initialized) {
             if (client.currentRoute != null &&
                 client.currentRoute.route == '/register-url') {

--- a/admin-frontend/app_singleapp/lib/widgets/user/signin/signin_widget.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/user/signin/signin_widget.dart
@@ -63,16 +63,16 @@ class _SigninState extends State<SigninWidget> {
       setState(() {
         loggingIn = false;
       });
-    }).catchError((e, s) => {
-          if (e is ApiException && e.code == 404)
-            {
-              setState(() {
-                displayError = true;
-              })
-            }
-          else
-            bloc.dialogError(e, s)
+    }).catchError((e, s) {
+      if (e is ApiException && e.code == 404) {
+        setState(() {
+          displayError = true;
+          loggingIn = false;
         });
+      } else {
+        bloc.dialogError(e, s);
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
Resolved issue where typing the wrong password would
prevent you from logging in a second time with the right
password without page refresh.

Fixes #195

