### PR TITLE
Ensure the Release Number is baked into apps

### DIFF
--- a/admin-frontend/app_singleapp/lib/version.dart
+++ b/admin-frontend/app_singleapp/lib/version.dart
@@ -1,0 +1,5 @@
+// DO NOT MOVE THIS FILE. this gets replaced by the build process.
+// You can change the version but do not add variables as the build.sh only
+// adds the appVersion and wipes the rest.
+
+final appVersion = '1.1.1';

--- a/admin-frontend/app_singleapp/lib/widgets/common/fh_appbar.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/common/fh_appbar.dart
@@ -1,7 +1,9 @@
 import 'package:app_singleapp/api/client_api.dart';
+import 'package:app_singleapp/version.dart';
 import 'package:app_singleapp/widgets/dynamic-theme/fh_dynamic_theme.dart';
 import 'package:app_singleapp/widgets/stepper/stepper_container.dart';
 import 'package:bloc_provider/bloc_provider.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:mrapi/api.dart';
@@ -37,6 +39,7 @@ class FHappBar extends StatelessWidget {
       ),
       titleSpacing: 0.0,
       title: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           SizedBox(
             height: kToolbarHeight - 20,
@@ -46,14 +49,19 @@ class FHappBar extends StatelessWidget {
                     'assets/logo/FeatureHub-icon.png',
                   ),
           ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Text(
+              ' (v$appVersion)',
+              style: TextStyle(fontSize: 10.0),
+            ),
+          )
         ],
       ),
       actions: <Widget>[
         StreamBuilder<Person>(
             stream: mrBloc.personStream,
             builder: (BuildContext context, AsyncSnapshot<Person> snapshot) {
-//            if (snapshot.hasData &&
-//                snapshot.data == InitializedCheckState.logged_in) {
               if (snapshot.hasData && mrBloc.isLoggedIn) {
                 final person = snapshot.data!;
                 var light = Theme.of(context).brightness == Brightness.light;

--- a/admin-frontend/app_singleapp/lib/widgets/features/custom_strategy_bloc.dart
+++ b/admin-frontend/app_singleapp/lib/widgets/features/custom_strategy_bloc.dart
@@ -44,9 +44,7 @@ class CustomStrategyBloc extends Bloc {
   }
 
   void addStrategy(RolloutStrategy rs) {
-    if (rs.id == null) {
-      rs.id = _strategyBlocUUidGenerator.v4();
-    }
+    rs.id ??= _strategyBlocUUidGenerator.v4();
     final strategies = _strategySource.value!;
     strategies.add(rs);
     markDirty();

--- a/admin-frontend/build-frontend.sh
+++ b/admin-frontend/build-frontend.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+if [ "$1" = "" ]; then
+  echo Must specify a build version as first parameter
+  exit -1
+fi
+rm -rf target/build_web
+mkdir -p target/build_web
+cp build/build.sh target
+cd target
 #docker run -it -v $PWD/app_singleapp:/opt/app/app -v $PWD/app_mr_layer:/opt/app/app_mr_layer -v $PWD/build:/opt/build featurehub/flutter_web:1.1 /bin/sh /opt/build/build.sh
-docker run -v $PWD/app_singleapp:/opt/app/app -v $PWD/app_mr_layer:/opt/app/app_mr_layer -v $PWD/build:/opt/build featurehub/flutter_web:1.3 /bin/sh /opt/build/build.sh
+docker run --rm -e BUILD_VERSION="$1" -v $PWD:/opt/app featurehub/flutter_web:1.3 /bin/sh /opt/app/build.sh
 

--- a/admin-frontend/build/build.sh
+++ b/admin-frontend/build/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-cd /opt/app/app
+cd /opt/app
+tar xf *.tar
 echo flutter home is $FLUTTER
 #echo "1.21.0-8.0.pre.110" > $FLUTTER_ROOT/version
 #ls -la $FLUTTER
@@ -7,21 +8,25 @@ VERSION=`cat $FLUTTER/version`
 DVERSION=`cat $FLUTTER/bin/cache/dart-sdk/version`
 echo Flutter version is $VERSION dart version is $DVERSION
 echo FLUTTER: Cleaning up after last build
-rm -rf build
-flutter clean
-flutter pub get
+
+cd app_mr_layer && flutter pub get
+echo "Flutter App will be version: ${BUILD_VERSION}"
+cd ../app_singleapp && echo "final appVersion = '${BUILD_VERSION}';" > lib/version.dart && flutter clean && flutter pub get
+
 echo FLUTTER: building deploy_main
 #flutter analyze
-if test "$?" != "0"; then
-  echo "failed"
-  exit 1
-fi
+#if test "$?" != "0"; then
+#  echo "failed"
+#  exit 1
+#fi
 flutter build web --target=lib/deploy_main.dart
 cd build/web
 MAIN_DATE=`date +"%s"`
 MAIN="main.dart-$MAIN_DATE.js"
 sed -i s/main.dart.js/$MAIN/ index.html
 mv main.dart.js $MAIN
-mv main.dart.js.map $MAIN.map
+if test -f "main.dart.js.map"; then
+  mv main.dart.js.map $MAIN.map
+fi
 echo FLUTTER: finished building, cleaning
 exit 0

--- a/admin-frontend/pom.xml
+++ b/admin-frontend/pom.xml
@@ -52,13 +52,16 @@
         <groupId>org.codehaus.mojo</groupId>
         <executions>
           <execution>
-            <id>generate-sources</id>
-            <phase>generate-sources</phase>
+            <id>generate-app</id>
+            <phase>compile</phase>
             <goals>
               <goal>exec</goal>
             </goals>
             <configuration>
               <executable>${project.basedir}/build-frontend.sh</executable>
+              <arguments>
+                <argument>${build.version}</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>
@@ -68,7 +71,21 @@
         <version>2.6</version>
         <executions>
           <execution>
-            <id>make-admin-ui</id>
+            <id>package-admin-ui</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>${project.basedir}/src/main/resources/pre-build-assembly.xml</descriptor>
+              </descriptors>
+              <attach>false</attach>
+            </configuration>
+          </execution>
+          <execution>
+            <id>post-build-admin-ui</id>
             <goals>
               <goal>single</goal>
             </goals>
@@ -76,7 +93,7 @@
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptors>
-                <descriptor>${project.basedir}/assembly.xml</descriptor>
+                <descriptor>${project.basedir}/src/main/resources/post-build-assembly.xml</descriptor>
               </descriptors>
               <attach>true</attach>
               <classifier>admin-ui</classifier>

--- a/admin-frontend/src/main/resources/post-build-assembly.xml
+++ b/admin-frontend/src/main/resources/post-build-assembly.xml
@@ -7,7 +7,7 @@
 
   <fileSets>
     <fileSet>
-      <directory>app_singleapp/build/web</directory>
+      <directory>target/app_singleapp/build/web</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/admin-frontend/src/main/resources/pre-build-assembly.xml
+++ b/admin-frontend/src/main/resources/pre-build-assembly.xml
@@ -1,0 +1,18 @@
+<assembly>
+  <id>admin-ui-to-build</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>tar</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>app_singleapp</directory>
+      <outputDirectory>app_singleapp</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>app_mr_layer</directory>
+      <outputDirectory>app_mr_layer</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/backend/common-web/src/main/kotlin/io/featurehub/info/InfoSource.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/info/InfoSource.kt
@@ -1,0 +1,41 @@
+package io.featurehub.info
+
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.Manifest
+
+class InfoSource {
+  companion object {
+    val cachedInfo = ConcurrentHashMap<String, String>()
+  }
+
+  private fun getInfoVal(key: String): String? {
+    var info = cachedInfo.get(key)
+
+    if (info == null) {
+      val resources = this.javaClass.classLoader.getResources("META-INF/MANIFEST.MF")
+
+      while (resources.hasMoreElements()) {
+        try {
+          val manifest = Manifest(resources.nextElement().openStream());
+          val attr = manifest.mainAttributes.getValue(key)
+          if (attr != null) {
+            info = attr.toString()
+            cachedInfo[key] = info
+          }
+        } catch (ignored: IOException) {
+        }
+      }
+    }
+
+    return info
+  }
+
+  fun appVersion() : String {
+    return getInfoVal("FeatureHub-Version") ?: "<UnknownVersion>"
+  }
+
+  fun appName() : String {
+    return getInfoVal("FeatureHub-AppName") ?: "<UnknownApp>"
+  }
+}

--- a/backend/common-web/src/test/groovy/io/featurehub/info/InfoSourceSpec.groovy
+++ b/backend/common-web/src/test/groovy/io/featurehub/info/InfoSourceSpec.groovy
@@ -1,0 +1,19 @@
+package io.featurehub.info
+
+import spock.lang.Specification
+
+class InfoSourceSpec extends Specification {
+  def "the application name is found"() {
+    when: "i ask for the app name"
+      def name = new InfoSource().appName()
+    then:
+      name == 'Sausage'
+  }
+
+  def "the application version is found"() {
+    when: "i ask for the app version"
+      def name = new InfoSource().appVersion()
+    then:
+      name == '1.3.7-RC'
+  }
+}

--- a/backend/common-web/src/test/resources/META-INF/MANIFEST.MF
+++ b/backend/common-web/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+FeatureHub-AppName: Sausage
+FeatureHub-Version: 1.3.7-RC

--- a/backend/tile-java/tile.xml
+++ b/backend/tile-java/tile.xml
@@ -27,6 +27,18 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <FeatureHub-AppName>${project.artifactId}</FeatureHub-AppName>
+              <FeatureHUb-Version>${build.version}</FeatureHUb-Version>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <version>1.5.0</version>


### PR DESCRIPTION
# Description

Changes the way the front end artifact is built so it is more friendly for ongoing development and isolated from "bad" changes. Exposes the version number from the Docker build to the front end and to the core application stack.

Fixes #380

