### PR TITLE
Decreased javascript sdk size by replacing semver with semver-compare

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/app/strategy_matcher.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/strategy_matcher.ts
@@ -6,7 +6,7 @@ import {
 } from './models';
 
 
-import { eq, gt, gte, lt, lte } from 'semver';
+import compareSemver from 'semver-compare';
 // this library was node specific so required de-noding
 import { Addr, CIDR } from './ip6addr';
 // this library is not node specific
@@ -332,22 +332,22 @@ class SemanticVersionMatcher implements StrategyMatcher {
     switch (attr.conditional) {
       case RolloutStrategyAttributeConditional.Includes:
       case RolloutStrategyAttributeConditional.Equals:
-        return vals.findIndex((v) => eq(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) === 0) >= 0;
       case RolloutStrategyAttributeConditional.EndsWith:
         break;
       case RolloutStrategyAttributeConditional.StartsWith:
         break;
       case RolloutStrategyAttributeConditional.Greater:
-        return vals.findIndex((v) => gt(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) > 0) >= 0;
       case RolloutStrategyAttributeConditional.GreaterEquals:
-        return vals.findIndex((v) => gte(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) >= 0) >= 0;
       case RolloutStrategyAttributeConditional.Less:
-        return vals.findIndex((v) => lt(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) < 0) >= 0;
       case RolloutStrategyAttributeConditional.LessEquals:
-        return vals.findIndex((v) => lte(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) <= 0) >= 0;
       case RolloutStrategyAttributeConditional.NotEquals:
       case RolloutStrategyAttributeConditional.Excludes:
-        return vals.findIndex((v) => !eq(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) !== 0) >= 0;
       case RolloutStrategyAttributeConditional.Regex:
         break;
     }

--- a/sdks/typescript/featurehub-javascript-client-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-client-sdk/package.json
@@ -61,9 +61,8 @@
   },
   "dependencies": {
     "@types/murmurhash": "^2.0.0",
-    "@types/semver": "^7.3.5",
     "murmurhash": "^2.0.0",
-    "semver": "^7.3.5"
+    "semver-compare": "^1.0.0"
   },
   "engines": {
     "node": ">=12.12.0"

--- a/sdks/typescript/featurehub-repository/app/strategy_matcher.ts
+++ b/sdks/typescript/featurehub-repository/app/strategy_matcher.ts
@@ -5,7 +5,7 @@ import {
   RolloutStrategyFieldType
 } from './models/models';
 
-import { eq, gt, gte, lt, lte } from 'semver';
+import compareSemver from 'semver-compare';
 import { Addr, CIDR, createCIDR, parse as parseIp } from 'ip6addr';
 import { v3 as murmur3 } from 'murmurhash';
 import { ClientContext } from './client_context';
@@ -328,22 +328,22 @@ class SemanticVersionMatcher implements StrategyMatcher {
     switch (attr.conditional) {
       case RolloutStrategyAttributeConditional.Includes:
       case RolloutStrategyAttributeConditional.Equals:
-        return vals.findIndex((v) => eq(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) === 0) >= 0;
       case RolloutStrategyAttributeConditional.EndsWith:
         break;
       case RolloutStrategyAttributeConditional.StartsWith:
         break;
       case RolloutStrategyAttributeConditional.Greater:
-        return vals.findIndex((v) => gt(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) > 0) >= 0;
       case RolloutStrategyAttributeConditional.GreaterEquals:
-        return vals.findIndex((v) => gte(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) >= 0) >= 0;
       case RolloutStrategyAttributeConditional.Less:
-        return vals.findIndex((v) => lt(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) < 0) >= 0;
       case RolloutStrategyAttributeConditional.LessEquals:
-        return vals.findIndex((v) => lte(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) <= 0) >= 0;
       case RolloutStrategyAttributeConditional.NotEquals:
       case RolloutStrategyAttributeConditional.Excludes:
-        return vals.findIndex((v) => !eq(suppliedValue, v)) >= 0;
+        return vals.findIndex((v) => compareSemver(suppliedValue, v) !== 0) >= 0;
       case RolloutStrategyAttributeConditional.Regex:
         break;
     }

--- a/sdks/typescript/featurehub-repository/package.json
+++ b/sdks/typescript/featurehub-repository/package.json
@@ -62,10 +62,9 @@
   "dependencies": {
     "@types/ip6addr": "^0.2.1",
     "@types/murmurhash": "^2.0.0",
-    "@types/semver": "^7.3.4",
     "ip6addr": "^0.2.3",
     "murmurhash": "^2.0.0",
-    "semver": "^7.3.4"
+    "semver-compare": "^1.0.0"
   },
   "engines": {
     "node": ">=12.12.0"


### PR DESCRIPTION
# Description
Semver is fairly big and currently represents ~25% of featurehub-javascript-client-sdk. This change replaces `semver` with `semver-compare` is which tiny (<1kb). This change helps adoption of size-sensitive environments such as while serving webpages.

Although `semver` provides a compreensive way of comparing versions, current code [1] makes use of compare functions which ends up as a `SemVer.compare()` call without any extra options such as `includePrerelease`, `loose` and `rtl` (listed here [2]). That being said, current usage relies on `compareIdentifier` [3] which can be safely replaced by `semver-compare`'s compare function [4].

[1] https://github.com/featurehub-io/featurehub/blob/d49780e14a2b6b6fdad8c561e45d5a07f1844b34/sdks/typescript/featurehub-javascript-client-sdk/app/strategy_matcher.ts#L9
[2] https://github.com/npm/node-semver/blob/e79ac3a450e8bb504e78b8159e3efc70895699b8/internal/parse-options.js#L3
[3] https://github.com/npm/node-semver/blob/e79ac3a450e8bb504e78b8159e3efc70895699b8/internal/identifiers.js#L2
[4] https://github.com/substack/semver-compare/blob/152c863e7c2615f9e9e81a9a370b672afaa3819a/index.js#L1-L13

Fixes #498

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Ran `npm run test`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
