### PR TITLE
[Bugfix] etag not in OPTIONS header, prevented browser SDK from using etag

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/rest/CorsFilter.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/rest/CorsFilter.kt
@@ -1,0 +1,82 @@
+package io.featurehub.rest
+
+import cd.connect.app.config.ConfigKey
+import cd.connect.app.config.DeclaredConfigResolver
+import jakarta.ws.rs.container.*
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.Provider
+import java.io.IOException
+import java.util.*
+
+@Provider
+@PreMatching
+class CorsFilter : ContainerRequestFilter, ContainerResponseFilter {
+  @ConfigKey("jersey.cors.headers")
+  var allowedHeaders: List<String> = listOf()
+
+  private var headers: String? = null
+
+  init {
+    DeclaredConfigResolver.resolve(this)
+    val actualHeaders: Set<String> = HashSet(allowedHeaders.map { it.lowercase() })
+      .plus("baggage").plus("if-none-match").plus("etag").plus("x-requested-with")
+      .plus("authorization").plus("content-type").plus("accept-version").plus("content-md5")
+      .plus("csrf-token").plus("x-ijt").plus("cache-control").plus("x-featurehub")
+
+    headers = java.lang.String.join(",", actualHeaders)
+  }
+
+  /**
+   * Method for ContainerRequestFilter.
+   */
+  @Throws(IOException::class)
+  override fun filter(request: ContainerRequestContext) {
+
+    // If it's a preflight request, we abort the request with
+    // a 200 status, and the CORS headers are added in the
+    // response filter method below.
+    if (isPreflightRequest(request)) {
+      request.abortWith(Response.ok().build())
+      return
+    }
+  }
+
+  /**
+   * A preflight request is an OPTIONS request
+   * with an Origin header.
+   */
+  private fun isPreflightRequest(request: ContainerRequestContext): Boolean {
+    return (request.getHeaderString("Origin") != null
+      && request.method.equals("OPTIONS", ignoreCase = true))
+  }
+
+  /**
+   * Method for ContainerResponseFilter.
+   */
+  override fun filter(request: ContainerRequestContext, response: ContainerResponseContext) {
+
+    // if there is no Origin header, then it is not a
+    // cross origin request. We don't do anything.
+    if (request.getHeaderString("Origin") == null) {
+      return
+    }
+
+    // If it is a preflight request, then we add all
+    // the CORS headers here.
+    if (isPreflightRequest(request)) {
+      response.headers.add("Access-Control-Allow-Credentials", "true")
+      response.headers.add(
+        "Access-Control-Allow-Methods",
+        "GET, POST, PUT, DELETE, OPTIONS, HEAD"
+      )
+      response.headers.addAll("Access-Control-Allow-Headers", headers)
+    }
+
+    // Cross origin requests can be either simple requests
+    // or preflight request. We need to add this header
+    // to both type of requests. Only preflight requests
+    // need the previously added headers.
+    response.headers.add("Access-Control-Expose-Headers", "etag")
+    response.headers.add("Access-Control-Allow-Origin", "*")
+  }
+}

--- a/backend/common-web/src/test/groovy/io/featurehub/rest/CorsFilterSpec.groovy
+++ b/backend/common-web/src/test/groovy/io/featurehub/rest/CorsFilterSpec.groovy
@@ -1,0 +1,80 @@
+package io.featurehub.rest
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.core.MultivaluedMap
+import jakarta.ws.rs.core.Response
+import org.spockframework.gentyref.TypeToken
+import spock.lang.Specification
+
+class CorsFilterSpec extends Specification {
+  CorsFilter filter
+  ContainerResponseContext response
+  ContainerRequestContext request
+
+  def setup() {
+    response = Mock(ContainerResponseContext)
+    request = Mock(ContainerRequestContext)
+
+    filter = new CorsFilter()
+  }
+
+  def "when i request an OPTIONS request, the filter catches it and returns ok"() {
+    when:
+      filter.filter(request)
+    then:
+      1 * request.getHeaderString("Origin") >> "origin"
+      1 * request.getMethod() >> "OPTIONS"
+      1 * request.abortWith({ Response r -> r.status == 200 })
+      0 * _
+  }
+
+  def "when it is not an options request, the filter ignores it"() {
+    when:
+      filter.filter(request)
+    then:
+      1 * request.getHeaderString("Origin") >> null
+      0 * _
+  }
+
+  def "if it is not a preflight request, we do not get any response"() {
+    when:
+      filter.filter(request, response)
+    then:
+      1 * request.getHeaderString("Origin") >> null
+      0 * _
+  }
+
+  def "If it is an origin request but not preflight, we should get access control headers back"() {
+    given: "i have headers"
+      def headers = Mock(type: new TypeToken<MultivaluedMap<String, Object>>(){}.type) as MultivaluedMap<String, Object>
+    when:
+      filter.filter(request, response)
+    then:
+      2 * request.getHeaderString("Origin") >> "Origin"
+      1 * request.getMethod() >> null
+      2 * response.headers >> headers
+      1 * headers.add("Access-Control-Expose-Headers", "etag")
+      1 * headers.add("Access-Control-Allow-Origin", "*")
+      0 * _
+  }
+
+  // this is a fragile test and i don't like it
+  def "If it is a preflight request, we should get a full set of headers back"() {
+    given: "i have headers"
+      def headers = Mock(type: new TypeToken<MultivaluedMap<String, Object>>(){}.type) as MultivaluedMap<String, Object>
+    when:
+      filter.filter(request, response)
+    then:
+      2 * request.getHeaderString("Origin") >> "Origin"
+      1 * request.getMethod() >> "OPTIONS"
+      5 * response.headers >> headers
+      1 * headers.add("Access-Control-Expose-Headers", "etag")
+      1 * headers.add("Access-Control-Allow-Origin", "*")
+      1 * headers.add("Access-Control-Allow-Credentials", "true")
+      1 * headers.add("Access-Control-Allow-Methods",
+        "GET, POST, PUT, DELETE, OPTIONS, HEAD")
+      1 * headers.addAll("Access-Control-Allow-Headers", { Object[] val -> val.length == 1 && val[0].toString().contains("etag") })
+      0 * _
+  }
+}

--- a/backend/dacha/src/main/kotlin/io/featurehub/dacha/resource/DachaApiKeyResource.kt
+++ b/backend/dacha/src/main/kotlin/io/featurehub/dacha/resource/DachaApiKeyResource.kt
@@ -9,6 +9,7 @@ import io.featurehub.dacha.model.DachaPermissionResponse
 import jakarta.inject.Inject
 import jakarta.ws.rs.InternalServerErrorException
 import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
 import org.glassfish.hk2.api.Immediate
 import java.util.*
@@ -26,7 +27,7 @@ class DachaApiKeyResource @Inject constructor(private val cache: InternalCache) 
     // in a proper load balance solution, this won't happen, it can happen in Party Server so we need to show the correct error
 
     if (!cache.cacheComplete()) {
-      throw InternalServerErrorException(Response.status(503).header("Retry-After", retryAfter).entity("The server is not ready yet").build())
+      throw WebApplicationException(Response.status(503).header("Retry-After", retryAfter).entity("The server is not ready yet").build())
     }
 
     val collection = cache.getFeaturesByEnvironmentAndServiceAccount(eId, serviceAccountKey) ?: throw NotFoundException()

--- a/backend/edge-full/src/main/java/io/featurehub/edge/Application.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/Application.java
@@ -1,7 +1,6 @@
 package io.featurehub.edge;
 
 import cd.connect.app.config.DeclaredConfigResolver;
-import cd.connect.jersey.common.CorsFilter;
 import cd.connect.lifecycle.ApplicationLifecycleManager;
 import cd.connect.lifecycle.LifecycleStatus;
 import io.featurehub.dacha.api.DachaClientFeature;
@@ -9,6 +8,7 @@ import io.featurehub.dacha.api.DachaClientServiceRegistry;
 import io.featurehub.health.MetricsHealthRegistration;
 import io.featurehub.jersey.FeatureHubJerseyHost;
 import io.featurehub.publish.NATSFeature;
+import io.featurehub.rest.CorsFilter;
 import io.featurehub.utils.FallbackPropertyConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.spi.Container;

--- a/backend/edge-rest/src/main/kotlin/io/featurehub/edge/Application.kt
+++ b/backend/edge-rest/src/main/kotlin/io/featurehub/edge/Application.kt
@@ -1,13 +1,13 @@
 package io.featurehub.edge
 
 import cd.connect.app.config.DeclaredConfigResolver
-import cd.connect.jersey.common.CorsFilter
 import cd.connect.lifecycle.ApplicationLifecycleManager
 import cd.connect.lifecycle.LifecycleStatus
 import io.featurehub.app.db.utils.CommonDbFeature
 import io.featurehub.health.MetricsHealthRegistration.Companion.registerMetrics
 import io.featurehub.jersey.FeatureHubJerseyHost
 import io.featurehub.lifecycle.TelemetryFeature
+import io.featurehub.rest.CorsFilter
 import io.featurehub.rest.Info
 import org.glassfish.jersey.server.ResourceConfig
 import org.slf4j.Logger

--- a/backend/mr/src/main/java/io/featurehub/mr/ManagementRepositoryFeature.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/ManagementRepositoryFeature.java
@@ -1,6 +1,5 @@
 package io.featurehub.mr;
 
-import cd.connect.jersey.common.CorsFilter;
 import io.featurehub.app.db.utils.CommonDbFeature;
 import io.featurehub.db.publish.CacheSource;
 import io.featurehub.db.publish.MRPublishModule;
@@ -51,6 +50,7 @@ import io.featurehub.mr.resources.UserStateResource;
 import io.featurehub.mr.resources.oauth2.OAuth2MRAdapter;
 import io.featurehub.mr.utils.ApplicationUtils;
 import io.featurehub.mr.utils.PortfolioUtils;
+import io.featurehub.rest.CorsFilter;
 import io.featurehub.web.security.oauth.AuthProvider;
 import io.featurehub.web.security.oauth.BlankProvider;
 import io.featurehub.web.security.oauth.OAuthAdapter;

--- a/backend/party-server-ish/src/main/kotlin/io.featurehub.party/Application.kt
+++ b/backend/party-server-ish/src/main/kotlin/io.featurehub.party/Application.kt
@@ -2,13 +2,13 @@ package io.featurehub.party
 
 import cd.connect.app.config.ConfigKey
 import cd.connect.app.config.DeclaredConfigResolver
-import cd.connect.jersey.common.CorsFilter
 import io.featurehub.edge.EdgeGetFeature
 import io.featurehub.health.MetricsHealthRegistration.Companion.registerMetrics
 import io.featurehub.jersey.FeatureHubJerseyHost
 import io.featurehub.lifecycle.TelemetryFeature
 import io.featurehub.mr.ManagementRepositoryFeature
 import io.featurehub.publish.ChannelConstants
+import io.featurehub.rest.CorsFilter
 import io.featurehub.rest.Info
 import io.featurehub.web.security.oauth.OAuth2Feature
 import org.glassfish.jersey.server.ResourceConfig

--- a/backend/party-server/src/main/kotlin/io.featurehub.party/Application.kt
+++ b/backend/party-server/src/main/kotlin/io.featurehub.party/Application.kt
@@ -2,7 +2,6 @@ package io.featurehub.party
 
 import cd.connect.app.config.ConfigKey
 import cd.connect.app.config.DeclaredConfigResolver
-import cd.connect.jersey.common.CorsFilter
 import io.featurehub.dacha.DachaFeature
 import io.featurehub.dacha.api.DachaClientFeature
 import io.featurehub.dacha.api.DachaClientServiceRegistry
@@ -15,6 +14,7 @@ import io.featurehub.lifecycle.TelemetryFeature
 import io.featurehub.mr.ManagementRepositoryFeature
 import io.featurehub.publish.ChannelConstants
 import io.featurehub.publish.NATSFeature
+import io.featurehub.rest.CorsFilter
 import io.featurehub.rest.Info.Companion.APPLICATION_NAME_PROPERTY
 import io.featurehub.web.security.oauth.OAuth2Feature
 import org.glassfish.jersey.server.ResourceConfig


### PR DESCRIPTION
The etag field was not included as an extra permissible header.
It should have been exposed as a Access-Control-Expose-Headers
for the browser SDK to be able to see it and thus allow the
browser to send back the if-none-match header.

Fixes #661 

