### PR TITLE
Enable support for Immediate Scope

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/health/CommonFeatureHubFeatures.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/CommonFeatureHubFeatures.kt
@@ -4,11 +4,20 @@ import cd.connect.jersey.common.LoggingConfiguration
 import cd.connect.jersey.prometheus.PrometheusDynamicFeature
 import cd.connect.openapi.support.ReturnStatusContainerResponseFilter
 import io.featurehub.jersey.config.CommonConfiguration
+import jakarta.inject.Inject
 import org.glassfish.jersey.server.ServerProperties
 import jakarta.ws.rs.core.Feature
 import jakarta.ws.rs.core.FeatureContext
+import org.glassfish.hk2.api.ServiceLocator
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities
 
-class CommonFeatureHubFeatures : Feature {
+class CommonFeatureHubFeatures @Inject constructor(locator: ServiceLocator) : Feature {
+
+  // ensure Immediate scope which is HK2 specific is enabled everywhere
+  init {
+    ServiceLocatorUtilities.enableImmediateScope(locator)
+  }
+
   override fun configure(context: FeatureContext): Boolean {
     context.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true)
 


### PR DESCRIPTION
This allows support for the Immediate Scope annotation in Jersey which allows preloading of injection resources.