### PR TITLE
Etag headers

### DIFF
--- a/backend/dacha-api/dacha-api.yaml
+++ b/backend/dacha-api/dacha-api.yaml
@@ -251,6 +251,9 @@ components:
             $ref: "#/components/schemas/RolloutStrategy"
     DachaKeyDetailsResponse:
       properties:
+        etag:
+          x-basename: etag
+          type: string
         organizationId:
           x-basename: oId
           type: string

--- a/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
@@ -1,0 +1,52 @@
+package io.featurehub.dacha;
+
+import io.featurehub.mr.model.FeatureValueCacheItem;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+class EnvironmentFeatures implements InternalCache.FeatureValues {
+  private final Map<UUID, FeatureValueCacheItem> features;
+  private String etag;
+
+  public EnvironmentFeatures(Map<UUID, FeatureValueCacheItem> features) {
+    this.features = features;
+
+    calculateEtag();
+  }
+
+  private void calculateEtag() {
+    etag =
+        Integer.toHexString(
+            features.values().stream()
+                .map(fvci -> fvci.getFeature().getId() + "-" + fvci.getFeature().getVersion())
+                .collect(Collectors.joining("-"))
+                .hashCode());
+  }
+
+  public FeatureValueCacheItem get(UUID id) {
+    return features.get(id);
+  }
+
+  public void put(UUID id, FeatureValueCacheItem feature) {
+    features.put(id, feature);
+    calculateEtag();
+  }
+
+  public void remove(UUID id) {
+    features.remove(id);
+    calculateEtag();
+  }
+
+  @Override
+  public Collection<FeatureValueCacheItem> getFeatures() {
+    return features.values();
+  }
+
+  @Override
+  public String getEtag() {
+    return etag;
+  }
+}

--- a/backend/dacha/src/main/java/io/featurehub/dacha/InternalCache.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/InternalCache.java
@@ -10,15 +10,20 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 public interface InternalCache {
+  interface FeatureValues {
+    Collection<FeatureValueCacheItem> getFeatures();
+    String getEtag();
+  }
+
   class FeatureCollection {
-    public Collection<FeatureValueCacheItem> features;
+    public FeatureValues features;
     public ServiceAccountPermission perms;
     public UUID organizationId;
     public UUID portfolioId;
     public UUID applicationId;
     public UUID serviceAccountId;
 
-    public FeatureCollection(Collection<FeatureValueCacheItem> features, ServiceAccountPermission perms,
+    public FeatureCollection(FeatureValues features, ServiceAccountPermission perms,
                              UUID organizationId, UUID portfolioId, UUID applicationId, UUID serviceAccountId) {
       this.features = features;
       this.perms = perms;

--- a/backend/dacha/src/main/kotlin/io/featurehub/dacha/resource/DachaApiKeyResource.kt
+++ b/backend/dacha/src/main/kotlin/io/featurehub/dacha/resource/DachaApiKeyResource.kt
@@ -20,13 +20,14 @@ class DachaApiKeyResource @Inject constructor(private val cache: InternalCache) 
       .portfolioId(collection.portfolioId)
       .applicationId(collection.applicationId)
       .serviceKeyId(collection.serviceAccountId)
-      .features(collection.features.toMutableList())
+      .etag(collection.features.etag)
+      .features(collection.features.features.toMutableList())
   }
 
   override fun getApiKeyPermissions(eId: UUID, serviceAccountKey: String, featureKey: String): DachaPermissionResponse {
     val collection = cache.getFeaturesByEnvironmentAndServiceAccount(eId, serviceAccountKey) ?: throw NotFoundException()
 
-    val feature = collection.features.find { fv -> fv.feature?.key?.equals(featureKey) == true } ?: throw NotFoundException()
+    val feature = collection.features.features.find { fv -> fv.feature?.key?.equals(featureKey) == true } ?: throw NotFoundException()
 
     return DachaPermissionResponse()
       .organizationId(collection.organizationId)

--- a/backend/sse-edge-stats-api/async-api.yaml
+++ b/backend/sse-edge-stats-api/async-api.yaml
@@ -70,6 +70,7 @@ components:
       enum:
         - success_until_kicked_off
         - success
+        - no_change
         - missed
         - failed_to_write_on_init
         - failed_to_process_request

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/StreamingFeatureSource.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/StreamingFeatureSource.java
@@ -158,7 +158,7 @@ public class StreamingFeatureSource implements StreamingFeatureController {
           // this squashes all of the requests and optimises the daylights out of this call so we don't need to
           final List<FeatureRequestResponse> request =
             dachaFeatureRequestSubmitter.request(Collections.singletonList(key),
-              client.getClientContext());
+              client.getClientContext(), client.etags());
 
           client.initResponse(request.get(0));
           client.registerEjection(this::clientRemoved);

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/client/ClientConnection.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/client/ClientConnection.java
@@ -1,6 +1,7 @@
 package io.featurehub.edge.client;
 
 import io.featurehub.edge.KeyParts;
+import io.featurehub.edge.features.EtagStructureHolder;
 import io.featurehub.edge.features.FeatureRequestResponse;
 import io.featurehub.edge.strategies.ClientContext;
 import io.featurehub.mr.model.FeatureValueCacheItem;
@@ -36,4 +37,6 @@ public interface ClientConnection {
 
   // notify the client of a new feature (if they have received their features)
   void notifyFeature(FeatureValueCacheItem rf);
+
+  EtagStructureHolder etags();
 }

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
@@ -54,7 +54,7 @@ public class TimedBucketClientConnection implements ClientConnection {
     attributesForStrategy =
         ClientContext.decode(builder.featureHubAttributes, Collections.singletonList(apiKey));
 
-    etags = ETagSplitter.Companion.splitTag(builder.etag, Arrays.asList(apiKey), attributesForStrategy.makeEtag());
+    etags = ETagSplitter.Companion.splitTag(builder.etag, List.of(apiKey), attributesForStrategy.makeEtag());
 
     timer = connectionLengthHistogram.startTimer();
   }
@@ -180,7 +180,7 @@ public class TimedBucketClientConnection implements ClientConnection {
           if (edgeResponse.getSuccess() == FeatureRequestSuccess.SUCCESS) {
             writeMessage(
               SSEResultState.FEATURES,
-              edgeResponse.getEtag(),
+              ETagSplitter.Companion.makeEtags(etags, List.of(edgeResponse)),
               CacheJsonMapper.mapper.writeValueAsString(edgeResponse.getEnvironment().getFeatures()));
           }
 

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/rest/EventStreamResource.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/rest/EventStreamResource.java
@@ -139,8 +139,6 @@ public class EventStreamResource {
         .entity(environments.stream().map(FeatureRequestResponse::getEnvironment).collect(Collectors.toList()))
         .build());
     }
-
-
   }
 
   private EdgeHitResultType mapSuccess(FeatureRequestSuccess success) {
@@ -163,7 +161,8 @@ public class EventStreamResource {
                               @PathParam("environmentId") UUID envId,
                               @PathParam("apiKey") String apiKey,
                               @HeaderParam("x-featurehub") List<String> featureHubAttrs, // non browsers can set headers
-                              @QueryParam("xfeaturehub") String browserHubAttrs // browsers can't set headers
+                              @QueryParam("xfeaturehub") String browserHubAttrs, // browsers can't set headers,
+                              @HeaderParam("Last-Event-ID") String etag
                               ) {
     EventOutput o = new EventOutput();
 
@@ -174,6 +173,7 @@ public class EventStreamResource {
         .featureTransformer(featureTransformer)
         .statRecorder(statRecorder)
         .apiKey(key)
+        .etag(etag)
         .featureHubAttributes(browserHubAttrs == null ? featureHubAttrs : Collections.singletonList(browserHubAttrs))
         .output(o)
         .build();

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/strategies/ClientContext.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/strategies/ClientContext.java
@@ -74,4 +74,8 @@ public class ClientContext {
 
     return val.get(0);
   }
+
+  public String makeEtag() {
+    return Integer.toHexString(attributes.hashCode());
+  }
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaFeatureRequestSubmitter.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaFeatureRequestSubmitter.kt
@@ -16,5 +16,5 @@ interface DachaFeatureRequestSubmitter {
   /*
    * Requests a bunch of environment details from Dacha in the most efficient way possible
    */
-  fun request(keys: List<KeyParts>, context: ClientContext): List<FeatureRequestResponse>
+  fun request(keys: List<KeyParts>, context: ClientContext, etags: EtagStructureHolder): List<FeatureRequestResponse>
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaRequestOrchestrator.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaRequestOrchestrator.kt
@@ -58,7 +58,7 @@ open class DachaRequestOrchestrator @Inject constructor(
     context: ClientContext,
     future: CompletableFuture<List<FeatureRequestResponse>>,
     etags: EtagStructureHolder
-  ) : FeatureRequestCompleteNotifier = FeatureRequestCollection(getters, featureTransformer, context, future, etags)
+  ) : FeatureRequestCompleteNotifier = FeatureRequestCollection(getters.size, featureTransformer, context, future, etags)
 
 
   override fun requestForKeyComplete(key: KeyParts) {

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaRequestOrchestrator.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/DachaRequestOrchestrator.kt
@@ -19,7 +19,7 @@ open class DachaRequestOrchestrator @Inject constructor(
     val inflightGauge = Gauge.build("edge_get_inflight_requests", "Inflight GET request Counter").register()
   }
 
-  override fun request(keys: List<KeyParts>, context: ClientContext): List<FeatureRequestResponse> {
+  override fun request(keys: List<KeyParts>, context: ClientContext, etags: EtagStructureHolder): List<FeatureRequestResponse> {
 
     // we need at least one for it to work
     if (keys.isEmpty()) {
@@ -38,7 +38,7 @@ open class DachaRequestOrchestrator @Inject constructor(
     }.toList()
 
     // now create a collector for the requests to notify
-    val action = getRequestCollector(getters, context, future)
+    val action = getRequestCollector(getters, context, future, etags)
 
     // and tell them to go get the data or add us to their list
     getters.forEach { getter -> getter.add(action) }
@@ -56,8 +56,9 @@ open class DachaRequestOrchestrator @Inject constructor(
   protected open fun getRequestCollector(
     getters: List<FeatureRequester>,
     context: ClientContext,
-    future: CompletableFuture<List<FeatureRequestResponse>>
-  ) : FeatureRequestCompleteNotifier = FeatureRequestCollection(getters, featureTransformer, context, future)
+    future: CompletableFuture<List<FeatureRequestResponse>>,
+    etags: EtagStructureHolder
+  ) : FeatureRequestCompleteNotifier = FeatureRequestCollection(getters, featureTransformer, context, future, etags)
 
 
   override fun requestForKeyComplete(key: KeyParts) {

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
@@ -1,0 +1,48 @@
+package io.featurehub.edge.features
+
+import io.featurehub.edge.KeyParts
+
+class EtagStructureHolder(val environmentTags: Map<KeyParts, String>, val contextTag: String, val validEtag: Boolean)
+
+class ETagSplitter {
+  companion object {
+    fun splitTag(etag: String?, keys: List<KeyParts>, clientContextTag: String): EtagStructureHolder {
+      if (etag == null) return EtagStructureHolder(mapOf(), clientContextTag, false)
+
+      val environmentTagVsContextTag = etag.trim().split("//").toTypedArray()
+
+      var contextTags: String = ""
+
+      if (environmentTagVsContextTag.size == 2) {
+        contextTags = environmentTagVsContextTag[1].trim()
+
+        if (!clientContextTag.equals(contextTags)) { // different so we will need to transform the features
+          return EtagStructureHolder(mapOf(), clientContextTag, false)
+        }
+      }
+
+      val envTags = mutableMapOf<KeyParts, String>()
+      if (environmentTagVsContextTag.isNotEmpty()) {
+        val tags = environmentTagVsContextTag[0].trim().split(";").toTypedArray()
+
+        // if the tags != key sizes, its not valid, they have added or removed a key
+        if (tags.size != keys.size) {
+          return EtagStructureHolder(mapOf(), clientContextTag, false)
+        }
+
+        for(count in tags.indices) {
+          envTags[keys[count]] = tags[count]
+        }
+      }
+
+      return EtagStructureHolder(envTags, clientContextTag, true)
+    }
+
+    /**
+     * makes the new etags with
+     */
+    fun makeEtags(etags: EtagStructureHolder, responses: List<FeatureRequestResponse>) : String {
+      return responses.map { it.etag }.joinToString(";") + "//" + etags.contextTag
+    }
+  }
+}

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
@@ -19,6 +19,8 @@ class ETagSplitter {
         if (!clientContextTag.equals(contextTags)) { // different so we will need to transform the features
           return EtagStructureHolder(mapOf(), clientContextTag, false)
         }
+      } else if (clientContextTag != "0") {
+        return EtagStructureHolder(mapOf(), clientContextTag, false)
       }
 
       val envTags = mutableMapOf<KeyParts, String>()
@@ -42,7 +44,7 @@ class ETagSplitter {
      * makes the new etags with
      */
     fun makeEtags(etags: EtagStructureHolder, responses: List<FeatureRequestResponse>) : String {
-      return responses.map { it.etag }.joinToString(";") + "//" + etags.contextTag
+      return responses.map { it.etag }.joinToString(";") + (if (etags.contextTag == "0") "" else  "//" + etags.contextTag)
     }
   }
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/EtagHolder.kt
@@ -23,7 +23,7 @@ class ETagSplitter {
 
       val envTags = mutableMapOf<KeyParts, String>()
       if (environmentTagVsContextTag.isNotEmpty()) {
-        val tags = environmentTagVsContextTag[0].trim().split(";").toTypedArray()
+        val tags = environmentTagVsContextTag[0].trim().split(";").filter { it.isNotEmpty() }.toTypedArray()
 
         // if the tags != key sizes, its not valid, they have added or removed a key
         if (tags.size != keys.size) {

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCollection.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCollection.kt
@@ -9,20 +9,20 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class FeatureRequestCollection(
-  private val requests: List<FeatureRequester>,
+  private val requestCount: Int,
   private val featureTransformer: FeatureTransformer,
   private val clientContext: ClientContext,
   private val future: CompletableFuture<List<FeatureRequestResponse>>,
   private val etags: EtagStructureHolder
 ) : FeatureRequestCompleteNotifier {
-  private val completed: MutableCollection<FeatureRequesterSource> = ConcurrentLinkedQueue()
+  private val completed: MutableCollection<FeatureRequester> = ConcurrentLinkedQueue()
 
   // this gets called on each requester each time a response comes back. Once it matches
   // the number that went in, we can process and complete the future
-  override fun complete(key: FeatureRequesterSource) {
+  override fun complete(key: FeatureRequester) {
     completed.add(key)
 
-    if (completed.size == requests.size) {
+    if (completed.size == requestCount) {
       // determine first if any of the environments failed its etag match
       val sendFullResults = !etags.validEtag || completed.find { !etags.environmentTags[it.key].equals(it.details?.etag) } != null
       future.complete(completed.map { req -> transformFeatures(req.details, req.key, sendFullResults) }.toList())

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCollection.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCollection.kt
@@ -12,7 +12,8 @@ class FeatureRequestCollection(
   private val requests: List<FeatureRequester>,
   private val featureTransformer: FeatureTransformer,
   private val clientContext: ClientContext,
-  private val future: CompletableFuture<List<FeatureRequestResponse>>
+  private val future: CompletableFuture<List<FeatureRequestResponse>>,
+  private val etags: EtagStructureHolder
 ) : FeatureRequestCompleteNotifier {
   private val completed: MutableCollection<FeatureRequesterSource> = ConcurrentLinkedQueue()
 
@@ -22,16 +23,24 @@ class FeatureRequestCollection(
     completed.add(key)
 
     if (completed.size == requests.size) {
-      future.complete(completed.map { req -> transformFeatures(req.details, req.key) }.toList())
+      // determine first if any of the environments failed its etag match
+      val sendFullResults = !etags.validEtag || completed.find { !etags.environmentTags[it.key].equals(it.details?.etag) } != null
+      future.complete(completed.map { req -> transformFeatures(req.details, req.key, sendFullResults) }.toList())
     }
   }
 
-  private fun transformFeatures(details: DachaKeyDetailsResponse?, key: KeyParts): FeatureRequestResponse {
+  private fun transformFeatures(details: DachaKeyDetailsResponse?, key: KeyParts, sendFullResults: Boolean): FeatureRequestResponse {
     val env = Environment().id(key.environmentId)
-    if (details == null)
-      return FeatureRequestResponse(env, false, key)
+
+    if (details == null) {
+      return FeatureRequestResponse(env, FeatureRequestSuccess.FAILED, key, "0")
+    }
+
+    if (!sendFullResults) {
+      return FeatureRequestResponse(env, FeatureRequestSuccess.NO_CHANGE, key, "")
+    }
 
     return FeatureRequestResponse(env
-      .features(featureTransformer.transform(details.features, clientContext)), true, key)
+      .features(featureTransformer.transform(details.features, clientContext)), FeatureRequestSuccess.SUCCESS, key, details.etag)
   }
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCompleteNotifier.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestCompleteNotifier.kt
@@ -1,5 +1,5 @@
 package io.featurehub.edge.features
 
 interface FeatureRequestCompleteNotifier {
-  fun complete(key: FeatureRequesterSource)
+  fun complete(key: FeatureRequester)
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestResponse.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequestResponse.kt
@@ -3,8 +3,12 @@ package io.featurehub.edge.features
 import io.featurehub.edge.KeyParts
 import io.featurehub.sse.model.Environment
 
+enum class FeatureRequestSuccess {
+  FAILED, SUCCESS, NO_CHANGE
+}
+
 /**
  * This holds the response per environment - it determines if we were successful in getting
  * this KeyPair or not. If Dacha does not know about it or it isn't up, success will be false.
  */
-class FeatureRequestResponse(val environment: Environment, val success: Boolean, val key: KeyParts)
+class FeatureRequestResponse(val environment: Environment, val success: FeatureRequestSuccess, val key: KeyParts, val etag: String)

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequester.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequester.kt
@@ -1,5 +1,11 @@
 package io.featurehub.edge.features
 
+import io.featurehub.edge.KeyParts
+import io.featurehub.mr.model.DachaKeyDetailsResponse
+
 interface FeatureRequester {
+  val details: DachaKeyDetailsResponse?
+  val key: KeyParts
+
   fun add(notifier: FeatureRequestCompleteNotifier)
 }

--- a/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequesterSource.kt
+++ b/backend/sse-edge/src/main/kotlin/io/featurehub/edge/features/FeatureRequesterSource.kt
@@ -7,11 +7,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentLinkedQueue
 
-class FeatureRequesterSource(private val api: DachaApiKeyService, val key: KeyParts, private val executor: EdgeConcurrentRequestPool, private val submitter: DachaFeatureRequestSubmitter) : FeatureRequester {
+class FeatureRequesterSource(private val api: DachaApiKeyService, override val key: KeyParts, private val executor: EdgeConcurrentRequestPool, private val submitter: DachaFeatureRequestSubmitter) : FeatureRequester {
   private val log: Logger = LoggerFactory.getLogger(FeatureRequesterSource::class.java)
 
   val notifyListener: MutableCollection<FeatureRequestCompleteNotifier> = ConcurrentLinkedQueue()
-  var details: DachaKeyDetailsResponse? = null
+  override var details: DachaKeyDetailsResponse? = null
 
   override fun add(notifier: FeatureRequestCompleteNotifier) {
     var size: Int?

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/EtagSplitterSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/EtagSplitterSpec.groovy
@@ -1,0 +1,77 @@
+package io.featurehub.edge.features
+
+import io.featurehub.edge.KeyParts
+import spock.lang.Specification
+
+class EtagSplitterSpec extends Specification {
+  def "when i have tags and a context tag it gets broken up properly"() {
+    given: "i have tags"
+      def etag = "1;2//other"
+    and: "i have two keypairs"
+      def k1 = new KeyParts("1", UUID.randomUUID(), "s1")
+      def k2 = new KeyParts("1", UUID.randomUUID(), "s2")
+      def keypairs = [k1,k2]
+    when: "i split"
+      def holder = ETagSplitter.@Companion.splitTag(etag, keypairs, "other")
+    then:
+      holder.validEtag
+      holder.contextTag == "other"
+      holder.environmentTags[k1] == "1"
+      holder.environmentTags[k2] == "2"
+  }
+
+  def "when the etag is null, the holder will be invalid but the context etag will still be the context's one"() {
+    given: "i have tags"
+      def etag = null
+    and: "i have two keypairs"
+      def k1 = new KeyParts("1", UUID.randomUUID(), "s1")
+      def k2 = new KeyParts("1", UUID.randomUUID(), "s2")
+      def keypairs = [k1,k2]
+    when: "i split"
+      def holder = ETagSplitter.@Companion.splitTag(etag, keypairs, "other")
+    then:
+      !holder.validEtag
+      holder.contextTag == "other"
+  }
+
+  def "when the keys have less in the header than are passed, the holder is invalid"() {
+    given: "i have tags"
+      def etag = "1;//other"
+    and: "i have two keypairs"
+      def k1 = new KeyParts("1", UUID.randomUUID(), "s1")
+      def k2 = new KeyParts("1", UUID.randomUUID(), "s2")
+      def keypairs = [k1,k2]
+    when: "i split"
+      def holder = ETagSplitter.@Companion.splitTag(etag, keypairs, "other")
+    then:
+      !holder.validEtag
+      holder.contextTag == "other"
+  }
+
+  def "when the keys have more in the header than are passed, the holder is invalid"() {
+    given: "i have tags"
+      def etag = "1;2//other"
+    and: "i have two keypairs"
+      def k1 = new KeyParts("1", UUID.randomUUID(), "s1")
+      def keypairs = [k1]
+    when: "i split"
+      def holder = ETagSplitter.@Companion.splitTag(etag, keypairs, "other")
+    then:
+      !holder.validEtag
+      holder.contextTag == "other"
+  }
+
+  def "when the keys are right but the context match is wrong"() {
+    given: "i have tags"
+      def etag = "1;2//other2"
+    and: "i have two keypairs"
+      def k1 = new KeyParts("1", UUID.randomUUID(), "s1")
+      def k2 = new KeyParts("1", UUID.randomUUID(), "s2")
+      def keypairs = [k1,k2]
+    when: "i split"
+      def holder = ETagSplitter.@Companion.splitTag(etag, keypairs, "other")
+    then:
+      !holder.validEtag
+      holder.contextTag == "other"
+  }
+}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestCollectionSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestCollectionSpec.groovy
@@ -1,0 +1,4 @@
+package io.featurehub.edge.features
+
+class FeatureRequestCollectionSpec {
+}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestCollectionSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestCollectionSpec.groovy
@@ -1,4 +1,80 @@
 package io.featurehub.edge.features
 
-class FeatureRequestCollectionSpec {
+import io.featurehub.edge.FeatureTransformer
+import io.featurehub.edge.KeyParts
+import io.featurehub.edge.strategies.ClientContext
+import io.featurehub.mr.model.DachaKeyDetailsResponse
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+class FeatureRequestCollectionSpec extends Specification {
+  FeatureTransformer transformer
+  ClientContext context
+  CompletableFuture<List<FeatureRequestResponse>> future
+  List<FeatureRequestResponse> responses
+  KeyParts kp1
+  KeyParts kp2
+//  EtagStructureHolder
+
+  def setup() {
+    transformer = Mock(FeatureTransformer)
+    context = new ClientContext(false)
+    future = new CompletableFuture<List<FeatureRequestResponse>>()
+    responses = []
+    kp1 = new KeyParts("c1", UUID.randomUUID(), "1")
+    kp2 = new KeyParts("c1", UUID.randomUUID(), "1")
+  }
+
+  def "if the etag holder is invalid, we will get success/failed mix appropriately"() {
+    given: "we have an invalid etag holder"
+      def holder = new EtagStructureHolder(Map.of(kp1, "x", kp2, "y"), "0", false)
+    and: "we have created our collection"
+      def coll = new FeatureRequestCollection(2, transformer, context, future, holder)
+    when: "we drop our requests in"
+      def r1 = Mock(FeatureRequester)
+      r1.key >> kp1
+      def r2 = Mock(FeatureRequester)
+      r2.key >> kp2
+      coll.complete(r1)
+      coll.complete(r2)
+    and: "we wait for the future"
+      def responses = future.get()
+    then:
+      responses.size() == 2
+      responses[0].success == FeatureRequestSuccess.FAILED
+      responses[1].success == FeatureRequestSuccess.FAILED
+  }
+
+  def "if all requests complete and have the same etags, we will get a NO_CHANGE response"() {
+    given: "we have an valid etag holder"
+      def holder = new EtagStructureHolder(Map.of(kp1, "x", kp2, "y"), "0", true)
+    and: "we have created our collection"
+      def coll = new FeatureRequestCollection(2, transformer, context, future, holder)
+    when: "we drop our requests in"
+      def r1 = Mock(FeatureRequester)
+      def details1 = new DachaKeyDetailsResponse().etag("x")
+      r1.key >> kp1
+      r1.details >> details1
+      def r2 = Mock(FeatureRequester)
+      def details2 = new DachaKeyDetailsResponse().etag("y")
+      r2.key >> kp2
+      r2.details >> details2
+      coll.complete(r1)
+      coll.complete(r2)
+    and: "we wait for the future"
+      def responses = future.get()
+    then:
+      responses.size() == 2
+      responses[0].success == FeatureRequestSuccess.NO_CHANGE
+      responses[1].success == FeatureRequestSuccess.NO_CHANGE
+  }
+
+  def "if all requests complete and at least one has a different etag, we will get a  SUCCESS response"() {
+
+  }
+
+  def "if any requests failed, the ones that are successful will get a success response even if their etags are the same"() {
+
+  }
 }

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestResponseSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestResponseSpec.groovy
@@ -1,4 +1,0 @@
-package io.featurehub.edge.features
-
-class FeatureRequestResponseSpec {
-}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestResponseSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestResponseSpec.groovy
@@ -1,0 +1,4 @@
+package io.featurehub.edge.features
+
+class FeatureRequestResponseSpec {
+}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestSuccessSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestSuccessSpec.groovy
@@ -1,4 +1,0 @@
-package io.featurehub.edge.features
-
-class FeatureRequestSuccessSpec {
-}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestSuccessSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequestSuccessSpec.groovy
@@ -1,0 +1,4 @@
+package io.featurehub.edge.features
+
+class FeatureRequestSuccessSpec {
+}

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequesterSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequesterSpec.groovy
@@ -23,45 +23,52 @@ class FeatureRequesterSpec extends Specification {
   def "when i pass no keys, i get no responses"() {
     given: "i have an orchestrator"
       def orch = new DachaRequestOrchestrator(Mock(FeatureTransformer), Mock(DachaClientServiceRegistry), Mock(EdgeConcurrentRequestPool))
+    and: "i have no etags"
+      def etags = new EtagStructureHolder([:], "", false)
     when: "i pass in no keys"
-      def result = orch.request([], new ClientContext(false))
+      def result = orch.request([], new ClientContext(false), etags)
     then:
       result.isEmpty()
   }
 
-//  def "when i pass 3 keys, i get 3 environments back"() {
-//    given: "I have 3 environments"
-//       def envs = [new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID())]
-//    and: "a mock notifier"
-//      def notifier = Mock(FeatureRequestCompleteNotifier)
-//    and: "a mock dacha registry"
-//      def dacha = Mock(DachaClientServiceRegistry)
-//    and: "a mocked inflight request"
-//    and: "i have an overridden orchestrator"
-//      def orch = new DachaRequestOrchestrator(Mock(FeatureTransformer), dacha, Mock(EdgeConcurrentRequestPool)) {
-//        @Override
-//        protected FeatureRequester createInflightRequest(@NotNull KeyParts key) {
-//          inflightRequestCounter ++
-//          return inflightRequest
-//        }
-//
-//        @Override
-//        protected FeatureRequestCompleteNotifier getRequestCollector(@NotNull List<? extends FeatureRequester> getters, @NotNull ClientContext context, @NotNull CompletableFuture<List<Environment>> future) {
-//          future.complete(envs)
-//          return notifier
-//        }
-//      }
-//    when:
-//      def result = orch.request([new KeyParts("default", UUID.randomUUID(), "x"),
-//                    new KeyParts("fred", UUID.randomUUID(), "x"),
-//                    new KeyParts("mary", UUID.randomUUID(), "x")], new ClientContext(false))
-//    then:
-//      1 * dacha.getApiKeyService("default") >> Mock(DachaApiKeyService)
-//      1 * dacha.getApiKeyService("fred") >> Mock(DachaApiKeyService)
-//      1 * dacha.getApiKeyService("mary") >> Mock(DachaApiKeyService)
-//      3 == inflightRequestCounter
-//      3 * inflightRequest.add(notifier)
-//      result == envs
-//
-//  }
+  def "when i pass 3 keys, i get 3 environments back"() {
+    given: "I have 3 environments"
+       def envs = [new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID())]
+    and: "a mock notifier"
+      def notifier = Mock(FeatureRequestCompleteNotifier)
+    and: "a mock dacha registry"
+      def dacha = Mock(DachaClientServiceRegistry)
+    and: "a mocked inflight request"
+    and: "i have an overridden orchestrator"
+      def orch = new DachaRequestOrchestrator(Mock(FeatureTransformer), dacha, Mock(EdgeConcurrentRequestPool)) {
+        @Override
+        protected FeatureRequester createInflightRequest(@NotNull KeyParts key) {
+          inflightRequestCounter ++
+          return inflightRequest
+        }
+
+        @Override
+        protected FeatureRequestCompleteNotifier getRequestCollector(@NotNull List<? extends FeatureRequester> getters,
+                                                                     @NotNull ClientContext context,
+                                                                     @NotNull CompletableFuture<List<Environment>> future,
+        @NotNull EtagStructureHolder etags) {
+          future.complete(envs)
+          return notifier
+        }
+      }
+    and: "I have a fake etags"
+      def etags = new EtagStructureHolder([:], "", true)
+    when:
+      def result = orch.request([new KeyParts("default", UUID.randomUUID(), "x"),
+                    new KeyParts("fred", UUID.randomUUID(), "x"),
+                    new KeyParts("mary", UUID.randomUUID(), "x")], new ClientContext(false), etags)
+    then:
+      1 * dacha.getApiKeyService("default") >> Mock(DachaApiKeyService)
+      1 * dacha.getApiKeyService("fred") >> Mock(DachaApiKeyService)
+      1 * dacha.getApiKeyService("mary") >> Mock(DachaApiKeyService)
+      3 == inflightRequestCounter
+      3 * inflightRequest.add(notifier)
+      result == envs
+
+  }
 }

--- a/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequesterSpec.groovy
+++ b/backend/sse-edge/src/test/groovy/io/featurehub/edge/features/FeatureRequesterSpec.groovy
@@ -29,39 +29,39 @@ class FeatureRequesterSpec extends Specification {
       result.isEmpty()
   }
 
-  def "when i pass 3 keys, i get 3 environments back"() {
-    given: "I have 3 environments"
-       def envs = [new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID())]
-    and: "a mock notifier"
-      def notifier = Mock(FeatureRequestCompleteNotifier)
-    and: "a mock dacha registry"
-      def dacha = Mock(DachaClientServiceRegistry)
-    and: "a mocked inflight request"
-    and: "i have an overridden orchestrator"
-      def orch = new DachaRequestOrchestrator(Mock(FeatureTransformer), dacha, Mock(EdgeConcurrentRequestPool)) {
-        @Override
-        protected FeatureRequester createInflightRequest(@NotNull KeyParts key) {
-          inflightRequestCounter ++
-          return inflightRequest
-        }
-
-        @Override
-        protected FeatureRequestCompleteNotifier getRequestCollector(@NotNull List<? extends FeatureRequester> getters, @NotNull ClientContext context, @NotNull CompletableFuture<List<Environment>> future) {
-          future.complete(envs)
-          return notifier
-        }
-      }
-    when:
-      def result = orch.request([new KeyParts("default", UUID.randomUUID(), "x"),
-                    new KeyParts("fred", UUID.randomUUID(), "x"),
-                    new KeyParts("mary", UUID.randomUUID(), "x")], new ClientContext(false))
-    then:
-      1 * dacha.getApiKeyService("default") >> Mock(DachaApiKeyService)
-      1 * dacha.getApiKeyService("fred") >> Mock(DachaApiKeyService)
-      1 * dacha.getApiKeyService("mary") >> Mock(DachaApiKeyService)
-      3 == inflightRequestCounter
-      3 * inflightRequest.add(notifier)
-      result == envs
-
-  }
+//  def "when i pass 3 keys, i get 3 environments back"() {
+//    given: "I have 3 environments"
+//       def envs = [new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID()), new Environment().id(UUID.randomUUID())]
+//    and: "a mock notifier"
+//      def notifier = Mock(FeatureRequestCompleteNotifier)
+//    and: "a mock dacha registry"
+//      def dacha = Mock(DachaClientServiceRegistry)
+//    and: "a mocked inflight request"
+//    and: "i have an overridden orchestrator"
+//      def orch = new DachaRequestOrchestrator(Mock(FeatureTransformer), dacha, Mock(EdgeConcurrentRequestPool)) {
+//        @Override
+//        protected FeatureRequester createInflightRequest(@NotNull KeyParts key) {
+//          inflightRequestCounter ++
+//          return inflightRequest
+//        }
+//
+//        @Override
+//        protected FeatureRequestCompleteNotifier getRequestCollector(@NotNull List<? extends FeatureRequester> getters, @NotNull ClientContext context, @NotNull CompletableFuture<List<Environment>> future) {
+//          future.complete(envs)
+//          return notifier
+//        }
+//      }
+//    when:
+//      def result = orch.request([new KeyParts("default", UUID.randomUUID(), "x"),
+//                    new KeyParts("fred", UUID.randomUUID(), "x"),
+//                    new KeyParts("mary", UUID.randomUUID(), "x")], new ClientContext(false))
+//    then:
+//      1 * dacha.getApiKeyService("default") >> Mock(DachaApiKeyService)
+//      1 * dacha.getApiKeyService("fred") >> Mock(DachaApiKeyService)
+//      1 * dacha.getApiKeyService("mary") >> Mock(DachaApiKeyService)
+//      3 == inflightRequestCounter
+//      3 * inflightRequest.add(notifier)
+//      result == envs
+//
+//  }
 }


### PR DESCRIPTION
# Description

Implements support for etag headers for SDK clients. Etags will always be sent back but if not provided edge will operate as normal. This is part one of the ticket, the SDKs now need to be updated to support it.

Fixes #442 

