### PR TITLE
remove jersey2 client from security-oauth

### DIFF
--- a/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2Feature.kt
+++ b/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2Feature.kt
@@ -4,6 +4,7 @@ import cd.connect.app.config.ConfigKey
 import cd.connect.app.config.DeclaredConfigResolver
 import cd.connect.jersey.common.LoggingConfiguration
 import io.featurehub.jersey.config.CommonConfiguration
+import io.featurehub.lifecycle.ClientTelemetryFeature
 import io.featurehub.web.security.oauth.providers.*
 import io.featurehub.web.security.oauth.providers.GithubProvider.Companion.PROVIDER_NAME
 import jakarta.inject.Singleton
@@ -52,9 +53,8 @@ class OAuth2Feature : Feature {
           bind(OAuth2ProviderManager::class.java).to(OAuth2ProviderDiscovery::class.java).to(
             AuthProvider::class.java
           ).`in`(Singleton::class.java)
-          bind(buildClient()).to(Client::class.java).`in`(Singleton::class.java)
 
-          // now the outbound http request to validte authorization flow
+          // now the outbound http request to validate authorization flow
           bind(OAuth2JerseyClient::class.java).to(OAuth2Client::class.java).`in`(Singleton::class.java)
         }
       })
@@ -62,12 +62,6 @@ class OAuth2Feature : Feature {
       log.info("No oauth2 providers in config, skipping oauth2.")
     }
     return true
-  }
-
-  protected fun buildClient(): Client {
-    return ClientBuilder.newClient()
-      .register(CommonConfiguration::class.java)
-      .register(LoggingConfiguration::class.java)
   }
 
   companion object {

--- a/pipeline/app-build-pipeline/cloudbuild.yaml
+++ b/pipeline/app-build-pipeline/cloudbuild.yaml
@@ -27,7 +27,8 @@ steps:
       - |
         (
           gsutil cp gs://${_GCS_CACHE_BUCKET}/fh-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
-          tar -xzf /tmp/m2-cache.tar.gz
+          tar -xzf /tmp/m2-cache.tar.gz &&
+          rm -rf /root/.m2/repository/io/featurehub
         ) || echo 'Cache not found'
     volumes:
       - name: user.home


### PR DESCRIPTION
# Description

remove jersey client from oauth2 feature as it isn't required because it is defined by the OTEL client


