### PR TITLE
Resolve issue around not correctly caching Edge connection

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/README.md
+++ b/sdks/typescript/featurehub-javascript-client-sdk/README.md
@@ -16,9 +16,9 @@ We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com
 
 ### featurehub-javascript-client-sdk
 #### 1.0.6
-- Fix to the SSE client where it can create an excess of connections to the server.
+- Fix to the SSE client to prevent excess of connections to the server.
 #### 1.0.5
-- Fix an issue with the polling client. We _strongly_ recommend people upgrade to this version if using the Polling client.  
+- Fix an issue with the polling client  
 #### 1.0.4
 - Documentation updates
 #### 1.0.3
@@ -32,8 +32,10 @@ We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com
 Angular & Vue to use this library. 
 
 ### featurehub-javascript-node-sdk
+#### 1.0.6
+- Fix to the SSE client to prevent excess of connections to the server.
 #### 1.0.5
-- Tracking the changes in the javascript-client-sdk
+- Fix an issue with the polling client
 #### 1.0.4
 - Documentation updates
 #### 1.0.3

--- a/sdks/typescript/featurehub-javascript-client-sdk/README.md
+++ b/sdks/typescript/featurehub-javascript-client-sdk/README.md
@@ -6,18 +6,17 @@ Welcome to the Javascript/Typescript SDK implementation for [FeatureHub.io](http
 This documentation covers both [featurehub-javascript-node-sdk](https://www.npmjs.com/featurehub-javascript-node-sdk) and [featurehub-javascript-client-sdk](https://www.npmjs.com/featurehub-javascript-client-sdk) and explains how you can use the FeatureHub SDK in Javascript or Typescript for applications like Node.js
 backend server, Web front-end (e.g. React) or Mobile apps (React Native, Ionic, etc.). 
 
-
 To control the feature flags from the FeatureHub Admin console, either use our [demo](https://demo.featurehub.io) version for evaluation or install the app using our guide [here](http://docs.featurehub.io/#_installation)
-
 
 ### **Important Note**
 
 We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com/package/featurehub-eventsource-sdk) which covers both client (browser) and server (node) applications in favor of splitting it into two separate NPM modules to enable support for additional browser frameworks like Angular and Vue. To transition to one of the new NPM modules, follow installation instructions below and change the imports in your code. The FeatureHub SDK API hasn't changed so you don't have to reimplement your SDK code.
 
-
 ## Changelog
 
 ### featurehub-javascript-client-sdk
+#### 1.0.6
+- Fix to the SSE client where it can create an excess of connections to the server.
 #### 1.0.5
 - Fix an issue with the polling client. We _strongly_ recommend people upgrade to this version if using the Polling client.  
 #### 1.0.4

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/edge_featurehub_config.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/edge_featurehub_config.ts
@@ -83,12 +83,20 @@ export class EdgeFeatureHubConfig implements FeatureHubConfig {
     edgeService = edgeService || this.edgeServiceProvider();
 
     return this._clientEval ?
-      new ClientEvalFeatureContext(repository, this, edgeService(this._repository, this)) :
-      new ServerEvalFeatureContext(repository, this, () => this._createEdgeService(edgeService));
+      new ClientEvalFeatureContext(repository, this, this._getOrCreateEdgeService(edgeService, repository)) :
+      new ServerEvalFeatureContext(repository, this, () => this._createEdgeService(edgeService, repository));
   }
 
-  _createEdgeService(edgeServSupplier: EdgeServiceProvider): EdgeService {
-    const es = edgeServSupplier(this._repository, this);
+  _getOrCreateEdgeService(edgeServSupplier: EdgeServiceProvider, repository?: InternalFeatureRepository): EdgeService {
+    if (this._edgeServices.length === 0) {
+      return this._createEdgeService(edgeServSupplier, repository);
+    }
+
+    return this._edgeServices[0];
+  }
+
+  _createEdgeService(edgeServSupplier: EdgeServiceProvider, repository?: InternalFeatureRepository): EdgeService {
+    const es = edgeServSupplier(repository || this.repository(), this);
     this._edgeServices.push(es);
     return es;
   }

--- a/sdks/typescript/featurehub-javascript-client-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
   "author": "info@featurehub.io",
   "main": "dist/index.js",

--- a/sdks/typescript/featurehub-javascript-client-sdk/test/feature_hub_config_spec.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/test/feature_hub_config_spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { EdgeFeatureHubConfig, EdgeService } from '../app';
+import { EdgeFeatureHubConfig, EdgeService, InternalFeatureRepository } from '../app';
 import { Substitute, } from '@fluffy-spoon/substitute';
 
 describe('We can initialize the config', () => {
@@ -41,6 +41,42 @@ describe('We can initialize the config', () => {
     // tslint:disable-next-line:no-unused-expression
     expect(repo).to.not.be.null;
     expect(fc.repository()).to.eq(repo);
+  });
+
+  it('should only create a default edge service implementation once no matter how many contexts are made', () => {
+    const edge = Substitute.for<EdgeService>();
+    let counter = 0;
+    const edgeProvider = (repo1, config) => {
+      counter ++;
+      return edge;
+    };
+    EdgeFeatureHubConfig.defaultEdgeServiceSupplier = edgeProvider;
+
+    const fc = new EdgeFeatureHubConfig('http://localhost:8080', '123*345');
+    fc.repository(Substitute.for<InternalFeatureRepository>());
+    fc.newContext();
+    fc.newContext();
+    fc.newContext();
+    fc.newContext();
+    expect(counter).to.eq(1);
+  });
+
+  it ('should create edge services with the repository i provide in a new context', () => {
+    const edge = Substitute.for<EdgeService>();
+    const repo = Substitute.for<InternalFeatureRepository>();
+    const repos = [];
+    const edgeProvider = (repo1, config) => {
+      repos.push(repo1);
+      return edge;
+    };
+    EdgeFeatureHubConfig.defaultEdgeServiceSupplier = edgeProvider;
+    const fc = new EdgeFeatureHubConfig('http://localhost:8080', '123*345');
+    fc.newContext(repo);
+    fc.newContext(repo);
+    fc.newContext(repo);
+    fc.newContext(repo);
+    expect(repos.length).to.eq(1);
+    expect(repos[0]).to.eq(repo);
   });
 
   it('should allow for the creation of a new context which on building should poll the edge repo', async () => {

--- a/sdks/typescript/featurehub-javascript-node-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-node-sdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "featurehub sdk intended for use by nodejs.",
   "author": "info@featurehub.io",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "coverage": "nyc npm run test",
     "test:watch": "npm run mocha --opts mocha.opts --watch",
     "tsc": "node ./node_modules/typescript/bin/tsc -p",
-    "link": "npm link featurehub-repository && npm link featurehub-eventsource-sdk",
+    "link": "npm link featurehub-javascript-client-sdk",
     "compile": "npm run build && npm link",
     "release": "rm README.md && cp ../featurehub-javascript-client-sdk/README.md . && npm run build && npm publish",
     "prepublishOnly": "npm run build",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "eventsource": "^1.1.0",
-    "featurehub-javascript-client-sdk": "^1.0.5"
+    "featurehub-javascript-client-sdk": "^1.0.6"
   },
   "engines": {
     "node": ">=12.12.0"


### PR DESCRIPTION
The SSE client with recent changes was not correctly caching
the open connection and reusing it.

Fixes #488 
