### PR TITLE
Introduced LocalClientContext for static deployments.

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/app/context_impl.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/context_impl.ts
@@ -1,10 +1,17 @@
 import { InternalFeatureRepository } from './internal_feature_repository';
 import { EdgeServiceSupplier, fhLog } from './feature_hub_config';
-import { StrategyAttributeCountryName, StrategyAttributeDeviceName, StrategyAttributePlatformName } from './models';
+import {
+  Environment,
+  SSEResultState,
+  StrategyAttributeCountryName,
+  StrategyAttributeDeviceName,
+  StrategyAttributePlatformName,
+} from "./models";
 import { FeatureStateHolder } from './feature_state';
 import { EdgeService } from './edge_service';
 import { FeatureHubRepository } from './featurehub_repository';
 import { ClientContext } from './client_context';
+import { ClientFeatureRepository } from './client_feature_repository';
 
 export abstract class BaseClientContext implements ClientContext {
   protected readonly _repository: InternalFeatureRepository;
@@ -210,4 +217,21 @@ export class ClientEvalFeatureContext extends BaseClientContext {
     return this._repository.feature(name).withContext(this);
   }
 
+}
+
+export class LocalClientContext extends BaseClientContext {
+  constructor(environment: Environment) {
+    super(new ClientFeatureRepository());
+    this._repository.notify(SSEResultState.Features, environment.features);
+  }
+
+  async build(): Promise<ClientContext> {
+    return this;
+  }
+
+  feature(name: string): FeatureStateHolder {
+    return this._repository.feature(name).withContext(this);
+  }
+
+  close() {}
 }

--- a/sdks/typescript/featurehub-javascript-client-sdk/test/client_context_spec.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/test/client_context_spec.ts
@@ -1,11 +1,16 @@
 import {
-  EdgeService, FeatureHubConfig,
+  EdgeService,
+  Environment,
+  FeatureState,
+  FeatureValueType,
+  LocalClientContext,
   StrategyAttributeCountryName,
   StrategyAttributeDeviceName,
   StrategyAttributePlatformName
 } from '../app';
 import { Substitute, Arg, SubstituteOf } from '@fluffy-spoon/substitute';
 import { ClientEvalFeatureContext, ServerEvalFeatureContext, InternalFeatureRepository } from '../app';
+import { expect } from 'chai';
 
 describe('Client context should be able to encode as expected', () => {
   let repo: SubstituteOf<InternalFeatureRepository>;
@@ -60,5 +65,21 @@ describe('Client context should be able to encode as expected', () => {
       .sessionKey('VirtualBurningMan').build();
     repo.received(0).notReady();
     edge.received(0).contextChange(Arg.all());
+  });
+
+  it("the static client context should just work", async () => {
+    const environment = new Environment({
+      features: [
+        new FeatureState({
+          id: "1", key: "banana", version: 1, type: FeatureValueType.Boolean, value: true,
+        }),
+      ],
+    });
+    const context = await new LocalClientContext(environment)
+      .userKey("DJElif")
+      .sessionKey("VirtualBurningMan")
+      .build();
+
+    expect(context.getBoolean("banana")).to.eq(true);
   });
 });


### PR DESCRIPTION
# Description
The `LocalClientContext` allows passing an `Environment` object as the source for feature strategies. It decouples "serving" from "evaluation" which alows deployments can't use a Edge Service (e.g. due to amount of traffic). Such deployments should provide the Environment object using another strategy, such as serving a JSON file with a `Environment` object serialized.

Fixes #497

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Added and run unittests.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
