### PR TITLE
Update SDK with logging and disable backoff

### DIFF
--- a/sdks/client-csharp/FeatureHubSDK/EventServiceListener.cs
+++ b/sdks/client-csharp/FeatureHubSDK/EventServiceListener.cs
@@ -16,6 +16,18 @@ namespace FeatureHubSDK
     void Poll();
   }
 
+  public static class FeatureLogging
+  {
+    // Attach event handler to receive Trace level logs
+    public static EventHandler<String> TraceLogger;
+    // Attach event handler to receive Debug level logs
+    public static EventHandler<String> DebugLogger;
+    // Attach event handler to receive Info level logs
+    public static EventHandler<String> InfoLogger;
+    // Attach event handler to receive Error level logs
+    public static EventHandler<String> ErrorLogger;
+  }
+
   public class EventServiceListener : IEdgeService
   {
     private EventSource _eventSource;
@@ -88,14 +100,24 @@ namespace FeatureHubSDK
     public void Init()
     {
       var config = new Configuration(uri: new UriBuilder(_featureHost.Url).Uri,
+        backoffResetThreshold: TimeSpan.MaxValue,
+        delayRetryDuration: TimeSpan.Zero,
         requestHeaders: _featureHost.ServerEvaluation ? BuildContextHeader() : null);
+
+      if (FeatureLogging.InfoLogger != null)
+      {
+        FeatureLogging.InfoLogger(this, $"Opening connection to ${_featureHost.Url}");
+      }
 
       _eventSource = new EventSource(config);
 
-      // _eventSource.Closed += (sender, args) =>
-      // {
-      //   Console.WriteLine("source closed\n");
-      // };
+      if (FeatureLogging.DebugLogger != null)
+      {
+        _eventSource.Closed += (sender, args) =>
+        {
+          FeatureLogging.DebugLogger(this, "source closed");
+        };
+      }
 
       _eventSource.MessageReceived += (sender, args) =>
       {
@@ -104,6 +126,11 @@ namespace FeatureHubSDK
         {
           case "features":
             state = SSEResultState.Features;
+            if (FeatureLogging.TraceLogger != null)
+            {
+              FeatureLogging.TraceLogger(this, "featurehub: fresh feature set received, ready to rumble");
+            }
+
             break;
           case "feature":
             state = SSEResultState.Feature;
@@ -114,12 +141,23 @@ namespace FeatureHubSDK
           case "delete_feature":
             state = SSEResultState.Deletefeature;
             break;
+          case "bye":
+            state = null;
+            if (FeatureLogging.TraceLogger != null)
+            {
+              FeatureLogging.TraceLogger(this, "featurehub: renewing connection process started");
+            }
+
+            break;
           default:
             state = null;
             break;
         }
 
-        // Console.WriteLine($"The state was {state} with value {args.Message.Data}\n");
+        if (FeatureLogging.TraceLogger != null)
+        {
+          FeatureLogging.TraceLogger(this , $"featurehub: The state was {state} with value {args.Message.Data}");
+        }
 
         if (state == null) return;
 
@@ -127,6 +165,11 @@ namespace FeatureHubSDK
 
         if (state == SSEResultState.Failure)
         {
+          if (FeatureLogging.ErrorLogger != null)
+          {
+            FeatureLogging.ErrorLogger(this, "featurehub: received a failure so closing");
+          }
+
           _eventSource.Close();
         }
       };

--- a/sdks/client-csharp/FeatureHubSDK/FeatureHubSDK.csproj
+++ b/sdks/client-csharp/FeatureHubSDK/FeatureHubSDK.csproj
@@ -17,7 +17,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>FeatureFlags Features Toggles CloudNative</PackageTags>
         <PackageReleaseNotes>Initial 1.0.0 release</PackageReleaseNotes>
-        <PackageVersion>2.1.2</PackageVersion>
+        <PackageVersion>2.1.3</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,7 +28,7 @@
       <PackageReference Include="NodaTime" Version="3.0.5" />
       <PackageReference Include="RestSharp" Version="106.10.1" />
       <None Include="FeatureHub-icon.png" Pack="true" PackagePath="\" />
-      <None Include="README.md" Pack="true" PackagePath="\"/>
+      <None Include="README.md" Pack="true" PackagePath="\" />
       <PackageReference Include="SemanticVersioning" Version="1.3.0" />
     </ItemGroup>
 

--- a/sdks/client-csharp/FeatureHubSDK/README.md
+++ b/sdks/client-csharp/FeatureHubSDK/README.md
@@ -13,6 +13,7 @@ Details about what general features are available in SDKs from FeatureHub are [a
 
 ## Changelog
 
+2.1.3 - logging support (see below) and fixing of the backoff for the eventsource (it was randomly increasing the time, making features go out of date)
 2.0.0 - client side evaluation support
 1.1.0 - analytics support
 1.0.0 - initial functionality with near-realtime event updates, full feature repository, server side rollout strategies.
@@ -190,7 +191,39 @@ _data[GoogleConstants.Cid] = "some-cid";
 context.LogAnalyticsEvent("event-name", _data);
 ```
 
-Read more on how to interpret events in Google Analytics [here](https://docs.featurehub.io/analytics.html) 
+Read more on how to interpret events in Google Analytics [here](https://docs.featurehub.io/analytics.html)
+
+### Logging
+
+This library doesn't "use" any of the various .NET logging systems, it simply exposes a static logger class, and
+if you add events to this, you can see what is going on. This can be especially useful diagnosing connection issues
+if you are having them. 
+
+```c#
+public static class FeatureLogging
+{
+  // Attach event handler to receive Trace level logs
+  public static EventHandler<String> TraceLogger;
+  // Attach event handler to receive Debug level logs
+  public static EventHandler<String> DebugLogger;
+  // Attach event handler to receive Info level logs
+  public static EventHandler<String> InfoLogger;
+  // Attach event handler to receive Error level logs
+  public static EventHandler<String> ErrorLogger;
+}
+```
+
+So a full diagnostic, as we have in our ASP.NET example in the [featurehub-examples](https://github.com/featurehub-io/featurehub-examples) 
+repository looks like this:
+
+```c#
+  FeatureLogging.DebugLogger += (sender, s) => Console.WriteLine("DEBUG: " + s + "\n"); 
+  FeatureLogging.TraceLogger += (sender, s) => Console.WriteLine("TRACE: " + s + "\n"); 
+  FeatureLogging.InfoLogger += (sender, s) => Console.WriteLine("INFO: " + s + "\n"); 
+  FeatureLogging.ErrorLogger += (sender, s) => Console.WriteLine("ERROR: " + s + "\n"); 
+```
+
+You can of course connect it to the logger of your choice.
 
 ### IO.FeatureHub.SSE
 


### PR DESCRIPTION
The SDK has been updated with logging support for diagnosis,
and backoff has been disabled, as it was causing feature
drift.

