### PR TITLE
Not removing items from internal list for group/add member

### DIFF
--- a/admin-frontend/app_singleapp/lib/routes/manage_group_route.dart
+++ b/admin-frontend/app_singleapp/lib/routes/manage_group_route.dart
@@ -372,7 +372,10 @@ class _AddMembersDialogWidgetState extends State<AddMembersDialogWidget> {
           child: InputChip(
             key: ObjectKey(p),
             label: Text('${person.name} (${person.email})'),
-            onDeleted: () => state.deleteChip(p),
+            onDeleted: () {
+              state.deleteChip(p);
+              membersToAdd.remove(p);
+            },
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
         );


### PR DESCRIPTION
If you choose to Add a user and then remove them and then
add them again in the dialog, it will fail to remove them
from the list. Depends on the merge of #382

Fixes issue #390

