### PR TITLE
minor changes to config to allow for sdks to be held externally

### DIFF
--- a/backend/common-web/src/main/java/io/featurehub/jersey/config/CommonConfiguration.java
+++ b/backend/common-web/src/main/java/io/featurehub/jersey/config/CommonConfiguration.java
@@ -1,5 +1,7 @@
 package io.featurehub.jersey.config;
 
+import cd.connect.openapi.support.OpenApiEnumProvider;
+import io.featurehub.jersey.OffsetDateTimeQueryProvider;
 import jakarta.ws.rs.core.Configurable;
 import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.FeatureContext;
@@ -20,6 +22,8 @@ public class CommonConfiguration implements Feature {
     config.register(GZipEncoder.class);
     config.register(JacksonContextProvider.class);
     config.register(LocalExceptionMapper.class);
+    config.register(OffsetDateTimeQueryProvider.class);
+    config.register(OpenApiEnumProvider.class);
   }
 
   @Override

--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/OffsetDateTimeQueryProvider.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/OffsetDateTimeQueryProvider.kt
@@ -1,0 +1,40 @@
+package io.featurehub.jersey
+
+import jakarta.ws.rs.ext.ParamConverter
+import jakarta.ws.rs.ext.ParamConverterProvider
+import jakarta.ws.rs.ext.Provider
+import java.lang.reflect.Type
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+@Provider
+class OffsetDateTimeQueryProvider : ParamConverterProvider {
+  override fun <T : Any?> getConverter(
+    rawType: Class<T>,
+    genericType: Type,
+    annotations: Array<out Annotation>?
+  ): ParamConverter<T?>? {
+    if (rawType.name.equals(OffsetDateTime::class.java.name)) {
+      return object: ParamConverter<T?> {
+        override fun toString(value: T?): String? {
+          if (value == null) {
+            return null
+          }
+
+          return (value as OffsetDateTime).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        }
+
+        override fun fromString(value: String?): T? {
+          if (value == null) {
+            return null;
+          }
+
+          return OffsetDateTime.parse(value) as T
+        }
+
+      }
+    }
+
+    return null;
+  }
+}

--- a/backend/composite-jersey/pom.xml
+++ b/backend/composite-jersey/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>cd.connect.openapi.gensupport</groupId>
       <artifactId>openapi-jersey3-support</artifactId>
-      <version>2.2-SNAPSHOT</version>
+      <version>2.2</version>
     </dependency>
 
     <dependency>

--- a/backend/composite-jersey/pom.xml
+++ b/backend/composite-jersey/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>cd.connect.openapi.gensupport</groupId>
       <artifactId>openapi-jersey3-support</artifactId>
-      <version>2.1</version>
+      <version>2.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/backend/sse-edge-api/pom.xml
+++ b/backend/sse-edge-api/pom.xml
@@ -83,7 +83,7 @@
                 <file>${project.basedir}/../mr-api/strategy-enums.yaml</file>
                 <file>${project.basedir}/src/main/resources/sse-api.yaml</file>
               </files>
-              <finalYaml>${project.basedir}/final.yaml</finalYaml>
+              <finalYaml>${project.basedir}/target/final.yaml</finalYaml>
             </configuration>
           </execution>
         </executions>
@@ -110,7 +110,7 @@
               <output>${project.basedir}/target/generated-sources/api</output>
               <apiPackage>io.featurehub.sse.api</apiPackage>
               <modelPackage>io.featurehub.sse.model</modelPackage>
-              <inputSpec>${project.basedir}/final.yaml</inputSpec>
+              <inputSpec>${project.basedir}/target/final.yaml</inputSpec>
               <generatorName>jersey3-api</generatorName>
 
               <additionalProperties>
@@ -142,6 +142,23 @@
               <sources>
                 <source>${project.build.directory}/generated-sources/api/src/gen</source>
               </sources>
+            </configuration>
+          </execution>
+          <!-- publish the API at packaging time -->
+          <execution>
+            <id>attach-final-yaml</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.basedir}/target/final.yaml</file>
+                  <type>yaml</type>
+                  <classifier>api</classifier>
+                </artifact>
+              </artifacts>
             </configuration>
           </execution>
         </executions>

--- a/backend/sse-edge-stats-api/async-api.yaml
+++ b/backend/sse-edge-stats-api/async-api.yaml
@@ -1,19 +1,3 @@
-openapi: 3.0.1
-info:
-  title: Usage API - consider nascent
-  description: This is primarily for model generation for the usage channel
-  version: 0.9.1
-paths:
-  /fake-get:
-    get:
-      description: "fake get api"
-      responses:
-        "200":
-          description: "fake response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/EdgeStatsBundle"
 components:
   schemas:
     EdgeStatsBundle:

--- a/backend/sse-edge-stats-api/fake-api.yaml
+++ b/backend/sse-edge-stats-api/fake-api.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.1
+info:
+  title: Usage API - consider nascent
+  description: This is primarily for model generation for the usage channel
+  version: 0.9.1
+paths:
+  /fake-get:
+    get:
+      description: "fake get api"
+      responses:
+        "200":
+          description: "fake response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EdgeStatsBundle"

--- a/backend/sse-edge-stats-api/pom.xml
+++ b/backend/sse-edge-stats-api/pom.xml
@@ -80,7 +80,7 @@
                 <file>${project.basedir}/fake-api.yaml</file>
                 <file>${project.basedir}/async-api.yaml</file>
               </files>
-              <finalYaml>${project.basedir}/final.yaml</finalYaml>
+              <finalYaml>${project.basedir}/target/final.yaml</finalYaml>
             </configuration>
           </execution>
         </executions>
@@ -108,7 +108,7 @@
               <output>${project.basedir}/target/generated-sources/api</output>
               <apiPackage>io.featurehub.sse.stats.api</apiPackage>
               <modelPackage>io.featurehub.sse.stats.model</modelPackage>
-              <inputSpec>${project.basedir}/final.yaml</inputSpec>
+              <inputSpec>${project.basedir}/target/final.yaml</inputSpec>
               <generatorName>jersey3-api</generatorName>
               <generateApis>false</generateApis>
             </configuration>

--- a/backend/sse-edge-stats-api/pom.xml
+++ b/backend/sse-edge-stats-api/pom.xml
@@ -65,6 +65,28 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>cd.connect.maven</groupId>
+        <artifactId>merge-yaml-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <id>combine</id>
+            <goals>
+              <goal>mergeYaml</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <files>
+                <file>${project.basedir}/fake-api.yaml</file>
+                <file>${project.basedir}/async-api.yaml</file>
+              </files>
+              <finalYaml>${project.basedir}/final.yaml</finalYaml>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
         <version>5.1.0</version>
@@ -86,7 +108,7 @@
               <output>${project.basedir}/target/generated-sources/api</output>
               <apiPackage>io.featurehub.sse.stats.api</apiPackage>
               <modelPackage>io.featurehub.sse.stats.model</modelPackage>
-              <inputSpec>${project.basedir}/async-api.yaml</inputSpec>
+              <inputSpec>${project.basedir}/final.yaml</inputSpec>
               <generatorName>jersey3-api</generatorName>
               <generateApis>false</generateApis>
             </configuration>
@@ -108,6 +130,23 @@
               <sources>
                 <source>${project.build.directory}/generated-sources/api/src/gen</source>
               </sources>
+            </configuration>
+          </execution>
+          <!-- publish the API at packaging time -->
+          <execution>
+            <id>attach-final-yaml</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.basedir}/async-api.yaml</file>
+                  <type>yaml</type>
+                  <classifier>api</classifier>
+                </artifact>
+              </artifacts>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This allows support for Enums that are specifically matched to their OpenAPI counterparts and supports timestamps in query parameters.