### PR TITLE
Fix new invalid line error and tooltip exploding

### DIFF
--- a/admin-frontend/app_singleapp/lib/widgets/features/table-collapsed-view/tooltip.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/table-collapsed-view/tooltip.dart
@@ -2,49 +2,60 @@ import 'package:app_singleapp/widgets/features/percentage_utils.dart';
 import 'package:mrapi/api.dart';
 
 String generateTooltipMessage(RolloutStrategy rolloutStrategy) {
-  var percentageMessage ='';
-  var userKeyMessage='';
-  var countryNameMessage='';
-  var platformNameMessage='';
-  var deviceNameMessage='';
-  var versionNameMessage='';
-  var customNameMessage='';
+  if (rolloutStrategy == null) {
+    return '';
+  }
 
-  if (rolloutStrategy?.percentage != null) {
+  var percentageMessage = '';
+  var userKeyMessage = '';
+  var countryNameMessage = '';
+  var platformNameMessage = '';
+  var deviceNameMessage = '';
+  var versionNameMessage = '';
+  var customNameMessage = '';
+
+  if (rolloutStrategy.percentage != null) {
     percentageMessage = 'Percentage: ${rolloutStrategy.percentageText}%\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-  rsa.fieldName == StrategyAttributeWellKnownNames.userkey.name)) {
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) =>
+          rsa.fieldName == StrategyAttributeWellKnownNames.userkey.name)) {
     userKeyMessage = 'User key\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-  rsa.fieldName == StrategyAttributeWellKnownNames.country.name)) {
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) =>
+          rsa.fieldName == StrategyAttributeWellKnownNames.country.name)) {
     countryNameMessage = 'Country\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-  rsa.fieldName == StrategyAttributeWellKnownNames.platform.name)) {
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) =>
+          rsa.fieldName == StrategyAttributeWellKnownNames.platform.name)) {
     platformNameMessage = 'Platform\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-  rsa.fieldName == StrategyAttributeWellKnownNames.device.name)) {
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) =>
+          rsa.fieldName == StrategyAttributeWellKnownNames.device.name)) {
     deviceNameMessage = 'Device\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-  rsa.fieldName == StrategyAttributeWellKnownNames.version.name)) {
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) =>
+          rsa.fieldName == StrategyAttributeWellKnownNames.version.name)) {
     versionNameMessage = 'Version\n';
   }
 
-  if (rolloutStrategy?.attributes != null && rolloutStrategy.attributes.any((rsa) =>
-      StrategyAttributeWellKnownNames.values
+  if (rolloutStrategy.attributes != null &&
+      rolloutStrategy.attributes.any((rsa) => StrategyAttributeWellKnownNames
+          .values
           .every((value) => rsa.fieldName != value.name))) {
     customNameMessage = 'Custom\n';
   }
 
-  var finalString =  '\n-- Applied rules -- \n\n${percentageMessage}${userKeyMessage}${countryNameMessage}${platformNameMessage}${deviceNameMessage}${versionNameMessage}${customNameMessage}';
+  var finalString =
+      '\n-- Applied rules -- \n\n${percentageMessage}${userKeyMessage}${countryNameMessage}${platformNameMessage}${deviceNameMessage}${versionNameMessage}${customNameMessage}';
   return finalString;
 }

--- a/admin-frontend/app_singleapp/lib/widgets/features/table-collapsed-view/value_cell.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/table-collapsed-view/value_cell.dart
@@ -136,17 +136,22 @@ class _ValueCard extends StatelessWidget {
                     flex: 4,
                     child: rolloutStrategy != null
                         ? Tooltip(
-                            textStyle: TextStyle(fontFamily: 'source', fontSize: 12, color: Colors.white),
+                            textStyle: TextStyle(
+                                fontFamily: 'source',
+                                fontSize: 12,
+                                color: Colors.white),
                             // decoration: BoxDecoration(
                             //     color: Theme.of(context).primaryColorLight,
                             //     borderRadius:
                             //         BorderRadius.all(Radius.circular(4.0))),
                             message: generateTooltipMessage(rolloutStrategy),
-                            child: Text(rolloutStrategy.name,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .caption
-                                    .copyWith(color: strategyTextColor)),
+                            child: rolloutStrategy == null
+                                ? SizedBox.shrink()
+                                : Text(rolloutStrategy.name,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .caption
+                                        .copyWith(color: strategyTextColor)),
                           )
                         : Text('default',
                             style: Theme.of(context)

--- a/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/individual_strategy_bloc.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/individual_strategy_bloc.dart
@@ -37,6 +37,9 @@ class IndividualStrategyBloc extends Bloc {
     // print('Attributes are ${rolloutStrategy.attributes}');
   }
 
+  bool get isUnsavedStrategy =>
+      (rolloutStrategy.id == null || rolloutStrategy.id == 'created');
+
   void createAttribute({StrategyAttributeWellKnownNames type}) {
     final rs = RolloutStrategyAttribute()
       ..id = DateTime.now().millisecond.toRadixString(16) // hex, just because
@@ -81,8 +84,7 @@ class IndividualStrategyBloc extends Bloc {
 
   /// updates our list of violations and updates the stream
   void updateStrategyViolations(
-      RolloutStrategyValidationResponse validationCheck,
-      RolloutStrategy rolloutStrategy) {
+      RolloutStrategyValidationResponse validationCheck) {
     var _violations = <RolloutStrategyViolation>[];
 
     final customViolations = validationCheck.customStategyViolations.firstWhere(

--- a/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/strategies/edit_value_strategy_link_button.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/strategies/edit_value_strategy_link_button.dart
@@ -25,20 +25,17 @@ class EditValueStrategyLinkButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FHUnderlineButton(
         title: '${rolloutStrategy.name}',
-        onPressed:  () => {
-                  fvBloc.mrClient.addOverlay((BuildContext context) {
-                    rolloutStrategy.attributes ??= [];
+        onPressed: () => {
+              fvBloc.mrClient.addOverlay((BuildContext context) {
+                rolloutStrategy.attributes ??= [];
 
-                    return BlocProvider(
-                      creator: (_c, _b) => IndividualStrategyBloc(
-                          strBloc.environmentFeatureValue, rolloutStrategy),
-                      child: StrategyEditingWidget(
-                          bloc: strBloc,
-                          rolloutStrategy: rolloutStrategy,
-                          editable: editable),
-                    );
-                  })
-                }
-            );
+                return BlocProvider(
+                  creator: (_c, _b) => IndividualStrategyBloc(
+                      strBloc.environmentFeatureValue, rolloutStrategy),
+                  child:
+                      StrategyEditingWidget(bloc: strBloc, editable: editable),
+                );
+              })
+            });
   }
 }

--- a/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/strategies/split_rollout_button.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/table-expanded-view/strategies/split_rollout_button.dart
@@ -21,15 +21,16 @@ class AddStrategyButton extends StatelessWidget {
         height: 36,
         child: ElevatedButton.icon(
             label: Text('Add split targeting rules'),
-            style: ElevatedButton.styleFrom(primary: Theme.of(context).buttonColor
-    ),
+            style: ElevatedButton.styleFrom(
+                primary: Theme.of(context).buttonColor),
             icon: Icon(MaterialCommunityIcons.arrow_split_vertical,
                 color: Colors.white, size: 16.0),
             onPressed: (editable == true)
                 ? () => bloc.fvBloc.mrClient.addOverlay((BuildContext context) {
                       return BlocProvider(
                         creator: (_c, _b) => IndividualStrategyBloc(
-                            bloc.environmentFeatureValue, RolloutStrategy()),
+                            bloc.environmentFeatureValue,
+                            RolloutStrategy()..id = 'created'),
                         child: StrategyEditingWidget(
                           bloc: bloc,
                           editable: editable,

--- a/e2e/test/steps/PortfolioStepdefs.dart
+++ b/e2e/test/steps/PortfolioStepdefs.dart
@@ -175,7 +175,7 @@ class PortfolioStepdefs {
         orElse: () => null);
     if (saPermission == null) {
       saPermission = ServiceAccountPermission();
-      List<RoleType> permissions = List();
+      List<RoleType> permissions = [];
       permissions.add(permission);
       saPermission.environmentId = environment.id;
       saPermission.permissions = permissions;


### PR DESCRIPTION
  New invalid line causes failure
    
    If you create an invalid line in a strategy attribute
    and it is a new strategy, then the backend is communicating
    in such a way that the frontend can never understand. This
    resolves this and cleans up the whole strategy editing
    section in terms of rollout strategy state.

Fixed exploding tooltip
    
    This was blowing up as well.

Required for 1.1.1 release