### PR TITLE
Prevent web traffic on metric ports

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
@@ -57,7 +57,7 @@ class MetricsHealthRegistration {
             })
 
             val port = FallbackPropertyConfig.getConfig(monitorPortName)!!.toInt()
-            FeatureHubJerseyHost(resourceConfig).start(port)
+            FeatureHubJerseyHost(resourceConfig).disallowWebHosting().start(port)
 
             log.info("metric/health endpoint now active on port {}", port)
           }


### PR DESCRIPTION
This change prevents the metric ports from being able to serve
html/js traffic as they will do currently (as they are picking
up the config on party-server/ish/mr).

Fixes #640

