### PR TITLE
[Maint] Upgrade Postgres for CVE and Ebean deps

### DIFF
--- a/backend/composite-db-drivers/pom.xml
+++ b/backend/composite-db-drivers/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.24</version>
+      <version>42.2.25</version>
     </dependency>
 
     <dependency>

--- a/backend/composite-parent/pom.xml
+++ b/backend/composite-parent/pom.xml
@@ -53,7 +53,7 @@
     <jackson.version>2.13.1</jackson.version>
     <sticky.version>1.3</sticky.version>
     <groovy.version>3.0.9</groovy.version>
-    <ebean.version>12.14.1</ebean.version>
+    <ebean.version>12.15.0</ebean.version>
     <h2.version>2.1.210</h2.version>
   </properties>
 

--- a/backend/mr-db-ebean/pom.xml
+++ b/backend/mr-db-ebean/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.12</version>
+      <version>42.2.25</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Ebean 12.15.0 has fully support for h2 v2, and postgres is a CVE.

