### PR TITLE
Update generator to latest Jersey OpenAPI generator

### DIFF
--- a/admin-frontend/app_mr_layer/pom.xml
+++ b/admin-frontend/app_mr_layer/pom.xml
@@ -118,7 +118,7 @@
           <dependency>
             <groupId>com.bluetrainsoftware.maven</groupId>
             <artifactId>openapi-dart-generator</artifactId>
-            <version>5.5</version>
+            <version>5.9</version>
           </dependency>
         </dependencies>
         <executions>

--- a/admin-frontend/app_mr_layer/pubspec.yaml
+++ b/admin-frontend/app_mr_layer/pubspec.yaml
@@ -12,4 +12,5 @@ dependencies:
   collection: '^1.15.0'
 dev_dependencies:
   test: ^1.3.0
+  analyzer: ^0.40.7
 # bought to you by the folks from FeatureHub https://featurehub.io

--- a/backend/dacha-api/pom.xml
+++ b/backend/dacha-api/pom.xml
@@ -82,7 +82,7 @@
           <dependency>
             <groupId>cd.connect.openapi</groupId>
             <artifactId>connect-openapi-jersey3</artifactId>
-            <version>7.1</version>
+            <version>7.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/backend/mr-api-java-server/pom.xml
+++ b/backend/mr-api-java-server/pom.xml
@@ -91,7 +91,7 @@
           <dependency>
             <groupId>cd.connect.openapi</groupId>
             <artifactId>connect-openapi-jersey3</artifactId>
-            <version>7.1</version>
+            <version>7.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/backend/mr-streaming-api/pom.xml
+++ b/backend/mr-streaming-api/pom.xml
@@ -54,7 +54,7 @@
           <dependency>
             <groupId>cd.connect.openapi</groupId>
             <artifactId>connect-openapi-jersey3</artifactId>
-            <version>7.1</version>
+            <version>7.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/backend/sse-edge-api/pom.xml
+++ b/backend/sse-edge-api/pom.xml
@@ -96,7 +96,7 @@
           <dependency>
             <groupId>cd.connect.openapi</groupId>
             <artifactId>connect-openapi-jersey3</artifactId>
-            <version>7.1</version>
+            <version>7.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/backend/sse-edge-stats-api/pom.xml
+++ b/backend/sse-edge-stats-api/pom.xml
@@ -72,7 +72,7 @@
           <dependency>
             <groupId>cd.connect.openapi</groupId>
             <artifactId>connect-openapi-jersey3</artifactId>
-            <version>7.1</version>
+            <version>7.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/e2e/lib/user_common.dart
+++ b/e2e/lib/user_common.dart
@@ -82,12 +82,7 @@ class UserCommon {
     clearAuth();
 
     var uriParse = Uri.parse(registrationUrl);
-    String token = uriParse.fragment;
-    token = token
-        .substring(token.indexOf('?') + 1)
-        .split("&")
-        .firstWhere((frag) => frag.startsWith("token="), orElse: () => 'token=')
-        .substring('token='.length);
+    String token = uriParse.queryParameters['token'] ?? '';
 
     assert(token.isNotEmpty, 'token is empty or null $token');
 


### PR DESCRIPTION
# Description

Update to 7.4 and fix the registration token url issue for the e2e tests.