### PR TITLE
[internal] Force specific version of Google Fonts

### DIFF
--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
-import 'package:open_admin_app/api/client_api.dart';
-import 'package:open_admin_app/api/mr_client_aware.dart';
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:collection/collection.dart';
 import 'package:mrapi/api.dart';
+import 'package:open_admin_app/api/client_api.dart';
+import 'package:open_admin_app/api/mr_client_aware.dart';
 import 'package:openapi_dart_common/openapi.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:rxdart/rxdart.dart';
 
 enum ManageAppPageState { loadingState, initialState }
@@ -225,7 +224,9 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
   }
 
   Future<void> _getGroupRoles(String? groupId) async {
-    if (groupId == null || !_mrClient.userIsCurrentPortfolioAdmin || applicationId == null) {
+    if (groupId == null ||
+        !_mrClient.userIsCurrentPortfolioAdmin ||
+        applicationId == null) {
       _groupWithRolesPS.add(null);
     } else {
       try {

--- a/admin-frontend/open_admin_app/lib/widgets/features/per_application_features_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/per_application_features_bloc.dart
@@ -4,7 +4,6 @@ import 'package:bloc_provider/bloc_provider.dart';
 import 'package:mrapi/api.dart';
 import 'package:open_admin_app/api/client_api.dart';
 import 'package:open_admin_app/api/mr_client_aware.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:rxdart/rxdart.dart' hide Notification;
 
 class FeatureStatusFeatures {

--- a/admin-frontend/open_admin_app/pubspec.yaml
+++ b/admin-frontend/open_admin_app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   url_launcher: ^6.0.3
   intl: ^0.17.0
   timeago: ^3.0.2
-  google_fonts: ^2.0.0
+  google_fonts: 2.2.0
   # do not change this version of animator
   animator: ^3.0.0
   shared_preferences: ^2.0.5


### PR DESCRIPTION
The latest version of Google Fonts caused breakages as it didn't limit
itself to Flutter 2.10 and beyond, this was causing the build to break.

