### PR TITLE
Improved Tree Shaking for LocalClientContext

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/app/context_impl.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/context_impl.ts
@@ -1,8 +1,6 @@
 import { InternalFeatureRepository } from './internal_feature_repository';
 import { EdgeServiceSupplier, fhLog } from './feature_hub_config';
 import {
-  Environment,
-  SSEResultState,
   StrategyAttributeCountryName,
   StrategyAttributeDeviceName,
   StrategyAttributePlatformName,
@@ -11,7 +9,6 @@ import { FeatureStateHolder } from './feature_state';
 import { EdgeService } from './edge_service';
 import { FeatureHubRepository } from './featurehub_repository';
 import { ClientContext } from './client_context';
-import { ClientFeatureRepository } from './client_feature_repository';
 
 export abstract class BaseClientContext implements ClientContext {
   protected readonly _repository: InternalFeatureRepository;
@@ -217,21 +214,4 @@ export class ClientEvalFeatureContext extends BaseClientContext {
     return this._repository.feature(name).withContext(this);
   }
 
-}
-
-export class LocalClientContext extends BaseClientContext {
-  constructor(environment: Environment) {
-    super(new ClientFeatureRepository());
-    this._repository.notify(SSEResultState.Features, environment.features);
-  }
-
-  async build(): Promise<ClientContext> {
-    return this;
-  }
-
-  feature(name: string): FeatureStateHolder {
-    return this._repository.feature(name).withContext(this);
-  }
-
-  close() {}
 }

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/featurehub_repository.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/featurehub_repository.ts
@@ -2,7 +2,7 @@ import { ClientContext } from './client_context';
 import { FeatureStateHolder } from './feature_state';
 import { FeatureStateValueInterceptor } from './interceptors';
 import { AnalyticsCollector } from './analytics';
-import { ClientFeatureRepository } from './client_feature_repository';
+import { InternalFeatureRepository } from './internal_feature_repository';
 
 export enum Readyness {
   NotReady = 'NotReady',
@@ -15,7 +15,7 @@ export interface ReadynessListener {
 }
 
 export interface PostLoadNewFeatureStateAvailableListener {
-  (repo: ClientFeatureRepository): void;
+  (repo: InternalFeatureRepository): void;
 }
 
 export interface FeatureHubRepository {

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/index.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/index.ts
@@ -16,3 +16,4 @@ export * from './featurehub_repository';
 export * from './edge_featurehub_config';
 export * from './models/models/model_serializer';
 export * from './featurehub_eventsource';
+export * from './local_context';

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/local_context.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/local_context.ts
@@ -1,0 +1,179 @@
+import { AnalyticsCollector } from "./analytics";
+import { ClientContext } from "./client_context";
+import { BaseClientContext } from "./context_impl";
+import { PostLoadNewFeatureStateAvailableListener, Readyness, ReadynessListener } from "./featurehub_repository";
+import { FeatureStateHolder } from "./feature_state";
+import { FeatureStateBaseHolder } from "./feature_state_holders";
+import { FeatureStateValueInterceptor, InterceptorValueMatch } from "./interceptors";
+import { InternalFeatureRepository } from "./internal_feature_repository";
+import { Environment, FeatureValueType, RolloutStrategy, SSEResultState } from "./models";
+import { Applied, ApplyFeature } from "./strategy_matcher";
+
+class LocalFeatureRepository implements InternalFeatureRepository {
+  // indexed by key as that what the user cares about
+  private features = new Map<string, FeatureStateBaseHolder>();
+  private analyticsCollectors = new Array<AnalyticsCollector>();
+  private _matchers: Array<FeatureStateValueInterceptor> = [];
+  private readonly _applyFeature: ApplyFeature;
+
+  constructor(environment: Environment, applyFeature?: ApplyFeature) {
+    this._applyFeature = applyFeature || new ApplyFeature();
+
+    environment.features.forEach((fs) => {
+      const holder = new FeatureStateBaseHolder(this, fs.key);
+      holder.setFeatureState(fs);
+      this.features.set(fs.key, holder);
+    });
+  }
+
+  public apply(strategies: Array<RolloutStrategy>, key: string, featureValueId: string,
+               context: ClientContext): Applied {
+    return this._applyFeature.apply(strategies, key, featureValueId, context);
+  }
+
+  public get readyness(): Readyness {
+    return Readyness.Ready;
+  }
+
+  public notify(state: SSEResultState, data: any): void {}
+
+  public addValueInterceptor(matcher: FeatureStateValueInterceptor) {
+    this._matchers.push(matcher);
+
+    matcher.repository(this);
+  }
+
+  public valueInterceptorMatched(key: string): InterceptorValueMatch {
+    for (let matcher of this._matchers) {
+      const m = matcher.matched(key);
+      if (m?.value) {
+        return m;
+      }
+    }
+
+    return null;
+  }
+
+  public addPostLoadNewFeatureStateAvailableListener(listener: PostLoadNewFeatureStateAvailableListener) {
+  }
+
+  public addReadynessListener(listener: ReadynessListener) {
+    listener(Readyness.Ready);
+  }
+
+  notReady(): void {
+  }
+
+  public async broadcastReadynessState() {
+  }
+
+  public addAnalyticCollector(collector: AnalyticsCollector): void {
+    this.analyticsCollectors.push(collector);
+  }
+
+  public simpleFeatures(): Map<string, string | undefined> {
+    const vals = new Map<string, string | undefined>();
+
+    this.features.forEach((value, key) => {
+      if (value.getKey()) { // only include value features
+        let val: any;
+        switch (value.getType()) {// we need to pick up any overrides
+          case FeatureValueType.Boolean:
+            val = value.getBoolean() ? 'true' : 'false';
+            break;
+          case FeatureValueType.String:
+            val = value.getString();
+            break;
+          case FeatureValueType.Number:
+            val = value.getNumber();
+            break;
+          case FeatureValueType.Json:
+            val = value.getRawJson();
+            break;
+          default:
+            val = undefined;
+        }
+        vals.set(key, val === undefined ? val : val.toString());
+      }
+    });
+
+    return vals;
+  }
+
+  public async logAnalyticsEvent(action: string, other?: Map<string, string>, ctx?: ClientContext) {
+    const featureStateAtCurrentTime = [];
+
+    for (let fs of this.features.values()) {
+      if (fs.isSet()) {
+        const fsVal: FeatureStateBaseHolder = ctx == null ? fs : fs.withContext(ctx) as FeatureStateBaseHolder;
+        featureStateAtCurrentTime.push( fsVal.analyticsCopy() );
+      }
+    }
+
+    this.analyticsCollectors.forEach((ac) => ac.logEvent(action, other, featureStateAtCurrentTime));
+  }
+
+  public hasFeature(key: string): FeatureStateHolder {
+    return this.features.get(key);
+  }
+
+  public feature(key: string): FeatureStateHolder {
+    let holder = this.features.get(key);
+
+    if (holder === undefined) {
+      holder = new FeatureStateBaseHolder(this, key);
+      this.features.set(key, holder);
+    }
+
+    return holder;
+  }
+
+  // deprecated
+  public getFeatureState(key: string): FeatureStateHolder {
+    return this.feature(key);
+  }
+
+  get catchAndReleaseMode(): boolean {
+    return false;
+  }
+
+  set catchAndReleaseMode(value: boolean) {}
+
+  public async release(disableCatchAndRelease?: boolean): Promise<void> {}
+
+  public getFlag(key: string): boolean | undefined {
+    return this.feature(key).getFlag();
+  }
+
+  public getString(key: string): string | undefined {
+    return this.feature(key).getString();
+  }
+
+  public getJson(key: string): string | undefined {
+    return this.feature(key).getRawJson();
+  }
+
+  public getNumber(key: string): number | undefined {
+    return this.feature(key).getNumber();
+  }
+
+  public isSet(key: string): boolean {
+    return this.feature(key).isSet();
+  }
+}
+
+export class LocalClientContext extends BaseClientContext {
+  constructor(environment: Environment) {
+    super(new LocalFeatureRepository(environment));
+  }
+
+  async build(): Promise<ClientContext> {
+    return this;
+  }
+
+  feature(name: string): FeatureStateHolder {
+    return this._repository.feature(name).withContext(this);
+  }
+
+  close() {}
+}

--- a/sdks/typescript/featurehub-javascript-client-sdk/test/local_context.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/test/local_context.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { Environment, FeatureState, FeatureValueType, LocalClientContext } from '../app';
+
+describe('Local context should be able to evaluate', () => {
+  it('the ', async () => {
+    const context = new LocalClientContext(new Environment({
+      features: [
+        new FeatureState({
+          id: '1',
+          key: 'banana',
+          version: 1,
+          type: FeatureValueType.Boolean,
+          value: true,
+        }),
+        new FeatureState({
+          id: '2',
+          key: 'organge',
+          version: 1,
+          type: FeatureValueType.Boolean,
+          value: false,
+        }),
+      ],
+    }));
+
+    expect(context.getBoolean('banana')).to.be.true;
+    expect(context.getBoolean('organge')).to.be.false;
+  });
+});


### PR DESCRIPTION
# Description
This change improves usage of `LocalClientContext` making it more lightweight. It no longer depends on `ClientFeatureRepository` which brings `FeatureStateTypeTransformer` which is quite large.

This change shines when webpack performs Tree Shaking and removes lots of unused code automatically.

Fixes #509

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Added unittests and manually verified it works with webpack.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
