### PR TITLE
Service name length too short for archiving

### DIFF
--- a/backend/mr-api/common.yaml
+++ b/backend/mr-api/common.yaml
@@ -341,7 +341,7 @@ components:
         name:
           type: string
           minLength: 1
-          maxLength: 40
+          maxLength: 70
         portfolioId:
           type: string
           format: uuid

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.6.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.6.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_service_account alter column name varchar(100);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/model/1.6.model.xml
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/model/1.6.model.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<migration xmlns="http://ebean-orm.github.io/xml/ns/dbmigration">
+    <changeSet type="apply">
+        <alterColumn columnName="name" tableName="fh_service_account" type="varchar(100)" currentType="varchar(40)" currentNotnull="false"/>
+    </changeSet>
+</migration>

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mssql/1.6.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mssql/1.6.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_service_account alter column name nvarchar(100);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.6.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.6.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_service_account modify name varchar(100);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.6.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.6.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_service_account alter column name type varchar(100) using name::varchar(100);

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/model/DbServiceAccount.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/model/DbServiceAccount.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 public class DbServiceAccount {
   @Id
   private UUID id;
-  @Column(length = 40)
+  @Column(length = 100)
   private String name;
   @Column(length = 400)
   private String description;


### PR DESCRIPTION
Because the length of a service name was only
allowed to be 40 chars, when archiving added
the current timestamp this dropped to under 20.

This increases it to 100, with an API change
to allow for 70, giving the timestamp breather
space.

Fixes #448

