### PR TITLE
Conflicting users being added in Groups causing explosions

### DIFF
--- a/admin-frontend/app_mr_layer/pom.xml
+++ b/admin-frontend/app_mr_layer/pom.xml
@@ -118,7 +118,7 @@
           <dependency>
             <groupId>com.bluetrainsoftware.maven</groupId>
             <artifactId>openapi-dart-generator</artifactId>
-            <version>5.2</version>
+            <version>5.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/admin-frontend/app_singleapp/test/person_test.dart
+++ b/admin-frontend/app_singleapp/test/person_test.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mrapi/api.dart';
+
+void main() {
+  // this occasionally causes problems, so lets keep a test for it
+  test('Two people should be equal', () {
+    final json =
+        '{"id":{"id":"931b68a1-8b87-43a2-abcd-7d16ee94075b"},"name":"Alex","email":"some@hgh.com","version":1,"passwordRequiresReset":false}';
+    final decoded = jsonDecode(json);
+    final person1 = Person.fromJson(decoded);
+    final person2 = Person.fromJson(decoded);
+    expect(person1, person2);
+  });
+}


### PR DESCRIPTION
There is a bug in the ChipsInput widget that is causing
deleted items to come back as if they were added. That will
be addressed in a different ticket. In this ticket, the
issue is that the "other" field in Person was causing the
equals method of Person to always fail, and thus the
list of members being forced into a Set would fail because
two people who were identical were appearing not to be. The
backend would rightfully reject this request.

Fixes issue #382

