### PR TITLE
Allow the monitor port to be different from the app port

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
@@ -1,0 +1,68 @@
+package io.featurehub.health
+
+import cd.connect.jersey.JerseyHttp2Server
+import cd.connect.jersey.common.JerseyPrometheusResource
+import io.prometheus.client.hotspot.DefaultExports
+import org.glassfish.hk2.api.ServiceLocator
+import org.glassfish.jersey.server.ResourceConfig
+import org.glassfish.jersey.server.spi.Container
+import org.glassfish.jersey.server.spi.ContainerLifecycleListener
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * This automatically detects if there is a monitor.port setting and if so, pulls the
+ * health and prometheus endpoint (/metrics) out of the main Jersey endpoint and waits
+ * until that one has fired up and then pulls out the health sources and creates a new
+ * resource
+ */
+
+class MetricsHealthRegistration {
+
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(MetricsHealthRegistration::class.java)
+    const val monitorPortName = "monitor.port"
+
+    fun registerMetrics(config: ResourceConfig) {
+      // turn on all jvm prometheus metrics
+      DefaultExports.initialize()
+
+      if (System.getProperty(monitorPortName) == null) {
+        config.register(JerseyPrometheusResource::class.java)
+        config.register(HealthFeature::class.java)
+      } else {
+        config.register(object : ContainerLifecycleListener {
+          override fun onStartup(container: Container) {
+            // access the ServiceLocator here
+            val injector = container.applicationHandler
+              .injectionManager.getInstance(ServiceLocator::class.java)
+
+            // pull all of the health sources out of the main context and replicate them
+            // into our health repository
+            val healthSources = injector.getAllServices(HealthSource::class.java);
+
+            val resourceConfig = ResourceConfig(JerseyPrometheusResource::class.java, HealthFeature::class.java)
+
+            healthSources.forEach { hs ->
+              if (!(hs is ApplicationHealthSource)) {
+                resourceConfig.register(hs)
+              }
+            }
+
+            JerseyHttp2Server().start(
+              resourceConfig, System.getProperty(monitorPortName).toInt()
+            )
+
+            log.info("metric/health endpoint now active on port {}", System.getProperty(monitorPortName))
+          }
+
+          override fun onReload(container: Container) {
+          }
+
+          override fun onShutdown(container: Container) {/*...*/}
+        });
+      }
+    }
+  }
+}

--- a/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/Application.java
@@ -2,18 +2,16 @@ package io.featurehub.dacha;
 
 import cd.connect.jersey.JerseyHttp2Server;
 import cd.connect.jersey.common.CommonConfiguration;
-import cd.connect.jersey.common.InfrastructureConfiguration;
 import cd.connect.jersey.common.LoggingConfiguration;
 import cd.connect.jersey.common.TracingConfiguration;
 import cd.connect.lifecycle.ApplicationLifecycleManager;
 import cd.connect.lifecycle.LifecycleStatus;
-import io.featurehub.health.HealthFeature;
 import io.featurehub.health.HealthSource;
+import io.featurehub.health.MetricsHealthRegistration;
 import io.featurehub.jersey.config.EndpointLoggingListener;
 import io.featurehub.publish.NATSHealthSource;
 import io.featurehub.publish.NATSSource;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
-import io.prometheus.client.hotspot.DefaultExports;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
@@ -39,18 +37,13 @@ public class Application {
   }
 
   private static void initializeCommonJerseyLayer(CacheManager cm) throws Exception {
-
-    // turn on all jvm prometheus metrics
-    DefaultExports.initialize();
-
     // register our resources, try and tag them as singleton as they are instantiated faster
     ResourceConfig config = new ResourceConfig(
       ClientTracingFeature.class,
       CommonConfiguration.class,
       LoggingConfiguration.class,
       TracingConfiguration.class,
-      EndpointLoggingListener.class,
-      HealthFeature.class)
+      EndpointLoggingListener.class)
       .register(new AbstractBinder() {
         @Override
         protected void configure() {
@@ -59,6 +52,9 @@ public class Application {
           bind(NATSHealthSource.class).to(HealthSource.class).in(Singleton.class);
         }
       });
+
+    // check if we should list on a different port
+    MetricsHealthRegistration.Companion.registerMetrics(config);
 
     new JerseyHttp2Server().start(config);
 

--- a/backend/mr/src/main/java/io/featurehub/Application.java
+++ b/backend/mr/src/main/java/io/featurehub/Application.java
@@ -1,23 +1,18 @@
 package io.featurehub;
 
 import cd.connect.jersey.JerseyHttp2Server;
-import cd.connect.jersey.common.HealthResource;
-import cd.connect.jersey.common.InfrastructureConfiguration;
-import cd.connect.jersey.common.JerseyPrometheusResource;
 import cd.connect.jersey.common.LoggingConfiguration;
 import cd.connect.jersey.common.TracingConfiguration;
-import cd.connect.jersey.prometheus.PrometheusDynamicFeature;
 import cd.connect.lifecycle.ApplicationLifecycleManager;
 import cd.connect.lifecycle.LifecycleStatus;
 import cd.connect.openapi.support.ReturnStatusContainerResponseFilter;
-import io.featurehub.health.HealthFeature;
+import io.featurehub.health.MetricsHealthRegistration;
 import io.featurehub.jersey.config.CommonConfiguration;
 import io.featurehub.jersey.config.EndpointLoggingListener;
 import io.featurehub.mr.ManagementRepositoryFeature;
 import io.featurehub.mr.resources.oauth2.OAuth2Feature;
 import io.featurehub.mr.utils.NginxUtils;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
-import io.prometheus.client.hotspot.DefaultExports;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +34,6 @@ public class Application {
   }
 
   private void run() throws Exception {
-
-    // turn on all jvm prometheus metrics
-    DefaultExports.initialize();
-
     // register our resources, try and tag them as singleton as they are instantiated faster
     ResourceConfig config = new ResourceConfig(
       ClientTracingFeature.class,
@@ -53,8 +44,9 @@ public class Application {
       )
       .register(EndpointLoggingListener.class)
       .register(ManagementRepositoryFeature.class)
-      .register(HealthFeature.class)
       .register(OAuth2Feature.class);
+
+    MetricsHealthRegistration.Companion.registerMetrics(config);
 
     new JerseyHttp2Server().start(config);
 

--- a/backend/mr/src/main/java/io/featurehub/mr/ManagementRepositoryFeature.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/ManagementRepositoryFeature.java
@@ -88,9 +88,8 @@ public class ManagementRepositoryFeature implements Feature {
       CorsFilter.class,
 //      ConstraintExceptionHandler.class,
       AuthApplicationEventListener.class,
-      JerseyPrometheusResource.class,
       PrometheusDynamicFeature.class
-      ).forEach(o -> context.register(o));
+      ).forEach(context::register);
 
     context.register(new DatabaseBinder());
     context.register(new ApiToSqlApiBinder());

--- a/backend/party-server/src/main/java/io/featurehub/party/Application.java
+++ b/backend/party-server/src/main/java/io/featurehub/party/Application.java
@@ -2,7 +2,6 @@ package io.featurehub.party;
 
 import cd.connect.jersey.JerseyHttp2Server;
 import cd.connect.jersey.common.CorsFilter;
-import cd.connect.jersey.common.InfrastructureConfiguration;
 import cd.connect.jersey.common.LoggingConfiguration;
 import cd.connect.jersey.common.TracingConfiguration;
 import cd.connect.lifecycle.ApplicationLifecycleManager;
@@ -10,15 +9,14 @@ import cd.connect.lifecycle.LifecycleStatus;
 import cd.connect.openapi.support.ReturnStatusContainerResponseFilter;
 import io.featurehub.dacha.CacheManager;
 import io.featurehub.edge.EdgeFeature;
-import io.featurehub.health.HealthFeature;
 import io.featurehub.health.HealthSource;
+import io.featurehub.health.MetricsHealthRegistration;
 import io.featurehub.jersey.config.CommonConfiguration;
 import io.featurehub.jersey.config.EndpointLoggingListener;
 import io.featurehub.mr.ManagementRepositoryFeature;
 import io.featurehub.mr.utils.NginxUtils;
 import io.featurehub.publish.NATSHealthSource;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
-import io.prometheus.client.hotspot.DefaultExports;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
@@ -42,10 +40,6 @@ public class Application {
 
 
   private void run() throws Exception {
-
-    // turn on all jvm prometheus metrics
-    DefaultExports.initialize();
-
     // start the dacha layer, it is a health source
     CacheManager dachaCacheManager = io.featurehub.dacha.Application.initializeDacha();
 
@@ -56,8 +50,7 @@ public class Application {
       LoggingConfiguration.class,
       TracingConfiguration.class,
       ReturnStatusContainerResponseFilter.class,
-      EndpointLoggingListener.class,
-      HealthFeature.class)
+      EndpointLoggingListener.class)
       .register(new AbstractBinder() {
         @Override
         protected void configure() {
@@ -68,6 +61,9 @@ public class Application {
       .register(CorsFilter.class)
       .register(ManagementRepositoryFeature.class)
       .register(EdgeFeature.class);
+
+    // check if we should list on a different port
+    MetricsHealthRegistration.Companion.registerMetrics(config);
 
     new JerseyHttp2Server().start(config);
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -140,6 +140,20 @@ don't go stale.
 
 The party server honours all values set by the Management Repository, Dacha and the the SSE-Edge.
 
+==== Common to all servers 
+
+All servers expose metrics and health checks. The metrics are for Prometheus and are on `/metrics`,
+liveness is on `/health/liveness` and readyness on `/health/readyness`. Each different server has a collection
+of what things are important to indicate aliveness. The `server.port` setting will expose these endpoints,
+which means they are available to all of your normal API endpoints as well. In a cloud-native environment,
+which FeatureHub is aimed at, this is rarely what you want. So FeatureHub has the ability to list these
+endpoints on a different port.
+
+- `monitor.port` (undefined) - if not defined, it will expose the metrics and health on the server port. 
+If not, it will expose them on this port (and not on the server port).
+
+All servers expose quite extensive metrics for Prometheus.
+
 ==== Common to Party, SSE Edge and Management Repository
 
 - `server.port` (8903) - the server port that the server runs on. it always listens to 0.0.0.0 (all network interfaces)


### PR DESCRIPTION
Adds documentation and the functionality to expose all servers
on an alternative port for monitoring.

Fixes #399 