### PR TITLE
incorrect key used for portfolio id

### DIFF
--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/ServiceAccountApi.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/ServiceAccountApi.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface ServiceAccountApi {
   ServiceAccount get(String id, Opts opts);
 
-  ServiceAccount update(String id, Person updater, ServiceAccount serviceAccount, Opts opts) throws OptimisticLockingException;
+  ServiceAccount update(String serviceAccountId, Person updater, ServiceAccount serviceAccount, Opts opts) throws OptimisticLockingException;
 
   /**
    * This has to determine if this user has access based on what they are asking for. If they have any access to the

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/ServiceAccountResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/ServiceAccountResource.java
@@ -130,7 +130,7 @@ public class ServiceAccountResource implements ServiceAccountServiceDelegate {
   }
 
   @Override
-  public ServiceAccount update(String id, ServiceAccount serviceAccount, UpdateHolder holder, SecurityContext securityContext) {
+  public ServiceAccount update(String serviceAccountId, ServiceAccount serviceAccount, UpdateHolder holder, SecurityContext securityContext) {
     Person person = authManager.from(securityContext);
 
     Set<String> envIds =
@@ -140,11 +140,15 @@ public class ServiceAccountResource implements ServiceAccountServiceDelegate {
       throw new BadRequestException("Duplicate environment ids were passed.");
     }
 
-    if (authManager.isPortfolioAdmin(id, person) || authManager.isOrgAdmin(person) ) {
+    if (serviceAccount.getPortfolioId() == null) {
+      throw new BadRequestException("No portfolio passed");
+    }
+
+    if (authManager.isPortfolioAdmin(serviceAccount.getPortfolioId(), person) || authManager.isOrgAdmin(person) ) {
       ServiceAccount result = null;
 
       try {
-        result = serviceAccountApi.update(id, person, serviceAccount, new Opts().add(FillOpts.Permissions, holder.includePermissions));
+        result = serviceAccountApi.update(serviceAccountId, person, serviceAccount, new Opts().add(FillOpts.Permissions, holder.includePermissions));
       } catch (OptimisticLockingException e) {
         throw new WebApplicationException(422);
       }


### PR DESCRIPTION
The portfolio id was not being used to check for permissions
to service accounts, the service account key was and thus
this was preventing a non-SuperAdmin user from changing
service account permissions.

Closes issue #278

