### PR TITLE
Attempt to use Maven to build asciidocs

### DIFF
--- a/.github/workflows/adocs-build.yml
+++ b/.github/workflows/adocs-build.yml
@@ -13,16 +13,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Get build container
         id: adocbuild
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs --backend=html5 -a stylesheet=featurehub-skin.css  docs/*.adoc"
+        uses: ./doc-gen
       - name: Print execution time
         run: echo "Time ${{ steps.adocbuild.outputs.timestamp }}"
       - name: Deploy docs to ghpages
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./docs
+          publish_dir: ./doc-gen/target/generated-docs
           external_repository: featurehub-io/featurehub-io
           publish_branch: master
           cname: docs.featurehub.io

--- a/doc-gen/Dockerfile
+++ b/doc-gen/Dockerfile
@@ -1,0 +1,5 @@
+FROM maven:3.6.3-jdk-11
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/doc-gen/action.yml
+++ b/doc-gen/action.yml
@@ -1,0 +1,6 @@
+name: 'maven-docs'
+description: 'Crazy stuffing around with Github actions to run docker'
+runs:
+  using: docker
+  image: Dockerfile
+

--- a/doc-gen/entrypoint.sh
+++ b/doc-gen/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+cd /github/workspace/doc-gen && mvn generate-resources
+

--- a/doc-gen/pom.xml
+++ b/doc-gen/pom.xml
@@ -1,0 +1,96 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.featurehub</groupId>
+  <artifactId>featurehub-docs</artifactId>
+  <version>1.1.1</version>
+  <packaging>pom</packaging>
+
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-puravida-software-repo</id>
+      <name>bintray</name>
+      <url>https://dl.bintray.com/puravida-software/repo</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-puravida-software-repo</id>
+      <name>bintray-plugins</name>
+      <url>https://dl.bintray.com/puravida-software/repo</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <properties>
+    <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
+    <jruby.version>9.2.13.0</jruby.version>
+    <asciidoctorj.version>2.4.1</asciidoctorj.version>
+    <puravida.asciidoctor.version>2.3.0</puravida.asciidoctor.version>
+  </properties>
+
+  <build>
+    <defaultGoal>process-resources</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>${asciidoctor.maven.plugin.version}</version>
+        <dependencies>
+          <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+          <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+            <version>${jruby.version}</version>
+          </dependency>
+          <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+          <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>${asciidoctorj.version}</version>
+          </dependency>
+
+          <!-- Add PuraVida Asciidoctor Extension -->
+          <!-- https://puravida-asciidoctor.gitlab.io/asciidoctor-extensions/ -->
+
+          <dependency>
+            <groupId>com.puravida.asciidoctor</groupId>
+            <artifactId>asciidoctor-extensions</artifactId>
+            <version>${puravida.asciidoctor.version}</version>
+          </dependency>
+
+        </dependencies>
+        <configuration>
+          <sourceDirectory>${project.basedir}/../docs</sourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-html-doc</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <backend>html5</backend>
+              <attributes>
+<!--                <imagesdir>./images</imagesdir>-->
+                <toc>left</toc>
+                <icons>font</icons>
+                <sectanchors>true</sectanchors>
+                <idprefix/>
+                <idseparator>-</idseparator>
+              </attributes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -4,6 +4,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :toc: left
 :toclevels: 4
 :toc-title: Contents
+:google-analytics-code: UA-173153929-1
 
 link:index{outfilesuffix}[Back to index]
 

--- a/docs/developers.adoc
+++ b/docs/developers.adoc
@@ -4,6 +4,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :toc: left
 :toclevels: 4
 :toc-title: Contents
+:google-analytics-code: UA-173153929-1
 
 link:index{outfilesuffix}[Back to index]
 

--- a/docs/identity.adoc
+++ b/docs/identity.adoc
@@ -4,6 +4,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :toc: left
 :toclevels: 4
 :toc-title: Contents
+:google-analytics-code: UA-173153929-1
 
 == Overview
 FeatureHub comes with a built in identity system, which stores passwords in a securely salted fashion. It is fine

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -5,6 +5,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :toclevels: 2
 :toc-title: Contents
 :favicon: favicon.ico
+:google-analytics-code: UA-173153929-1
 
 FeatureHub Team <info@featurehub.io>
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -4,6 +4,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :toc: left
 :toclevels: 4
 :toc-title: Contents
+:google-analytics-code: UA-173153929-1
 
 link:index{outfilesuffix}[Back to index]
 


### PR DESCRIPTION
# Description

This swaps us to using Maven for asciidoc generation of the docs.featurehub.io site. The advantage is consistent build, being able to build locally and preview and easy addition of extensions to Asciidoctor without having to fuss about with Ruby.

