### PR TITLE
fix copy-to-clipboard for Firefox (issue 280).

### DIFF
--- a/admin-frontend/app_singleapp/lib/routes/service_env_route.dart
+++ b/admin-frontend/app_singleapp/lib/routes/service_env_route.dart
@@ -1,6 +1,5 @@
-import 'dart:html' as html;
-
 import 'package:app_singleapp/widgets/common/application_drop_down.dart';
+import 'package:app_singleapp/widgets/common/copy_to_clipboard_html.dart';
 import 'package:app_singleapp/widgets/common/decorations/fh_page_divider.dart';
 import 'package:app_singleapp/widgets/common/fh_header.dart';
 import 'package:app_singleapp/widgets/service-accounts/service_accounts_env_bloc.dart';
@@ -160,7 +159,12 @@ class _ServiceAccountPermissionWidget extends StatelessWidget {
                     width: 16.0,
                   ),
                   if (account.sdkUrl != null)
-                    _CopyServiceAccountUrlToClipboard(account: account),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        FHCopyToClipboard(copyString: account.sdkUrl, tooltipMessage: account.sdkUrl),
+                      ],
+                    ),
                   if (account.sdkUrl == null)
                     Tooltip(
                       message:

--- a/admin-frontend/app_singleapp/lib/routes/service_env_route.dart
+++ b/admin-frontend/app_singleapp/lib/routes/service_env_route.dart
@@ -159,12 +159,7 @@ class _ServiceAccountPermissionWidget extends StatelessWidget {
                     width: 16.0,
                   ),
                   if (account.sdkUrl != null)
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        FHCopyToClipboard(copyString: account.sdkUrl, tooltipMessage: account.sdkUrl),
-                      ],
-                    ),
+                    FHCopyToClipboard(copyString: account.sdkUrl, tooltipMessage: account.sdkUrl),
                   if (account.sdkUrl == null)
                     Tooltip(
                       message:
@@ -183,38 +178,5 @@ class _ServiceAccountPermissionWidget extends StatelessWidget {
                       style: Theme.of(context).textTheme.caption),
                 ],
               ));
-  }
-}
-
-class _CopyServiceAccountUrlToClipboard extends StatelessWidget {
-  final ServiceAccountPermission account;
-
-  const _CopyServiceAccountUrlToClipboard({Key key, @required this.account})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return
-//      sa.sdkUrl  != null ?
-        Tooltip(
-      message: 'Copy SDK Url to clipboard',
-      child: InkWell(
-        mouseCursor: SystemMouseCursors.click,
-        borderRadius: BorderRadius.circular(10.0),
-        hoverColor: Theme.of(context).primaryColorLight,
-        splashColor: Theme.of(context).primaryColor,
-        child: Container(
-            width: 20,
-            height: 20,
-            child: Icon(Icons.content_copy, size: 16.0)),
-        onTap: () async {
-          await html.window.navigator.permissions
-              .query({'name': 'clipboard-write'});
-          await html.window.navigator.clipboard.writeText(account.sdkUrl);
-        },
-      ),
-    )
-//        : SizedBox.shrink()
-        ;
   }
 }

--- a/admin-frontend/app_singleapp/lib/widgets/common/copy_to_clipboard_html.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/common/copy_to_clipboard_html.dart
@@ -1,6 +1,5 @@
-import 'dart:html' as html;
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 typedef CopyToClipboardTextProvider = Future<String> Function();
 
@@ -28,9 +27,7 @@ class FHCopyToClipboardFlatButton extends StatelessWidget {
       onPressed: () async {
         final clipboardText = text ?? (await textProvider());
         if (clipboardText != null) {
-          await html.window.navigator.permissions
-              .query({'name': 'clipboard-write'});
-          await html.window.navigator.clipboard.writeText(clipboardText);
+          await Clipboard.setData(ClipboardData(text: clipboardText));
         }
       },
       child: Row(
@@ -79,9 +76,7 @@ class FHCopyToClipboard extends StatelessWidget {
       icon: Icon(Icons.content_copy, size: 16.0),
       tooltip: tooltipMessage,
       onPressed: () async {
-        await html.window.navigator.permissions
-            .query({'name': 'clipboard-write'});
-        await html.window.navigator.clipboard.writeText(copyString);
+        await Clipboard.setData(ClipboardData(text: copyString));
       },
     );
   }


### PR DESCRIPTION
# Description
Fix copy to clipboard button which is not working on Firefox browsers. 

Fixes # (280)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with Safari, Firefox and Chrome