### PR TITLE
In-the-wild testing and etag support for typescript SDK

### DIFF
--- a/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
@@ -17,13 +17,12 @@ class EnvironmentFeatures implements InternalCache.FeatureValues {
     calculateEtag();
   }
 
-  private void calculateEtag() {
+  public void calculateEtag() {
+    String val = features.values().stream()
+      .map(fvci -> fvci.getFeature().getId() + "-" + (fvci.getValue() == null ? "0000" :  fvci.getValue().getVersion()))
+      .collect(Collectors.joining("-"));
     etag =
-        Integer.toHexString(
-            features.values().stream()
-                .map(fvci -> fvci.getFeature().getId() + "-" + fvci.getFeature().getVersion())
-                .collect(Collectors.joining("-"))
-                .hashCode());
+        Integer.toHexString(val.hashCode());
   }
 
   public FeatureValueCacheItem get(UUID id) {

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
@@ -61,10 +61,12 @@ public class TimedBucketClientConnection implements ClientConnection {
 
   @Override
   public boolean discovery() {
-    try {
-      writeMessage(SSEResultState.ACK, SSEStatusMessage.status("discover"));
-    } catch (IOException e) {
-      return false;
+    if (!etags.getValidEtag()) {
+      try {
+        writeMessage(SSEResultState.ACK, SSEStatusMessage.status("discover"));
+      } catch (IOException e) {
+        return false;
+      }
     }
 
     return true;
@@ -98,7 +100,7 @@ public class TimedBucketClientConnection implements ClientConnection {
   public void writeMessage(SSEResultState name, String etags, String data) throws IOException {
     if (!output.isClosed()) {
       final OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
-      log.trace("data is : {}", data);
+      log.debug("data is  etag `{}`: data `{}`", etags, data);
       eventBuilder.name(name.toString());
       eventBuilder.mediaType(MediaType.TEXT_PLAIN_TYPE);
       if (etags != null) {

--- a/backend/sse-edge/src/main/java/io/featurehub/edge/rest/EventStreamResource.java
+++ b/backend/sse-edge/src/main/java/io/featurehub/edge/rest/EventStreamResource.java
@@ -97,7 +97,7 @@ public class EventStreamResource {
   public void getFeatureStates(@Suspended AsyncResponse response, @QueryParam("sdkUrl") List<String> sdkUrls,
                                @QueryParam("apiKey") List<String> apiKeys,
                                @HeaderParam("x-featurehub") List<String> featureHubAttrs,
-                               @HeaderParam("etag") String etagHeader) {
+                               @HeaderParam("if-none-match") String etagHeader) {
     if ((sdkUrls == null || sdkUrls.isEmpty()) && (apiKeys == null || apiKeys.isEmpty()) ) {
       response.resume(new BadRequestException());
       return;


### PR DESCRIPTION
# Description

This is an update for extensive in-the-wild testing for typescript and
fixes an issue with etag generation in the Dacha server.

Fixes #533

# Testing
- the browser was tested with the polling and SSE client, using a client and server evaluated key with context
- the node server was tested with polling and SSE client with only a server evaluated key (as only this makes sense) with context

Some updates were done as a result of this based on real life testing over discovered documentation.