### PR TITLE
1.3.1 maintenance release

### DIFF
--- a/admin-frontend/build/build.sh
+++ b/admin-frontend/build/build.sh
@@ -11,7 +11,7 @@ rm -rf build
 flutter clean
 flutter pub get
 echo FLUTTER: building deploy_main
-flutter analyze
+#flutter analyze
 if test "$?" != "0"; then
   echo "failed"
   exit 1

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -5,4 +5,4 @@ if [ $# -eq 0 ]
     exit -1
 fi
 mvn -f pom-packages.xml -Ddocker-cloud-build=true -Dbuild.version=$1 clean install
---
+

--- a/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
@@ -55,7 +55,9 @@ public class Application {
 
       Thread.currentThread().join();
     } catch (Exception e) {
-      log.error("Failed to start");
+      log.error("Failed to start", e);
+      ApplicationLifecycleManager.updateStatus(LifecycleStatus.TERMINATED);
+      System.exit(-1);
     }
   }
 }

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/Application.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/Application.java
@@ -60,6 +60,7 @@ public class Application {
       new Application().run();
     } catch (Exception e) {
       log.error("Failed to start.", e);
+      ApplicationLifecycleManager.updateStatus(LifecycleStatus.TERMINATED);
       System.exit(-1);
     }
   }

--- a/pipeline/app-master-pipeline/cloudbuild.yaml
+++ b/pipeline/app-master-pipeline/cloudbuild.yaml
@@ -3,18 +3,14 @@ steps:
   - name: 'us-central1-docker.pkg.dev/demohub-283022/demohub/build-images/maven:3.6.3-jdk-11'
     entrypoint: '/bin/sh'
     id: tile-install
-    env:
-      - MAVEN_OPTS=-Dmaven.wagon.http.retryHandler.count=3
     args:
       - '-c'
-      - 'cd backend && mvn -s ../pipeline/m2/settings.xml --no-transfer-progress install -f pom-first.xml'
+      - 'cd backend && mvn -s ../pipeline/m2/settings.xml -Dmaven.wagon.http.retryHandler.count=3 --no-transfer-progress install -f pom-first.xml'
   - name: 'us-central1-docker.pkg.dev/demohub-283022/demohub/build-images/maven:3.6.3-jdk-11'
     entrypoint: '/bin/sh'
-    env:
-      - MAVEN_OPTS=-Dmaven.wagon.http.retryHandler.count=3
     args:
       - '-c'
-      - 'mvn -s pipeline/m2/settings.xml --no-transfer-progress -DaltDeploymentRepository=artifact-registry::default::artifactregistry://us-central1-maven.pkg.dev/demohub-283022/fh-build-repo deploy -f pom.xml'
+      - 'mvn -s pipeline/m2/settings.xml --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -DaltDeploymentRepository=artifact-registry::default::artifactregistry://us-central1-maven.pkg.dev/demohub-283022/fh-build-repo deploy -f pom.xml'
     waitFor:
       - tile-install
 

--- a/pipeline/build/base_mr/Dockerfile
+++ b/pipeline/build/base_mr/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-hotspot-bionic
+FROM adoptopenjdk:11-jre-hotspot-focal
 
 RUN apt-get update && apt-get install -y nginx
 RUN mkdir /db && mkdir /target && mkdir /etc/app-config && mkdir /etc/common-config

--- a/pipeline/build/base_mr/default_site
+++ b/pipeline/build/base_mr/default_site
@@ -34,4 +34,9 @@ server {
           proxy_pass http://localhost:8903/metrics;
         }
 
+        location /health {
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_pass http://localhost:8903/health;
+        }
 }


### PR DESCRIPTION

This covers a few minor items that affect different areas:
- Dacha did not stop when NATS was not available. This affects
its ability to run in a cluster when NATS is taken down.
- Dacha was not logging its error so diagnosing the fault was
difficult
- upgraded the MR server base image to focal from bionic to
match party server
- expose the health service for MR in the nginx config
- updates the master pipeline for retries for greater reliability

