### PR TITLE
Release sdk 1.1.1

### DIFF
--- a/sdks/dart/client-dart-api/CHANGELOG.md
+++ b/sdks/dart/client-dart-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.2
+=====
+* Documentation update
+
 1.1.1
 =====
 * Updated API for Edge, including GET api.

--- a/sdks/dart/client-dart-api/pubspec.yaml
+++ b/sdks/dart/client-dart-api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: featurehub_client_api
-version: 1.0.1
+version: 1.1.2
 description: This is the OpenAPI client for the FeatureHub SDK. It is not likely to be used on its own.
 repository: https://github.com/featurehub-io/featurehub/tree/master/sdks/dart/client-dart-api
 homepage: https://www.featurehub.io

--- a/sdks/dart/client-dart-sdk/CHANGELOG.md
+++ b/sdks/dart/client-dart-sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.4
+=====
+* documentation updates
+
 1.1.3
 =====
 * allow the release process for catch & release to turn the catch flag off once released. Ensure turning

--- a/sdks/dart/client-dart-sdk/pubspec.yaml
+++ b/sdks/dart/client-dart-sdk/pubspec.yaml
@@ -1,5 +1,5 @@
 name: featurehub_client_sdk
-version: 1.1.3
+version: 1.1.4
 description: Client SDK for FeatureHub
 repository: https://github.com/featurehub-io/featurehub/tree/master/sdks/dart/client-dart-sdk
 homepage: https://www.featurehub.io
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.14.11
   logging: ^0.11.4
   rxdart: ^0.24.1
-  featurehub_client_api: ^1.1.1
+  featurehub_client_api: ^1.1.2
 #  featurehub_client_api:
 #    path: ../client-dart-api
   openapi_dart_common: ^3.1.0

--- a/sdks/typescript/client-typescript-core/package.json
+++ b/sdks/typescript/client-typescript-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-repository",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
   "author": "info@featurehub.io",
   "main": "dist/index.js",


### PR DESCRIPTION
release of Dart and NPM because they needed their docs updated.