### PR TITLE
Create cucumber steps for featurehub-examples repository applications

### DIFF
--- a/adks/e2e-sdk/.gitignore
+++ b/adks/e2e-sdk/.gitignore
@@ -1,3 +1,4 @@
 app/apis
 logs
 node_modules
+./example-test.sh

--- a/adks/e2e-sdk/README.adoc
+++ b/adks/e2e-sdk/README.adoc
@@ -9,3 +9,10 @@ behaviour of the SDK itself as that would require testing each SDK for the entir
 Create a nodejs run config, this folder as the working directory, application
 parameters should be `--require-module ts-node/register --require "app/**/*.ts"`
 and Javascript file is `node_modules/.bin/cucumber-js`
+
+== Setting up for the FeatureHub-Examples project
+
+Running the `create-demo.sh` file will cause only those tests to run against the system that are necessary to
+create the right features and then output the configuration necessary to stdout. These environment variables
+can be copied into the appropriate run.sh files in the example directories.
+

--- a/adks/e2e-sdk/app/steps/flag_steps.ts
+++ b/adks/e2e-sdk/app/steps/flag_steps.ts
@@ -18,6 +18,19 @@ Given(/^There is a new feature flag$/, async function () {
   this.feature = fCreate.data[0];
 });
 
+Given(/^There is a feature flag with the key (.*)$/, async function (key: string) {
+  const fCreate = await this.featureApi.createFeaturesForApplication(this.application.id, new Feature({
+    name: key,
+    key: key,
+    valueType: FeatureValueType.Boolean
+  }));
+  expect(fCreate.status).to.eq(200);
+  const feature = fCreate.data.find(f => f.key == key);
+  expect(feature).to.not.be.undefined;
+
+  this.feature = feature;
+});
+
 Then(/^the feature flag is (locked|unlocked) and (off|on)$/, async function (lockedStatus, value) {
   await waitForExpect(() => {
     expect(this.repository.readyness).to.eq(Readyness.Ready);

--- a/adks/e2e-sdk/app/steps/general_steps.ts
+++ b/adks/e2e-sdk/app/steps/general_steps.ts
@@ -1,10 +1,8 @@
 import { Given, Then, When } from '@cucumber/cucumber';
-import { Feature, FeatureValueType, RolloutStrategy, RolloutStrategyAttribute } from 'featurehub-javascript-admin-sdk';
-import { makeid } from '../support/random';
-import { expect } from 'chai';
-import waitForExpect from 'wait-for-expect';
-import { ClientContext, FeatureHubRepository, FeatureStateHolder, Readyness } from 'featurehub-javascript-node-sdk';
+import { FeatureValueType, RolloutStrategy, RolloutStrategyAttribute } from 'featurehub-javascript-admin-sdk';
+import { ClientContext } from 'featurehub-javascript-node-sdk';
 import DataTable from '@cucumber/cucumber/lib/models/data_table';
+import * as fs from 'fs';
 
 Then(/^I add a strategy (.*) with (.*) percentage and value (.*)$/, async function (strategyName, percentage, value, table: DataTable) {
   const fValue = await this.getFeature();
@@ -68,4 +66,10 @@ Then(/^I clear the context$/, function () {
 
 Given(/^I connect to the Edge server using (sse-client-eval|poll-client-eval|poll-server-eval)$/, function() {
 
+});
+
+Then('I write out a feature-examples config file', function() {
+  const buf = `#!/bin/sh\nexport FEATUREHUB_CLIENT_API_KEY=${this.sdkUrlClientEval}\nexport FEATUREHUB_EDGE_URL=${this.featureUrl}\n`;
+
+  fs.writeFileSync('./example-test.sh', buf);
 });

--- a/adks/e2e-sdk/app/steps/setup.ts
+++ b/adks/e2e-sdk/app/steps/setup.ts
@@ -71,6 +71,8 @@ Given(/^I connect to the feature server$/, function () {
     expect(found).to.be.true;
     logger.info('Successfully completed poll');
     const edge = new EdgeFeatureHubConfig(world.featureUrl, serviceAccountPerm.sdkUrlClientEval);
+    this.sdkUrlClientEval = serviceAccountPerm.sdkUrlClientEval;
+    this.sdkUrlServerEval = serviceAccountPerm.sdkUrlServerEval;
     //edge.edgeServiceProvider((repo, config) => new FeatureHubPollingClient(repo, config, 200));
     edge.init();
     world.edgeServer = edge;

--- a/adks/e2e-sdk/app/support/world.ts
+++ b/adks/e2e-sdk/app/support/world.ts
@@ -48,6 +48,9 @@ export class SdkWorld extends World {
   public readonly serviceAccountApi: ServiceAccountServiceApi;
   public readonly featureValueApi: EnvironmentFeatureServiceApi;
   private _clientContext: ClientContext;
+  public sdkUrlClientEval: string;
+  public sdkUrlServerEval: string;
+
 
   constructor(props) {
     super(props);

--- a/adks/e2e-sdk/create-demo.sh
+++ b/adks/e2e-sdk/create-demo.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+npm run test -- --tags '@demoexamples'
+cat example-test.sh

--- a/adks/e2e-sdk/features/examples.feature
+++ b/adks/e2e-sdk/features/examples.feature
@@ -1,0 +1,16 @@
+Feature: I setup the example features to be able to run the examples
+
+  Background:
+    Given I create a new portfolio
+    And I create an application
+    And I create a service account and full permissions based on the application environments
+    And I connect to the feature server
+
+  @demoexamples
+  Scenario: I setup the main scenario
+    When There is a feature flag with the key FEATURE_TITLE_TO_UPPERCASE
+    And I set the feature flag to unlocked and on
+    And There is a string feature named FEATURE_STRING
+    And There is a number feature named FEATURE_NUMBER
+    And There is a json feature named FEATURE_JSON
+    Then I write out a feature-examples config file


### PR DESCRIPTION
The example applications all require a basic setup, this change
allows the test to be run and a file will be output that will
be all ready to go.
