### PR TITLE
[Feature] Add in extra options for logging information (user, environment, web-headers)

### DIFF
--- a/backend/common-web/src/main/java/io/featurehub/jersey/config/CommonConfiguration.java
+++ b/backend/common-web/src/main/java/io/featurehub/jersey/config/CommonConfiguration.java
@@ -2,6 +2,9 @@ package io.featurehub.jersey.config;
 
 import cd.connect.openapi.support.OpenApiEnumProvider;
 import io.featurehub.jersey.OffsetDateTimeQueryProvider;
+import io.featurehub.rest.WebHeaderAuditLogger;
+import io.featurehub.utils.FallbackPropertyConfig;
+import io.featurehub.utils.FeatureHubConfig;
 import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.FeatureContext;
 import org.glassfish.jersey.CommonProperties;
@@ -28,6 +31,12 @@ public class CommonConfiguration implements Feature {
     config.register(LocalExceptionMapper.class);
     config.register(OffsetDateTimeQueryProvider.class);
     config.register(OpenApiEnumProvider.class);
+
+    // only wire this up if the config is actually there
+    if (FallbackPropertyConfig.Companion.getConfig(WebHeaderAuditLogger.Companion.getCONFIG_KEY())
+        != null) {
+      config.register(WebHeaderAuditLogger.class);
+    }
 
     return true;
   }

--- a/backend/common-web/src/main/kotlin/io/featurehub/rest/WebHeaderAuditLogger.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/rest/WebHeaderAuditLogger.kt
@@ -1,0 +1,45 @@
+package io.featurehub.rest
+
+import cd.connect.app.config.ConfigKey
+import cd.connect.app.config.DeclaredConfigResolver
+import cd.connect.context.ConnectContext
+import jakarta.ws.rs.container.*
+import jakarta.ws.rs.ext.Provider
+
+/**
+ * We should only be wired if there is a setting at all for tracking web config, otherwise it is a waste of
+ * resources to intercept. Do NOT wire if the config-key doesn't exist
+ */
+@Provider
+@PreMatching
+class WebHeaderAuditLogger : ContainerRequestFilter, ContainerResponseFilter {
+  @ConfigKey("audit.logging.web.header-fields")
+  var auditHeaders: List<String>? = null
+
+  companion object {
+    val CONFIG_KEY = "audit.logging.web.header-fields"
+    val WEBHEADERS = "http-headers"
+  }
+
+  init {
+    DeclaredConfigResolver.resolve(this)
+  }
+
+  override fun filter(requestContext: ContainerRequestContext) {
+    val headers = mutableMapOf<String, String>()
+
+    auditHeaders?.forEach {header ->
+      requestContext.getHeaderString(header)?.let {
+        headers.put(header, it)
+      }
+    }
+
+    if (headers.isNotEmpty()) {
+      ConnectContext.set(WEBHEADERS, headers)
+    }
+  }
+
+  override fun filter(requestContext: ContainerRequestContext?, responseContext: ContainerResponseContext?) {
+    ConnectContext.remove(WEBHEADERS)
+  }
+}

--- a/backend/common-web/src/test/groovy/io/featurehub/rest/WebHeaderAuditLoggerSpec.groovy
+++ b/backend/common-web/src/test/groovy/io/featurehub/rest/WebHeaderAuditLoggerSpec.groovy
@@ -1,0 +1,30 @@
+package io.featurehub.rest
+
+import cd.connect.context.ConnectContext
+import jakarta.ws.rs.container.ContainerRequestContext
+import spock.lang.Specification
+
+class WebHeaderAuditLoggerSpec extends Specification {
+  def cleanup() {
+    ConnectContext.clear()
+    System.clearProperty(WebHeaderAuditLogger.@Companion.CONFIG_KEY)
+  }
+
+  def "when i configure headers, it will pick up what was asked for and ignore what wasn't"() {
+    given: 'i have some headers'
+      System.setProperty(WebHeaderAuditLogger.@Companion.CONFIG_KEY, "X-Forwarded-For,X-Forwarded-Proto,X-Forwarded-Port")
+    and: 'i have an audit logger'
+      def auditLogger = new WebHeaderAuditLogger()
+    and: 'i have mocked my request'
+      def request = Mock(ContainerRequestContext)
+    when:
+      auditLogger.filter(request)
+    then:
+      1 * request.getHeaderString('X-Forwarded-For') >> 'http://chipmonnks-inc.io'
+      1 * request.getHeaderString('X-Forwarded-Proto') >> 'http'
+      1 * request.getHeaderString('X-Forwarded-Port') >> null
+      0 * _  // no other mock interactions
+      ConnectContext.get(WebHeaderAuditLogger.@Companion.WEBHEADERS, Map<String, String>) ==
+        ['X-Forwarded-For': 'http://chipmonnks-inc.io', 'X-Forwarded-Proto':'http']
+  }
+}

--- a/backend/composite-app/pom.xml
+++ b/backend/composite-app/pom.xml
@@ -128,21 +128,7 @@
     <dependency>
       <groupId>cd.connect.common</groupId>
       <artifactId>connect-env-logging</artifactId>
-      <version>1.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>cd.connect.common</groupId>
-          <artifactId>connect-java-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>cd.connect.composites.java</groupId>
-          <artifactId>connect-composite-jackson</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>cd.connect.composites.java</groupId>
-          <artifactId>connect-composite-test</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.2</version>
     </dependency>
 
     <dependency>

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/DBLoginSession.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/DBLoginSession.java
@@ -1,29 +1,32 @@
 package io.featurehub.db.api;
 
 import io.featurehub.mr.model.Person;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 
 public class DBLoginSession {
   private final Person person;
   private final String token;
   private final Instant lastSeen;
 
-  public DBLoginSession(Person person, String token, Instant lastSeen) {
+  public DBLoginSession(@NotNull Person person, @NotNull String token, @NotNull Instant lastSeen) {
     this.person = person;
     this.token = token;
     this.lastSeen = lastSeen;
   }
 
+  @NotNull
   public Person getPerson() {
     return person;
   }
 
+  @NotNull
   public String getToken() {
     return token;
   }
 
+  @NotNull
   public Instant getLastSeen() {
     return lastSeen;
   }

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/SessionApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/SessionApi.kt
@@ -3,6 +3,10 @@ package io.featurehub.db.api
 interface SessionApi {
   fun findSession(token: String): DBLoginSession?
 
+  /**
+   * Creates the session that has been externally created. The token should be randomised and
+   * the person provided.
+   */
   fun createSession(session: DBLoginSession): DBLoginSession?
 
   fun invalidateSession(sessionToken: String)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
@@ -1,6 +1,6 @@
 package io.featurehub.db.services
 
-
+import io.featurehub.db.api.DBLoginSession
 import io.featurehub.db.api.Opts
 import io.featurehub.db.publish.CacheSource
 import io.featurehub.mr.model.Application
@@ -8,8 +8,11 @@ import io.featurehub.mr.model.ApplicationGroupRole
 import io.featurehub.mr.model.ApplicationRoleType
 import io.featurehub.mr.model.Group
 import io.featurehub.mr.model.Person
+import io.featurehub.mr.model.PersonId
 import io.featurehub.mr.model.Portfolio
 import spock.lang.Shared
+
+import java.time.LocalDateTime
 
 class AuthenticationSpec extends BaseSpec {
   @Shared AuthenticationSqlApi auth
@@ -216,4 +219,71 @@ class AuthenticationSpec extends BaseSpec {
     then: "i have the application role permission to the portfolio"
       user.groups.find({it.applicationRoles.find({ar -> ar.roles.contains(ApplicationRoleType.FEATURE_EDIT) && ar.applicationId == app1.id})})
   }
+
+  def "We can create a session for a person and then find their session by token"() {
+    given: "i register"
+      def email = 'portman27@mailinator.com'
+      personApi.create(email, "Portman27",superuser)
+      Person p2 = auth.register("william", email, "hooray", null)
+    and: 'a defined session'
+      def originalSession = new DBLoginSession(p2, "token", LocalDateTime.now())
+    when: 'i create the session'
+      def session = auth.createSession(originalSession)
+    and: "then find the session"
+      def foundSession = auth.findSession(originalSession.token)
+    and: "then invalidate the session"
+      auth.invalidateSession("token")
+      def invalidSession = auth.findSession(originalSession.token)
+    then:
+      session == originalSession
+      foundSession.token == originalSession.token
+      foundSession.lastSeen == originalSession.lastSeen
+      foundSession.person.id.id == p2.id.id
+      foundSession.person.email == p2.email
+      invalidSession == null
+  }
+
+  def "I can't create a session with missing person details"() {
+    when: 'i create a session with no token'
+      auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: null)), "tok", LocalDateTime.now()))
+    then:
+      thrown IllegalArgumentException
+  }
+
+  def "an invalid person will create a null session"() {
+    when: 'i create a session with no token'
+      def session = auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: UUID.randomUUID())), "tok", LocalDateTime.now()))
+    then:
+      session == null
+  }
+
+  def "when i try and reset an expired token that has no token i get no result"() {
+    given: "i register"
+      def email = 'portman28@mailinator.com'
+      personApi.create(email, "Portman28",superuser)
+    and: "i register them so their token goes away"
+      Person p2 = auth.register("william", email, "hooray", null)
+    when: "i try and reset the token"
+      def reset = auth.resetExpiredRegistrationToken(email)
+    then:
+      reset == null
+  }
+
+  def "when i try and reset an expired token that has a token we get a new token"() {
+    given: "i register"
+      def email = 'portman28@mailinator.com'
+      def token = personApi.create(email, "Portman28",superuser)
+    when: "i try and reset the token"
+      def reset = auth.resetExpiredRegistrationToken(email)
+    then:
+      reset != token.token
+  }
+
+  def "when i try and reset an expired token for someone that doesn't exist, i get no result"() {
+    when: 'i try and reset the token'
+      def reset = auth.resetExpiredRegistrationToken('fred@choppa-chip.com')
+    then:
+      reset == null
+  }
+
 }

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
@@ -12,6 +12,7 @@ import io.featurehub.mr.model.PersonId
 import io.featurehub.mr.model.Portfolio
 import spock.lang.Shared
 
+import java.time.Instant
 import java.time.LocalDateTime
 
 class AuthenticationSpec extends BaseSpec {
@@ -226,7 +227,7 @@ class AuthenticationSpec extends BaseSpec {
       personApi.create(email, "Portman27",superuser)
       Person p2 = auth.register("william", email, "hooray", null)
     and: 'a defined session'
-      def originalSession = new DBLoginSession(p2, "token", LocalDateTime.now())
+      def originalSession = new DBLoginSession(p2, "token", Instant.now())
     when: 'i create the session'
       def session = auth.createSession(originalSession)
     and: "then find the session"
@@ -245,14 +246,14 @@ class AuthenticationSpec extends BaseSpec {
 
   def "I can't create a session with missing person details"() {
     when: 'i create a session with no token'
-      auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: null)), "tok", LocalDateTime.now()))
+      auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: null)), "tok", Instant.now()))
     then:
       thrown IllegalArgumentException
   }
 
   def "an invalid person will create a null session"() {
     when: 'i create a session with no token'
-      def session = auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: UUID.randomUUID())), "tok", LocalDateTime.now()))
+      def session = auth.createSession(new DBLoginSession(new Person(id: new PersonId(id: UUID.randomUUID())), "tok", Instant.now()))
     then:
       session == null
   }
@@ -271,8 +272,8 @@ class AuthenticationSpec extends BaseSpec {
 
   def "when i try and reset an expired token that has a token we get a new token"() {
     given: "i register"
-      def email = 'portman28@mailinator.com'
-      def token = personApi.create(email, "Portman28",superuser)
+      def email = 'portman29@mailinator.com'
+      def token = personApi.create(email, "Portman29",superuser)
     when: "i try and reset the token"
       def reset = auth.resetExpiredRegistrationToken(email)
     then:

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
@@ -111,8 +111,8 @@ class FeatureSpec extends BaseSpec {
 
   def "i can create the same named feature toggle in two different applications"() {
     when:
-      def app1Features = appApi.createApplicationFeature(appId, new Feature().key("FEATURE_THREE"), superPerson)
-      def app2Features = appApi.createApplicationFeature(app2Id, new Feature().key("FEATURE_THREE"), superPerson)
+      def app1Features = appApi.createApplicationFeature(appId, new Feature().name("x").key("FEATURE_THREE"), superPerson)
+      def app2Features = appApi.createApplicationFeature(app2Id, new Feature().name("y").key("FEATURE_THREE"), superPerson)
     then:
       app1Features.find({it -> it.key == 'FEATURE_THREE'}) != null
       app2Features.find({it -> it.key == 'FEATURE_THREE'}) != null
@@ -120,7 +120,7 @@ class FeatureSpec extends BaseSpec {
 
   def "if i try and update without passing the version i am updating, i will get a optimistic locking exception"() {
     when:
-      appApi.createApplicationFeature(appId, new Feature().key("FEATURE_UPD_LOCKX"), superPerson)
+      appApi.createApplicationFeature(appId, new Feature().name('x').key("FEATURE_UPD_LOCKX"), superPerson)
       appApi.updateApplicationFeature(appId, "FEATURE_UPD_LOCKX", new Feature().key("FEATURE_UPD_LOCKX"))
     then:
       thrown OptimisticLockingException
@@ -128,7 +128,7 @@ class FeatureSpec extends BaseSpec {
 
   def "i can update an existing feature toggle to a new name"() {
     when:
-      def app1Features = appApi.createApplicationFeature(appId, new Feature().key("FEATURE_UPD1"), superPerson)
+      def app1Features = appApi.createApplicationFeature(appId, new Feature().name("x").key("FEATURE_UPD1"), superPerson)
       def feature = app1Features.find({it -> it.key == 'FEATURE_UPD1'}).copy()
       def updatedFeatures = appApi.updateApplicationFeature(appId, "FEATURE_UPD1",
         feature.name("Drunks trying to be Quiet").alias("ssssshhhh"))
@@ -140,8 +140,8 @@ class FeatureSpec extends BaseSpec {
 
   def "i cannot overwrite another feature with the same name when i update"() {
     given: "i have two features"
-      appApi.createApplicationFeature(appId, new Feature().key("FEATURE_UPD2"), superPerson)
-      Feature f2 = appApi.createApplicationFeature(appId, new Feature().key("FEATURE_UPD3"), superPerson).find({ it -> it.key == 'FEATURE_UPD3'})
+      appApi.createApplicationFeature(appId, new Feature().name("x").key("FEATURE_UPD2"), superPerson)
+      Feature f2 = appApi.createApplicationFeature(appId, new Feature().name('FEATURE_UPD3').key("FEATURE_UPD3"), superPerson).find({ it -> it.key == 'FEATURE_UPD3'})
     when: "i update the second to the same name as the first"
       appApi.updateApplicationFeature(appId, 'FEATURE_UPD3', f2.key('FEATURE_UPD2'))
     then:
@@ -157,7 +157,7 @@ class FeatureSpec extends BaseSpec {
 
   def "i can delete an existing feature"() {
     given: "i have a feature"
-      def features = appApi.createApplicationFeature(appId, new Feature().key("FEATURE_DELUROLO"), superPerson)
+      def features = appApi.createApplicationFeature(appId, new Feature().name("x").key("FEATURE_DELUROLO"), superPerson)
     when: "i delete it"
       def deletedList = appApi.deleteApplicationFeature(appId, 'FEATURE_DELUROLO')
       def getList = appApi.getApplicationFeatures(appId)
@@ -171,7 +171,7 @@ class FeatureSpec extends BaseSpec {
   def "i can use basic crud for feature values for an application"() {
     given: "i have a feature"
       String k = "FEATURE_FV1"
-      def features = appApi.createApplicationFeature(appId, new Feature().key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
+      def features = appApi.createApplicationFeature(appId, new Feature().name("x").key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
       def pers = new PersonFeaturePermission(superPerson, [RoleType.CHANGE_VALUE, RoleType.UNLOCK, RoleType.LOCK] as Set<RoleType>)
     when: "i set the feature value"
       def f = featureSqlApi.getFeatureValueForEnvironment(envIdApp1, k);
@@ -201,7 +201,7 @@ class FeatureSpec extends BaseSpec {
   def "if i only have unlock permission i cannot lock or change a feature value"() {
     given: "i have a feature"
       String k = "FEATURE_FV_UNLOCK1"
-      def features = appApi.createApplicationFeature(appId, new Feature().key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
+      def features = appApi.createApplicationFeature(appId, new Feature().name("x").key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
       def pers = new PersonFeaturePermission(superPerson, [RoleType.CHANGE_VALUE, RoleType.UNLOCK, RoleType.LOCK] as Set<RoleType>)
     when: "i set the feature value"
       def f = featureSqlApi.getFeatureValueForEnvironment(envIdApp1, k);
@@ -222,7 +222,7 @@ class FeatureSpec extends BaseSpec {
   def "if i only have unlock permission i get an exception if i try and lock"() {
     given: "i have a feature"
       String k = "FEATURE_FV_UNLOCK2"
-      def features = appApi.createApplicationFeature(appId, new Feature().key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
+      def features = appApi.createApplicationFeature(appId, new Feature().name("x").key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
       def pers = new PersonFeaturePermission(superPerson, [RoleType.CHANGE_VALUE, RoleType.UNLOCK, RoleType.LOCK] as Set<RoleType>)
     when: "i set the feature value"
       def f = featureSqlApi.getFeatureValueForEnvironment(envIdApp1, k);
@@ -239,7 +239,7 @@ class FeatureSpec extends BaseSpec {
   def 'boolean features cannot be removed when a update all feature values for environment happens'() {
     given: "i have a list of features"
       String[] names = ['FEATURE_FBU_1', 'FEATURE_FBU_2', 'FEATURE_FBU_3', 'FEATURE_FBU_4', 'FEATURE_FBU_5']
-      names.each { k -> appApi.createApplicationFeature(appId, new Feature().key(k).valueType(FeatureValueType.BOOLEAN), superPerson) }
+      names.each { k -> appApi.createApplicationFeature(appId, new Feature().name(k).key(k).valueType(FeatureValueType.BOOLEAN), superPerson) }
       def pers = new PersonFeaturePermission(superPerson, [RoleType.CHANGE_VALUE, RoleType.UNLOCK, RoleType.LOCK] as Set<RoleType>)
     when: "i get all the features"
       List<FeatureValue> found = featureSqlApi.getAllFeatureValuesForEnvironment(envIdApp1).featureValues.findAll({ fv -> fv.key.startsWith('FEATURE_FBU')})
@@ -253,7 +253,7 @@ class FeatureSpec extends BaseSpec {
   def "i can block update a bunch of features for an environment"() {
     given: "i have a list of features"
       String[] names = ['FEATURE_FVU_1', 'FEATURE_FVU_2', 'FEATURE_FVU_3', 'FEATURE_FVU_4', 'FEATURE_FVU_5']
-      names.each { k -> appApi.createApplicationFeature(appId, new Feature().key(k).valueType(FeatureValueType.STRING), superPerson) }
+      names.each { k -> appApi.createApplicationFeature(appId, new Feature().name(k).key(k).valueType(FeatureValueType.STRING), superPerson) }
       def pers = new PersonFeaturePermission(superPerson, [RoleType.CHANGE_VALUE, RoleType.UNLOCK, RoleType.LOCK] as Set<RoleType>)
     when: "i set two of those values"
       def updatesForCreate = [new FeatureValue().key('FEATURE_FVU_1').valueString('h').locked(true),
@@ -305,7 +305,7 @@ class FeatureSpec extends BaseSpec {
       groupSqlApi.updateGroup(g1.id, g1, true, true, true, Opts.empty());
     and: "i create a feature value called FEATURE_BUNCH and unlock the feature in all branches"
       String k = 'FEATURE_BUNCH'
-      appApi.createApplicationFeature(app2Id, new Feature().key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
+      appApi.createApplicationFeature(app2Id, new Feature().name(k).key(k).valueType(FeatureValueType.BOOLEAN), superPerson)
       def perm = new PersonFeaturePermission.Builder().roles([RoleType.UNLOCK] as Set<RoleType>).person(superPerson).appRoles([] as Set<ApplicationRoleType>).build()
       [env1.id, env2.id, env3.id, env4.id].each { envId ->
         featureSqlApi.updateFeatureValueForEnvironment(envId, k,
@@ -370,7 +370,7 @@ class FeatureSpec extends BaseSpec {
       def env1 = environmentSqlApi.create(new Environment().name("rstrat-test-env1"), new Application().id(app2Id), superPerson)
     and: "i have a boolean feature (which will automatically create a feature value in each environment)"
       def key = 'FEATURE_MISINTERPRET'
-      appApi.createApplicationFeature(app2Id, new Feature().key(key).valueType(FeatureValueType.BOOLEAN), superPerson)
+      appApi.createApplicationFeature(app2Id, new Feature().name(key).key(key).valueType(FeatureValueType.BOOLEAN), superPerson)
     when: "i update the fv with the custom strategy"
       def fv = featureSqlApi.getFeatureValueForEnvironment(env1.id, key)
       def strat = new RolloutStrategy().name('freddy').percentage(20).percentageAttributes(['company'])
@@ -398,7 +398,7 @@ class FeatureSpec extends BaseSpec {
       def env1 = environmentSqlApi.create(new Environment().name("rstrat-test-env2"), new Application().id(app2Id), superPerson)
     and: "i have a boolean feature (which will automatically create a feature value in each environment)"
       def key = 'FEATURE_NOT_WHEN_LOCKED'
-      appApi.createApplicationFeature(app2Id, new Feature().key(key).valueType(FeatureValueType.BOOLEAN), superPerson)
+      appApi.createApplicationFeature(app2Id, new Feature().name(key).key(key).valueType(FeatureValueType.BOOLEAN), superPerson)
     when: "i update the fv with the custom strategy"
       def fv = featureSqlApi.getFeatureValueForEnvironment(env1.id, key)
       def strat = new RolloutStrategy().name('freddy').percentage(20).percentageAttributes(['company'])
@@ -424,7 +424,7 @@ class FeatureSpec extends BaseSpec {
       def env1 = environmentSqlApi.create(new Environment().name("lock-unlock-env"), new Application().id(app2Id), superPerson)
     and: "i have a string feature (which will automatically create a feature value in each environment) - which has no feature value created"
       def key = 'FEATURE_LOCK_UNLOCK_NOT_CHANGE'
-      appApi.createApplicationFeature(app2Id, new Feature().key(key).valueType(FeatureValueType.STRING), superPerson)
+      appApi.createApplicationFeature(app2Id, new Feature().name(key).key(key).valueType(FeatureValueType.STRING), superPerson)
     and: "i have a person"
       def person = personSqlApi.createPerson("lockunlock@mailinator.com", "Locky McLockface", "password123", superuser, Opts.empty())
     and: "a group in the current portfolio"

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/RolloutStrategyValidationUtilsSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/RolloutStrategyValidationUtilsSpec.groovy
@@ -43,39 +43,6 @@ class RolloutStrategyValidationUtilsSpec extends Specification {
       validations.customStrategyViolations[fv[0]]*.violation.contains(RolloutStrategyViolationType.NEGATIVE_PERCENTAGE)
   }
 
-//  def "updating all environment features in an application by a specific feature will fail if we have attributes update with no attributes"() {
-//    given: "i have a feature value with no valid percentage configs"
-//      def fv = [new RolloutStrategy().name('empty')]
-//    when: "i attempt to update"
-//      def validations = validator.validateStrategies(fv, [])
-//    then:
-//      validations.isInvalid()
-//      !validations.customStrategyViolations.isEmpty()
-//      validations.customStrategyViolations[fv[0]]*.violation.contains(RolloutStrategyViolationType.EMPTY_MATCH_CRITERIA)
-//  }
-
-  def 'updating features and having a strategy with no name causes a failure'() {
-    given: "i have a feature value with no valid configs"
-      def fv =
-        [new RolloutStrategy().percentage(3456).value(true)]
-    when: "i attempt to update"
-      def validations = validator.validateStrategies(fv, [])
-    then:
-      validations.isInvalid()
-      !validations.customStrategyViolations.isEmpty()
-      validations.customStrategyViolations[fv[0]]*.violation.contains(RolloutStrategyViolationType.NO_NAME)
-  }
-
-//  def "we specify an array but the values aren't in the array"() {
-//    when: " rollout an array which is empty"
-//      def fv = [new RolloutStrategy().name("fred").attributes([new RolloutStrategyAttribute()])]
-//      def validations = validator.validateStrategies(fv, [])
-//    then:
-//      validations.isInvalid()
-//      !validations.customStrategyViolations.isEmpty()
-//      validations.customStrategyViolations[fv[0]]*.violation.contains(RolloutStrategyViolationType.ARRAY_ATTRIBUTE_NO_VALUES)
-//  }
-
   def "when we specify all attributes is ok"() {
     when: "attr has everything field"
       def validations = validator.validateStrategies([new RolloutStrategy().name("fred").attributes([

--- a/backend/party-server/src/test/resources/log4j2-test.xml
+++ b/backend/party-server/src/test/resources/log4j2-test.xml
@@ -1,8 +1,8 @@
 <Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <ConnectJsonLayout/>
-<!--      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>-->
+<!--      <ConnectJsonLayout/>-->
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 

--- a/backend/party-server/src/test/resources/log4j2-test.xml
+++ b/backend/party-server/src/test/resources/log4j2-test.xml
@@ -1,8 +1,8 @@
 <Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-<!--      <ConnectJsonLayout/>-->
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>
+      <ConnectJsonLayout/>
+<!--      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>-->
     </Console>
   </Appenders>
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -349,6 +349,19 @@ endpoints on a different port.
 If not, it will expose them on this port (and not on the server port).
 - `featurehub.url-path` - allows  to configure base path (context root) other than "/". This will set the base path in the index.html of the FeatureHub web app and the backend. Note, this is an offset, not a full domain name, e.g. `featurehub.url-path=/foo/featurehub`.
 In case if the front-end is decoupled on a CDN, the base bath needs to be configured directly in index.html by setting: `<base href="/foo/featurehub/">` (note the trailing slash).
+
+- `connect.logging.environment` - this is a comma separated value list that lets you pick up values from environment variables that get added directly to your logs. It is typically used in Kubernetes deploys to allow you to extract information from the k8s deploy and put it in environment variables and have them logged. The format is `<ENV-VAR>=<log-key>`. You can use `.` notation to split it into objects. 
+
+.Config
+----
+connect.logging.environment=MY_KUBERNETES_NODE=kubernetes.node,MY_KUBERNETES_ZONE=kubernetes.zone
+----
+
+.Generated Logs
+----
+{"@timestamp":"2022-01-22T18:12:56.767+1300","message":"1 * Server has received a request on thread grizzly-http-server-0\n1 > GET http://localhost:8903/info/version\n1 > accept: */*\n1 > host: localhost:8903\n1 > user-agent: curl/7.77.0\n","priority":"TRACE","path":"jersey-logging","thread":"grizzly-http-server-0","kubernetes":{"node":"peabody","zone":"amelia"},"host":"thepolishedbrasstack.lan","connect.rest.method":"received: GET - http://localhost:8903/info/version"}
+----
+
 - `audit.logging.web.header-fields` - a comma separated list of fields that will be extracted out of each web request and put into a field
 in the JSON logs output by the server. All headers are grouped into an object called `http-headers`. Headers by definition are case insensitive. Available from *1.5.5*. An example:
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -349,6 +349,30 @@ endpoints on a different port.
 If not, it will expose them on this port (and not on the server port).
 - `featurehub.url-path` - allows  to configure base path (context root) other than "/". This will set the base path in the index.html of the FeatureHub web app and the backend. Note, this is an offset, not a full domain name, e.g. `featurehub.url-path=/foo/featurehub`.
 In case if the front-end is decoupled on a CDN, the base bath needs to be configured directly in index.html by setting: `<base href="/foo/featurehub/">` (note the trailing slash).
+- `audit.logging.web.header-fields` - a comma separated list of fields that will be extracted out of each web request and put into a field
+in the JSON logs output by the server. All headers are grouped into an object called `http-headers`. Headers by definition are case insensitive. Available from *1.5.5*. An example:
+
+.Config
+----
+audit.logging.web.header-fields=user-agent,origin,Sec-fetch-Mode
+----
+.Generated Logs
+----
+{"@timestamp":"2022-01-22T14:46:19.374+1300","message":"txn[1106] Begin","priority":"TRACE","path":"io.ebean.TXN","thread":"grizzly-http-server-0","host":"my-computer","http-headers":{"user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36","origin":"http://localhost:53000","Sec-fetch-Mode":"cors"}}
+----
+- `audit.logging.user` - if this is set to true (it is false by default) then the user's ID and email will be logged against each of their requests
+where it is known. It appears in a `user` object with `id` and `email` as components. Available from *1.5.5*. An example
+
+.Config
+----
+audit.logging.user=true
+----
+
+.Generated Logs
+----
+{"@timestamp":"2022-01-22T14:58:15.854+1300","message":"txn[1109] select t0.id, t0.when_archived, t0.feature_key, t0.alias, t0.name, t0.secret, t0.link, t0.value_type, t0.when_updated, t0.when_created, t0.version, t0.fk_app_id from fh_app_feature t0 where t0.id = ?; --bind(2b86605b-1a81-4fc7-80b7-17edc5e3206e, ) --micros(697)","priority":"DEBUG","path":"io.ebean.SQL","thread":"grizzly-http-server-1","host":"my-computer","user":{"id":"68c09a3d-6e44-4379-bfc1-3e75af59af38","email":"irina@i.com"}}
+
+----
 
 
 ==== Common to Party, SSE Edge and Management Repository


### PR DESCRIPTION
# Description

This change brings in three big changes to the logging

- any arbitrary environment variable can be logged in a structure (see docs)
- any web header can be captured and logged
- the user who is performing the action can be added to the logs

Fixes #660 

## Type of change

