### PR TITLE
Lock only perms not resolved correctly

### DIFF
--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/PersonFeaturePermission.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/PersonFeaturePermission.java
@@ -4,6 +4,7 @@ import io.featurehub.mr.model.ApplicationRoleType;
 import io.featurehub.mr.model.Person;
 import io.featurehub.mr.model.RoleType;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,8 +60,8 @@ public class PersonFeaturePermission {
 
   public static final class Builder {
     private Person person;
-    private Set<RoleType> roles;
-    private Set<ApplicationRoleType> appRoles;
+    private Set<RoleType> roles = Collections.emptySet();
+    private Set<ApplicationRoleType> appRoles = Collections.emptySet();
 
     public Builder() {
     }

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
@@ -101,7 +101,7 @@ public class FeatureSqlApi implements FeatureApi, FeatureUpdateBySDKApi {
     if (dbFeatureValue != null) {
       // this is an update not a create, environment + app-feature key exists
       return onlyUpdateFeatureValueForEnvironment(featureValue, person, dbFeatureValue);
-    } else if (person.hasChangeValueRole() || person.hasLockRole()) {
+    } else if (person.hasChangeValueRole() || person.hasLockRole() || person.hasUnlockRole()) {
       return onlyCreateFeatureValueForEnvironment(eId, key, featureValue, person);
     } else {
       log.info("roles for person are {} and are not enough for environment {} and key {}", person.toString(), eId, key);

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/FeatureSqlApi.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -101,7 +101,7 @@ public class FeatureSqlApi implements FeatureApi, FeatureUpdateBySDKApi {
     if (dbFeatureValue != null) {
       // this is an update not a create, environment + app-feature key exists
       return onlyUpdateFeatureValueForEnvironment(featureValue, person, dbFeatureValue);
-    } else if (person.hasChangeValueRole()) {
+    } else if (person.hasChangeValueRole() || person.hasLockRole()) {
       return onlyCreateFeatureValueForEnvironment(eId, key, featureValue, person);
     } else {
       log.info("roles for person are {} and are not enough for environment {} and key {}", person.toString(), eId, key);


### PR DESCRIPTION
# Description

the specific use case is where the feature
value does not exist and you have
lock/unlock role but not “set”. So you
are essentially creating the feature
value for the first time.

