### PR TITLE
Add the health check to the delegating handler

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
@@ -7,7 +7,7 @@ import org.glassfish.grizzly.http.server.Response
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer
 
 class DelegatingHandler constructor(private val jerseyHandler: GrizzlyHttpContainer, private val staticHttpHandler: AdminAppStaticHttpHandler) : HttpHandler() {
-  private var jerseyPrefixes = listOf("/mr-api/", "/oauth/", "/features")
+  private var jerseyPrefixes = listOf("/mr-api/", "/oauth/", "/features", "/health/")
 
   init {
     var prefixes = FallbackPropertyConfig.getConfig("jersey.prefixes")


### PR DESCRIPTION
# Description

Ensures the health check gets passed on instead of being service as HTML.

