### PR TITLE
fix/636-json-editor

### DIFF
--- a/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/json/edit_json_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/json/edit_json_value_container.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:mrapi/api.dart';
 import 'package:open_admin_app/utils/utils.dart';
@@ -36,7 +38,7 @@ class _EditJsonValueContainerState extends State<EditJsonValueContainer> {
     final valueSource = widget.rolloutStrategy != null
         ? widget.rolloutStrategy!.value
         : widget.strBloc.featureValue.valueJson;
-    tec.text = (valueSource ?? '').toString();
+    tec.text = (const JsonEncoder.withIndent('  ').convert(json.decode(valueSource)) ?? '').toString();
   }
 
   @override
@@ -125,7 +127,7 @@ class _EditJsonValueContainerState extends State<EditJsonValueContainer> {
   }
 
   void _valueChanged() {
-    final replacementValue = tec.text.isEmpty ? null : tec.text.trim();
+    final replacementValue = tec.text.isEmpty ? null : json.encode(json.decode(tec.text.trim())).toString();
     if (widget.rolloutStrategy != null) {
       widget.rolloutStrategy!.value = replacementValue;
       widget.strBloc.updateStrategy();

--- a/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/json/edit_json_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/table-expanded-view/json/edit_json_value_container.dart
@@ -38,7 +38,17 @@ class _EditJsonValueContainerState extends State<EditJsonValueContainer> {
     final valueSource = widget.rolloutStrategy != null
         ? widget.rolloutStrategy!.value
         : widget.strBloc.featureValue.valueJson;
-    tec.text = (const JsonEncoder.withIndent('  ').convert(json.decode(valueSource)) ?? '').toString();
+    if (valueSource != null) {
+      try {
+        tec.text = const JsonEncoder.withIndent('  ')
+            .convert(json.decode(valueSource))
+            .toString();
+      } catch (e) {
+        tec.text = valueSource.toString();
+      }
+    } else {
+      tec.text = '';
+    }
   }
 
   @override
@@ -127,7 +137,9 @@ class _EditJsonValueContainerState extends State<EditJsonValueContainer> {
   }
 
   void _valueChanged() {
-    final replacementValue = tec.text.isEmpty ? null : json.encode(json.decode(tec.text.trim())).toString();
+    final replacementValue = tec.text.isEmpty
+        ? null
+        : json.encode(json.decode(tec.text.trim())).toString();
     if (widget.rolloutStrategy != null) {
       widget.rolloutStrategy!.value = replacementValue;
       widget.strBloc.updateStrategy();


### PR DESCRIPTION
# Description

Ensure when JSON feature values are set, they do not contain characters like \n due to formatting

Fixes #636

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)