### PR TITLE
Upgrade OpenAPI dependencies

### DIFF
--- a/admin-frontend/app_mr_layer/pom.xml
+++ b/admin-frontend/app_mr_layer/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.0.0</version>
+        <version>5.1.0</version>
         <dependencies>
           <dependency>
             <groupId>com.bluetrainsoftware.maven</groupId>

--- a/backend/dacha-api/pom.xml
+++ b/backend/dacha-api/pom.xml
@@ -77,7 +77,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.0.0</version>
+        <version>5.1.0</version>
         <dependencies>
           <dependency>
             <groupId>cd.connect.openapi</groupId>

--- a/backend/mr-api/pom.xml
+++ b/backend/mr-api/pom.xml
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.0.0</version>
+        <version>5.1.0</version>
         <dependencies>
           <dependency>
             <groupId>cd.connect.openapi</groupId>

--- a/backend/mr-streaming-api/pom.xml
+++ b/backend/mr-streaming-api/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.0.0</version>
+        <version>5.1.0</version>
         <dependencies>
           <dependency>
             <groupId>cd.connect.openapi</groupId>


### PR DESCRIPTION
This moves us to 5.1.0 as per recommendations from OpenAPI.

Fixes #386

