### PR TITLE
[Typescript SDK] Bug fix: Error when a new feature arrives and Catch&Release mode is active

### DIFF
--- a/sdks/typescript/featurehub-javascript-client-sdk/README.md
+++ b/sdks/typescript/featurehub-javascript-client-sdk/README.md
@@ -15,6 +15,8 @@ We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com
 ## Changelog
 
 ### featurehub-javascript-client-sdk
+#### 1.0.10
+- Fix a bug related to Catch & Release mode [GitHub issue](https://github.com/featurehub-io/featurehub/issues/648)
 #### 1.0.9
 - Enabled e-tag support 
 #### 1.0.8
@@ -40,6 +42,8 @@ We have deprecated [FeatureHub Eventsource Javascript SDK](https://www.npmjs.com
 Angular & Vue to use this library. 
 
 ### featurehub-javascript-node-sdk
+#### 1.0.10
+- Fix a bug related to Catch & Release mode [GitHub issue](https://github.com/featurehub-io/featurehub/issues/648)
 #### 1.0.9
 - Enabled e-tag support
 #### 1.0.8

--- a/sdks/typescript/featurehub-javascript-client-sdk/app/client_feature_repository.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/app/client_feature_repository.ts
@@ -246,7 +246,7 @@ export class ClientFeatureRepository implements InternalFeatureRepository {
     if (features && features.length > 0) {
       features.forEach((f) => {
         const existingFeature = this.features.get(f.key);
-        if (existingFeature === null || (existingFeature.getKey()
+        if (!existingFeature || (existingFeature.getKey()
           && f.version > existingFeature.getFeatureState().version)) {
           const fs = this._catchReleaseStates.get(f.id);
           if (fs == null) {

--- a/sdks/typescript/featurehub-javascript-client-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-client-sdk/package.json
@@ -50,10 +50,10 @@
   "devDependencies": {
     "@fluffy-spoon/substitute": "^1.208.0",
     "@types/chai": "^4.2.18",
-    "@types/mocha": "^8.0.2",
+    "@types/mocha": "^9.0.0",
     "@types/node": "^12.20.12",
     "chai": "^4.2.0",
-    "mocha": "^8.4.0",
+    "mocha": "^9.1.4",
     "nyc": "^15.1.0",
     "ts-node": "8.10.2",
     "eslint": "^7.16.0",
@@ -61,7 +61,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "@typescript-eslint/typescript-estree": "^4.11.0",
-    "typescript": "3.9.7"
+    "typescript": "4.5.4"
   },
   "dependencies": {
     "@types/murmurhash": "^2.0.0",

--- a/sdks/typescript/featurehub-javascript-client-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
   "author": "info@featurehub.io",
   "sideEffects": false,

--- a/sdks/typescript/featurehub-javascript-client-sdk/test/repository_catch_release_spec.ts
+++ b/sdks/typescript/featurehub-javascript-client-sdk/test/repository_catch_release_spec.ts
@@ -1,9 +1,4 @@
-import {
-  ClientFeatureRepository, FeatureHubRepository,
-  FeatureState,
-  FeatureValueType,
-  SSEResultState
-} from '../app';
+import { ClientFeatureRepository, FeatureHubRepository, FeatureState, FeatureValueType, SSEResultState } from '../app';
 import { expect } from 'chai';
 import { InternalFeatureRepository } from '../app/internal_feature_repository';
 
@@ -37,19 +32,24 @@ describe('Catch and release should hold and then release feature changes', () =>
 
     expect(postNewTrigger).to.eq(2);
     expect(bananaTrigger).to.eq(1);
+
+    internalRepo.notify(SSEResultState.Feature, new FeatureState({ id: '3', key: 'apricot', version: 1, type: FeatureValueType.Boolean, value: false }));
+    expect(repo.feature('apricot').getBoolean()).to.be.undefined;
+
     expect(repo.getFeatureState('banana').getBoolean()).to.eq(true);
     await repo.release();
     expect(repo.catchAndReleaseMode).to.eq(true);
-    expect(postNewTrigger).to.eq(2);
+    expect(postNewTrigger).to.eq(3);
     expect(bananaTrigger).to.eq(2);
     expect(repo.getFeatureState('banana').getBoolean()).to.eq(false);
+    expect(repo.getFeatureState('apricot').getBoolean()).to.eq(false);
     // notify with new state, should still hold
     const features2 = [
       new FeatureState({ id: '1', key: 'banana', version: 4, type: FeatureValueType.Boolean, value: true }),
     ];
 
     internalRepo.notify(SSEResultState.Features, features2);
-    expect(postNewTrigger).to.eq(3);
+    expect(postNewTrigger).to.eq(4);
     expect(bananaTrigger).to.eq(2);
     expect(repo.getFlag('banana')).to.eq(false);
     expect(repo.getFeatureState('banana').getVersion()).to.eq(3);

--- a/sdks/typescript/featurehub-javascript-node-sdk/package.json
+++ b/sdks/typescript/featurehub-javascript-node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-node-sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "featurehub sdk intended for use by nodejs.",
   "author": "info@featurehub.io",
   "main": "dist/index.js",


### PR DESCRIPTION
When a new feature arrives, the map returns undefined not null, so the
existing code throws an error. A test was added to detect this, and then
the problem fixed.

fixes #648
