### PR TITLE
Add API for rollout strategies

### DIFF
--- a/admin-frontend/app_singleapp/lib/widgets/features/custom_strategy_bloc.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/custom_strategy_bloc.dart
@@ -47,6 +47,8 @@ class CustomStrategyBloc extends Bloc {
     _strategySource.add(strategies);
   }
 
+  bool validateStrategy(RolloutStrategy rs) {}
+
   @override
   void dispose() {}
 }

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -736,6 +736,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RolloutStrategyInfo"
+  /mr-api/application/{appId}/rollout-strategy-validation:
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - RolloutStrategyService
+      description: "Provide server validation responses for this group of rollout strategies"
+      parameters:
+        - name: appId
+          description: "The id of the application to find"
+          in: path
+          schema:
+            type: string
+          required: true
+      operationId: validate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RolloutStrategyValidationRequest"
+      responses:
+        "200":
+          description: "validation results"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RolloutStrategyValidationResponse"
+        "400":
+          description: "invalid body"
+        "401":
+          description: "no permission"
   /mr-api/application/{appId}/rollout-strategy/{strategyId}:
     parameters:
       - name: appId
@@ -976,6 +1008,14 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/FeatureEnvironment"
+        409:
+          description: "Conflict in trying to save, someone else updated a record first"
+        422:
+          description: "There were validation failures in the rollout strategies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RolloutStrategyValidationResponse"
   /mr-api/application/{id}/all-feature-environment:
     parameters:
       - name: id
@@ -1218,6 +1258,14 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/FeatureValue"
+        409:
+          description: "Conflict in trying to save, someone else updated a record first"
+        422:
+          description: "There were validation failures in the rollout strategies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RolloutStrategyValidationResponse"
   /mr-api/features/{eid}/feature/{key}:
     parameters:
       - name: eid
@@ -1266,6 +1314,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FeatureValue"
+        409:
+          description: "Conflict in trying to save, someone else updated a record first"
+        422:
+          description: "There were validation failures in the rollout strategies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RolloutStrategyValidationResponse"
     post:
       security:
         - bearerAuth: []
@@ -1286,6 +1342,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FeatureValue"
+        409:
+          description: "Conflict in trying to save, someone else updated a record first"
+        422:
+          description: "There were validation failures in the rollout strategies"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RolloutStrategyValidationResponse"
     delete:
       security:
         - bearerAuth: []
@@ -1817,4 +1881,70 @@ components:
           format: date-time
         changedBy:
           $ref: "#/components/schemas/Person"
-
+    RolloutStrategyValidationRequest:
+      type: object
+      description: "A collection of strategies to validate together to see if it violates any rules"
+      properties:
+        customStrategies:
+          type: array
+          items:
+            $ref: "#/components/schemas/RolloutStrategy"
+        sharedStrategies:
+          type: array
+          items:
+            $ref: "#/components/schemas/RolloutStrategyInstance"
+    CustomRolloutStrategyViolation:
+      type: object
+      properties:
+        strategy:
+          $ref: "#/components/schemas/RolloutStrategy"
+        violations:
+          type: array
+          items:
+            $ref: "#/components/schemas/RolloutStrategyViolationType"
+    SharedRolloutStrategyViolation:
+      type: object
+      properties:
+        strategy:
+          $ref: "#/components/schemas/RolloutStrategyInstance"
+        violation:
+          type: array
+          items:
+            $ref: "#/components/schemas/RolloutStrategyViolationType"
+    RolloutStrategyValidationResponse:
+      type: object
+      properties:
+        customStategyViolations:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomRolloutStrategyViolation"
+        sharedStrategyViolations:
+          type: array
+          items:
+            $ref: "#/components/schemas/SharedRolloutStrategyViolation"
+        violations:
+          type: array
+          items:
+            $ref: "#/components/schemas/RolloutStrategyCollectionViolationType"
+    RolloutStrategyViolationType:
+      type: string
+      enum:
+        - no_name
+        - name_too_long
+        - empty_match_criteria
+        - negative_percentage
+        - percentage_over_100_percent
+        - array_attribute_no_values
+        - attr_missing_conditional
+        - attr_missing_field_name
+        - attr_missing_field_type
+        - attr_val_not_semantic_version
+        - attr_val_not_number
+        - attr_val_not_date
+        - attr_val_not_date_time
+        - attr_val_not_cidr
+        - attr_unknown_failure
+    RolloutStrategyCollectionViolationType:
+      type: string
+      enum:
+        - percentage_adds_over_100_percent

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/FeatureApi.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/FeatureApi.java
@@ -13,7 +13,6 @@ public interface FeatureApi {
   void updateAllFeatureValuesByApplicationForKey(String id, String key, List<FeatureValue> featureValue, Person from,
                                                  boolean removeValuesNotPassed)
     throws OptimisticLockingException, NoAppropriateRole,
-    RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent,
     RolloutStrategyValidator.InvalidStrategyCombination;
 
   ApplicationFeatureValues findAllFeatureAndFeatureValuesForEnvironmentsByApplication(String appId, Person current);
@@ -25,22 +24,20 @@ public interface FeatureApi {
 
   FeatureValue createFeatureValueForEnvironment(String eid, String key, FeatureValue featureValue,
                                                 PersonFeaturePermission person) throws OptimisticLockingException,
-    NoAppropriateRole, RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent,
-    RolloutStrategyValidator.InvalidStrategyCombination;
+    RolloutStrategyValidator.InvalidStrategyCombination, NoAppropriateRole;
 
   boolean deleteFeatureValueForEnvironment(String eid, String key);
 
   FeatureValue updateFeatureValueForEnvironment(String eid, String key, FeatureValue featureValue,
                                                 PersonFeaturePermission person) throws OptimisticLockingException,
-    NoAppropriateRole, RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent,
-    RolloutStrategyValidator.InvalidStrategyCombination;
+    RolloutStrategyValidator.InvalidStrategyCombination, NoAppropriateRole;
 
   FeatureValue getFeatureValueForEnvironment(String eid, String key);
 
   EnvironmentFeaturesResult getAllFeatureValuesForEnvironment(String eid);
 
   List<FeatureValue> updateAllFeatureValuesForEnvironment(String eid, List<FeatureValue> featureValues,
-                                                          PersonFeaturePermission requireRoleCheck) throws OptimisticLockingException, NoAppropriateRole, RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent, RolloutStrategyValidator.InvalidStrategyCombination;
+                                                          PersonFeaturePermission requireRoleCheck) throws OptimisticLockingException, NoAppropriateRole, RolloutStrategyValidator.InvalidStrategyCombination;
 
   List<FeatureEnvironment> getFeatureValuesForApplicationForKeyForPerson(String appId, String key, Person person);
 }

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/RolloutStrategyValidator.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/RolloutStrategyValidator.java
@@ -1,15 +1,58 @@
 package io.featurehub.db.api;
 
 import io.featurehub.mr.model.RolloutStrategy;
+import io.featurehub.mr.model.RolloutStrategyCollectionViolationType;
+import io.featurehub.mr.model.RolloutStrategyInstance;
+import io.featurehub.mr.model.RolloutStrategyValidationResponse;
+import io.featurehub.mr.model.RolloutStrategyViolationType;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface RolloutStrategyValidator {
 
-  void validateStrategies(List<RolloutStrategy> rolloutStrategies)
-    throws InvalidStrategyCombination, PercentageStrategyGreaterThan100Percent;
+  class ValidationFailure {
+    public Map<RolloutStrategy, Set<RolloutStrategyViolationType>> customStrategyViolations = new HashMap<>();
+    public Map<RolloutStrategyInstance, Set<RolloutStrategyViolationType>> sharedStrategyViolations = new HashMap<>();
+    public Set<RolloutStrategyCollectionViolationType> collectionViolationType = new HashSet<>();
 
-  static class InvalidStrategyCombination extends Exception {}
-  static class PercentageStrategyGreaterThan100Percent extends Exception {}
+    public void add(RolloutStrategyViolationType failure, RolloutStrategy strategy) {
+      customStrategyViolations.computeIfAbsent(strategy, (k) -> new HashSet<>()).add(failure);
+    }
 
+    public void add(RolloutStrategyViolationType failure, RolloutStrategyInstance rsi) {
+      sharedStrategyViolations.computeIfAbsent(rsi, (k) -> new HashSet<>()).add(failure);
+    }
+
+    public void add(RolloutStrategyCollectionViolationType failure) {
+      collectionViolationType.add(failure);
+    }
+
+    public void hasFailedValidation() throws InvalidStrategyCombination {
+      if (isInvalid()) {
+        throw new InvalidStrategyCombination(this);
+      }
+    }
+
+    public boolean isInvalid() {
+      return !(customStrategyViolations.isEmpty() && sharedStrategyViolations.isEmpty() && collectionViolationType.isEmpty());
+    }
+  }
+
+  class InvalidStrategyCombination extends Exception {
+    public final ValidationFailure failure;
+
+    public InvalidStrategyCombination(ValidationFailure failure) {
+      this.failure = failure;
+    }
+  }
+
+  ValidationFailure validateStrategies(List<RolloutStrategy> customStrategies,
+                             List<RolloutStrategyInstance> sharedStrategies);
+  ValidationFailure validateStrategies(List<RolloutStrategy> customStrategies,
+                             List<RolloutStrategyInstance> sharedStrategies, ValidationFailure failure);
 }

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/listener/FeatureUpdateBySDKApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/listener/FeatureUpdateBySDKApi.java
@@ -8,5 +8,5 @@ import java.util.function.Function;
 
 public interface FeatureUpdateBySDKApi {
   void updateFeature(String sdkUrl, String envId, String featureKey, boolean updatingValue, Function<FeatureValueType, FeatureValue> buildFeatureValue)
-    throws  RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent, RolloutStrategyValidator.InvalidStrategyCombination;
+    throws RolloutStrategyValidator.InvalidStrategyCombination;
 }

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/listener/FeatureUpdateListener.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/listener/FeatureUpdateListener.java
@@ -71,7 +71,7 @@ public class FeatureUpdateListener implements EdgeUpdateListener, MessageHandler
         });
     } catch (IOException e) {
       log.error("Unable to decompose incoming message to update feature.", e);
-    } catch (RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent|RolloutStrategyValidator.InvalidStrategyCombination ignoreEx) {
+    } catch (RolloutStrategyValidator.InvalidStrategyCombination ignoreEx) {
       // ignore
     }
   }

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
@@ -72,7 +72,10 @@ class FeatureSpec extends BaseSpec {
     environmentSqlApi = new EnvironmentSqlApi(database, convertUtils, Mock(CacheSource), archiveStrategy)
     envIdApp1 = environmentSqlApi.create(new Environment().name("feature-app-1-env-1"), new Application().id(appId), superPerson).id
 
-    featureSqlApi = new FeatureSqlApi(database, convertUtils, Mock(CacheSource), Mock(RolloutStrategyValidator), Mock(StrategyDiffer))
+    def rsv = Mock(RolloutStrategyValidator)
+    rsv.validateStrategies(_, _) >> new RolloutStrategyValidator.ValidationFailure()
+
+    featureSqlApi = new FeatureSqlApi(database, convertUtils, Mock(CacheSource), rsv, Mock(StrategyDiffer))
 
     def averageJoe = new DbPerson.Builder().email("averagejoe-fvs@featurehub.io").name("Average Joe").build()
     database.save(averageJoe)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/StrategyDifferUtilsSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/StrategyDifferUtilsSpec.groovy
@@ -51,7 +51,10 @@ class StrategyDifferUtilsSpec extends BaseSpec {
     def environmentSqlApi = new EnvironmentSqlApi(database, convertUtils, Mock(CacheSource), archiveStrategy)
     envId = environmentSqlApi.create(new Environment().name("strategy-diff-env-1"), new Application().id(app1.id), superPerson).id
 
-    featureSqlApi = new FeatureSqlApi(database, convertUtils, Mock(CacheSource), Mock(RolloutStrategyValidator), new StrategyDifferUtils())
+    def rsv = Mock(RolloutStrategyValidator)
+    rsv.validateStrategies(_, _) >> new RolloutStrategyValidator.ValidationFailure()
+
+    featureSqlApi = new FeatureSqlApi(database, convertUtils, Mock(CacheSource), rsv, new StrategyDifferUtils())
     rolloutStrategyApi = new RolloutStrategySqlApi(database, convertUtils, Mock(CacheSource))
   }
 

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/EnvironmentFeatureResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/EnvironmentFeatureResource.java
@@ -19,6 +19,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 
@@ -50,11 +51,11 @@ public class EnvironmentFeatureResource implements EnvironmentFeatureServiceDele
     try {
       featureForEnvironment = featureApi.createFeatureValueForEnvironment(eid, key, featureValue, requireRoleCheck(eid, securityContext));
     } catch (OptimisticLockingException e) {
-      throw new WebApplicationException(422);
+      throw new WebApplicationException(409);
     } catch (FeatureApi.NoAppropriateRole noAppropriateRole) {
       throw new ForbiddenException(noAppropriateRole);
-    } catch (RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent| RolloutStrategyValidator.InvalidStrategyCombination bad) {
-      throw new WebApplicationException(400); // can't do anything with it
+    } catch (RolloutStrategyValidator.InvalidStrategyCombination bad) {
+      throw new WebApplicationException(Response.status(422).entity(bad.failure).build()); // can't do anything with it
     }
 
     if (featureForEnvironment == null) {
@@ -117,11 +118,11 @@ public class EnvironmentFeatureResource implements EnvironmentFeatureServiceDele
       updated = featureApi.updateAllFeatureValuesForEnvironment(eid, featureValues,
         requireRoleCheck(eid, securityContext));
     } catch (OptimisticLockingException e) {
-      throw new WebApplicationException(422);
+      throw new WebApplicationException(409);
     } catch (FeatureApi.NoAppropriateRole noAppropriateRole) {
       throw new ForbiddenException(noAppropriateRole);
-    } catch (RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent| RolloutStrategyValidator.InvalidStrategyCombination bad) {
-      throw new WebApplicationException(400); // can't do anything with it
+    } catch (RolloutStrategyValidator.InvalidStrategyCombination bad) {
+      throw new WebApplicationException(Response.status(422).entity(bad.failure).build()); // can't do anything with it
     }
 
     if (updated == null) {
@@ -137,11 +138,11 @@ public class EnvironmentFeatureResource implements EnvironmentFeatureServiceDele
       return featureApi.updateFeatureValueForEnvironment(eid, key, featureValue, requireRoleCheck(eid, securityContext));
     } catch (OptimisticLockingException e) {
       log.error("optimistic locking", e);
-      throw new WebApplicationException(422);
+      throw new WebApplicationException(409);
     } catch (FeatureApi.NoAppropriateRole noAppropriateRole) {
       throw new ForbiddenException(noAppropriateRole);
-    } catch (RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent| RolloutStrategyValidator.InvalidStrategyCombination bad) {
-      throw new WebApplicationException(400); // can't do anything with it
+    } catch (RolloutStrategyValidator.InvalidStrategyCombination bad) {
+      throw new WebApplicationException(Response.status(422).entity(bad.failure).build()); // can't do anything with it
     }
   }
 }

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
@@ -115,12 +115,12 @@ public class FeatureResource implements FeatureServiceDelegate {
       featureApi.updateAllFeatureValuesByApplicationForKey(id, key, featureValue, person, Boolean.TRUE.equals(holder.removeValuesNotPassed));
     } catch (OptimisticLockingException e) {
       log.warn("Optimistic locking failure", e);
-      throw new WebApplicationException(422);
+      throw new WebApplicationException(409);
     } catch (FeatureApi.NoAppropriateRole noAppropriateRole) {
       log.warn("User attempted to update feature they had no access to", noAppropriateRole);
       throw new BadRequestException(noAppropriateRole);
-    } catch (RolloutStrategyValidator.PercentageStrategyGreaterThan100Percent| RolloutStrategyValidator.InvalidStrategyCombination bad) {
-      throw new WebApplicationException(400); // can't do anything with it
+    } catch (RolloutStrategyValidator.InvalidStrategyCombination bad) {
+      throw new WebApplicationException(Response.status(422).entity(bad.failure).build()); // can't do anything with it
     }
 
     return featureApi.getFeatureValuesForApplicationForKeyForPerson(id, key, person);

--- a/sdks/java/client-java-loadtest/src/main/java/io/featurehub/loadtest/LoadTest.java
+++ b/sdks/java/client-java-loadtest/src/main/java/io/featurehub/loadtest/LoadTest.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.featurehub.client.AnalyticsCollector;
+import io.featurehub.client.ClientContext;
+import io.featurehub.client.ClientContextRepository;
 import io.featurehub.client.FeatureRepository;
 import io.featurehub.client.FeatureStateHolder;
 import io.featurehub.client.FeatureValueInterceptor;
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 
 class FeatureVersionHolder {
   private static final Logger log = LoggerFactory.getLogger(FeatureVersionHolder.class);
@@ -55,6 +58,12 @@ class InternetFeatureTrackerRepository implements FeatureRepository {
   Map<Long, FeatureVersionHolder> versionMap = new ConcurrentHashMap<>();
   static ObjectMapper mapper;
   private final int maxConnections;
+  private final ClientContext clientContext = new ClientContextRepository(new Executor() {
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
+  });
 
   static {
     mapper = new ObjectMapper();
@@ -139,6 +148,11 @@ class InternetFeatureTrackerRepository implements FeatureRepository {
   @Override
   public void setJsonConfigObjectMapper(ObjectMapper jsonConfigObjectMapper) {
 
+  }
+
+  @Override
+  public ClientContext clientContext() {
+    return clientContext;
   }
 }
 


### PR DESCRIPTION
# Description

This change modifies the validation logic to return all
of the individual errors that exist for validation for a
strategy. Only custom strategies are covered. Existing
apis are updated to return the 422 necessary.

Fixes #206 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

