### PR TITLE
[typescript-client-sdk] Ensure if person passes url with /features it strips it correctly

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/README.md
+++ b/sdks/typescript/featurehub-javascript-client-sdk/README.md
@@ -18,6 +18,8 @@ We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com
 ## Changelog
 
 ### featurehub-javascript-client-sdk
+#### 1.0.3
+- Bugfix: Edge server urls passed to the config that include '/feature' should be processed correctly
 #### 1.0.2
 - Documentation updates
 #### 1.0.1

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/edge_featurehub_config.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/edge_featurehub_config.ts
@@ -39,7 +39,7 @@ export class EdgeFeatureHubConfig implements FeatureHubConfig {
     }
 
     if (this._host.endsWith('/features/')) {
-      this._host = this._host.substring(0, this._host.length - '/features/'.length);
+      this._host = this._host.substring(0, this._host.length - ('/features/'.length-1));
     }
 
     this._url = this._host + 'features/' + this._apiKey;

--- a/sdks/typescript/featurehub-javascript-client-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
   "author": "info@featurehub.io",
   "main": "dist/index.js",

--- a/sdks/typescript/featurehub-javascript-client-sdk/test/feature_hub_config_spec.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/test/feature_hub_config_spec.ts
@@ -6,7 +6,14 @@ describe('We can initialize the config', () => {
 
   it('should construct urls properly', () => {
     const fc = new EdgeFeatureHubConfig('http://localhost:8080', '123*345');
+    expect(fc.getHost()).to.eq('http://localhost:8080/');
     expect(fc.url()).to.eq('http://localhost:8080/features/123*345');
+  });
+
+  it('should strip off /feature/ if a user provided it', () => {
+    const fc = new EdgeFeatureHubConfig('https://feature.featurehub.io/features/', '123*345');
+    expect(fc.getHost()).to.eq('https://feature.featurehub.io/');
+    expect(fc.url()).to.eq('https://feature.featurehub.io/features/123*345');
   });
 
   it('should allow me to specify a config and initialise the config', () => {


### PR DESCRIPTION
# Description

When a url is provided with /features or /features/ at the end, the
SDK is supposed to strip it off and add it in its own format,
holding onto the base url for use in GET and PUT updates for the
test API. This was incorrectly formatting, so this adds a test
to ensure it is correct and fixes #411

