### PR TITLE
ClientContext support

### DIFF
--- a/sdks/client-go/README.md
+++ b/sdks/client-go/README.md
@@ -33,7 +33,10 @@ There are 3 steps to connecting:
     config := &client.Config{
         SDKKey:        "default/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/ajhsgdJHGAFKJAHSGDFKAJHHSDLFKAJLSKJDHFLAJKHlkjahlkjhfsld",
         ServerAddress: "http://1.2.3.4:8085",
-        WaitForData:   true,
+		WaitForData:   true,
+		ClientContext: &client.Context{
+			Userkey: uuid.New().String(),
+		},
     }
 ```
 
@@ -145,5 +148,6 @@ Todo
 - [X] Global "readyness" callback (either OK when data has arrived, or an error if there was a fail)
 - [X] Analytics support
 - [X] Google Analytics support
+- [X] Add support for ClientContext, and submit this as an x-featurehub header upon connection
 - [ ] Re-introduce the "polling" client (if we decide to go down that route for other SDKs)
 - [ ] Run tests and code-generation inside Docker (instead of requiring Go to be installed locally)

--- a/sdks/client-go/config.go
+++ b/sdks/client-go/config.go
@@ -14,6 +14,7 @@ const (
 
 // Config defines parameters for the client:
 type Config struct {
+	Context       *Context     // Client context metadata (optional)
 	LogLevel      logrus.Level // Logging level (default is "info")
 	SDKKey        string       // SDK key (copied from the UI), in the format "{namedCache}/environmentID/APIKey"
 	ServerAddress string       // FeatureHub API endpoint

--- a/sdks/client-go/context.go
+++ b/sdks/client-go/context.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Context defines metadata for the client:
+// This is sent to the FeatureHub server, and powers the rollout strategy decisions.
+type Context struct {
+	Userkey  string // Unique key which will be hashed to calculate percentage rollouts
+	Session  string // Session ID key
+	Device   string // [browser, mobile, desktop]
+	Platform string // [linux, windows,	macos, android, ios]
+	Country  string // Country / geographic region: https://www.britannica.com/topic/list-of-countries-1993160
+	Version  string // Version of the client
+}
+
+// String concatenates the context and URL encodes it:
+func (c *Context) String() string {
+	return url.QueryEscape(fmt.Sprintf("userkey=%s,session=%s,device=%s,platform=%s,country=%s,version=%s", c.Userkey, c.Session, c.Device, c.Platform, c.Country, c.Version))
+}

--- a/sdks/client-go/context_test.go
+++ b/sdks/client-go/context_test.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext(t *testing.T) {
+
+	// Make a new context:
+	context := &Context{
+		Userkey:  "some-random-string",
+		Session:  "some-session-ID",
+		Device:   "desktop",
+		Platform: "macos",
+		Country:  "new_zealand",
+		Version:  "5.0.0",
+	}
+
+	assert.Equal(t, url.QueryEscape("userkey=some-random-string,session=some-session-ID,device=desktop,platform=macos,country=new_zealand,version=5.0.0"), context.String())
+}


### PR DESCRIPTION
- ClientContext now included in the Config struct
- If this is populated then the SDK will automatically URL-encode it and submit it as an `x-featurehub` header whenever it connects to the server