### PR TITLE
Const on Stateful object prevents didUpdateWidgets

### DIFF
--- a/admin-frontend/open_admin_app/lib/routes/create_user_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/create_user_route.dart
@@ -52,7 +52,8 @@ class TopWidget extends StatelessWidget {
               snapshot.data == CreateUserForm.successState) {
             return const TopWidgetSuccess();
           }
-          return const TopWidgetDefault();
+          // ignore: prefer_const_constructors
+          return TopWidgetDefault();
         });
   }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/strategies/add_attribute_strategy_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/strategies/add_attribute_strategy_widget.dart
@@ -19,7 +19,8 @@ class EditAttributeStrategyWidget extends StatefulWidget {
   final bool attributeIsFirst;
   final IndividualStrategyBloc bloc;
 
-  const EditAttributeStrategyWidget({
+  // ignore: prefer_const_constructors, prefer_const_constructors_in_immutables
+  EditAttributeStrategyWidget({
     Key? key,
     required this.attribute,
     required this.attributeIsFirst,


### PR DESCRIPTION
# Description

This appears to be a bug in the underlying framework,
but it resolves the issue where putting a recommended
const (recommended by the linting framework) on an
underlying stateful object prevents it from issuing a
didUpdateWidgets.

Fixes #494
