### PR TITLE
[feature] Support Heartbeats in SSE

### DIFF
--- a/backend/edge-full/src/main/java/io/featurehub/edge/bucket/BucketService.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/bucket/BucketService.java
@@ -4,5 +4,5 @@ import io.featurehub.edge.client.ClientConnection;
 
 public interface BucketService {
   void putInBucket(ClientConnection b);
-  void shuftyBucketsBecauseDachaIsUnavailable(ClientConnection b);
+  void dachaIsUnavailable(ClientConnection b);
 }

--- a/backend/edge-full/src/main/java/io/featurehub/edge/bucket/EventOutputBucketService.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/bucket/EventOutputBucketService.java
@@ -7,6 +7,8 @@ import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -21,27 +23,52 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EventOutputBucketService implements BucketService {
   private static final Logger log = LoggerFactory.getLogger(EventOutputBucketService.class);
   private final Map<Integer, TimedBucket> discardTimerBuckets = new ConcurrentHashMap<>();
-  private int timerSlice;
+  private final Map<Integer, TimedBucket> heartbeatTimerBuckets = new ConcurrentHashMap<>();
+  private final Map<Integer, List<ClientConnection>> dachaNotReadyConnections = new ConcurrentHashMap<>();
+  private int dropConnectionTimer;
+  private int heartbeatConnectionTimer;
+  private int delaySlotTimer;
 
   @ConfigKey("maxSlots")
-  protected Integer maxSlots = 30;
+  protected Integer maxSlots = -1;
 
   @ConfigKey("edge.dacha.delay-slots")
   protected Integer delaySlots = 10;
 
+  // if > 0 then we will drop the connection automatically after this period, used ot be dropAfterSeconds
+  @ConfigKey("edge.sse.drop-after-seconds")
+  protected Integer dropAfterSeconds = 30;
+
+  // if zero, then no heartbeat
+  @ConfigKey("edge.sse.heartbeat-period")
+  protected Integer heartbeatAfterSeconds = 0;
+
   @ConfigKey("edge.dacha.response-timeout")
-  protected Integer namedCacheTimeout = 2000; // milliseconds to wait for dacha to responsd
+  protected Integer namedCacheTimeout = 2000; // milliseconds to wait for dacha to response
 
   public EventOutputBucketService() {
     DeclaredConfigResolver.resolve(this);
 
-    if (namedCacheTimeout / 1000 > maxSlots) {
-      throw new RuntimeException(
-          "You cannot wait for longer than the connection will be open. Please increase your "
-              + "maxSlots or decrease your Dacha timeout.");
+    if (maxSlots > 0 && dropAfterSeconds != 30) {
+      dropAfterSeconds = maxSlots;
     }
 
-    timerSlice = maxSlots - 1;
+    if (dropAfterSeconds > 0 && namedCacheTimeout / 1000 > dropAfterSeconds) {
+      throw new RuntimeException(
+          "You cannot wait for longer than the connection will be open. Please increase your "
+              + "edge.sse.drop-after-seconds or decrease your edge.dacha.response-timeout millisecond value.");
+    }
+
+    if (dropAfterSeconds > 0) {
+      dropConnectionTimer = dropAfterSeconds - 1;
+    }
+
+    if (heartbeatAfterSeconds > 0) {
+      heartbeatConnectionTimer = heartbeatAfterSeconds - 1;
+    }
+
+    delaySlotTimer = delaySlots - 1;
+
     startTimer();
   }
 
@@ -51,48 +78,97 @@ public class EventOutputBucketService implements BucketService {
         new TimerTask() {
           @Override
           public void run() {
-            kickout();
+            // we are kicking people off? if so, kick them off first
+            if (dropAfterSeconds > 0) {
+              kickout();
+            }
+
+            // are we heartbeating? if so, check them too
+            if (heartbeatAfterSeconds > 0) {
+              heartbeatRemainingConnections();
+            }
+
+            delaySlotKickout();
           }
         },
         0,
         1000);
   }
 
-  // every second, we clear out the buckets going down the list
-  void kickout() {
-    timerSlice--;
+  /**
+   * every second, we check if there are connections who couldn't
+   */
+  void delaySlotKickout() {
+    final List<ClientConnection> conns = dachaNotReadyConnections.replace(delaySlotTimer, new ArrayList<>());
 
-    if (timerSlice < 0) {
-      timerSlice = maxSlots - 1;
+    if (conns != null && !conns.isEmpty()) {
+      conns.parallelStream().forEach(ClientConnection::close);
     }
 
-    TimedBucket timedBucketClientConnections = discardTimerBuckets.remove(timerSlice);
+    delaySlotTimer --;
+
+    if (delaySlotTimer < 0) {
+      delaySlotTimer = delaySlots -1;
+    }
+  }
+
+  void heartbeatRemainingConnections() {
+    heartbeatConnectionTimer --;
+
+    if (heartbeatConnectionTimer < 0) {
+      heartbeatConnectionTimer = heartbeatAfterSeconds - 1;
+    }
+
+    // in this case, we are going to write something and see if they are still there
+    // if we get a connection error, it will automatically
+    TimedBucket bucketToCheck = heartbeatTimerBuckets.get(heartbeatConnectionTimer);
+
+    if (bucketToCheck != null) {
+      bucketToCheck.ensureConnectionsInBucketAreActive();
+    }
+  }
+
+  // every second, we clear out the buckets going down the list
+  void kickout() {
+    dropConnectionTimer--;
+
+    if (dropConnectionTimer < 0) {
+      dropConnectionTimer = dropAfterSeconds - 1;
+    }
+
+    // traditional behaviour, kick them off
+    TimedBucket timedBucketClientConnections = discardTimerBuckets.remove(dropConnectionTimer);
 
     if (timedBucketClientConnections != null) {
-      log.debug("Expiring slice {}", timerSlice);
+      log.debug("expiring slice {} has {} connections", dropConnectionTimer,
+        timedBucketClientConnections.numConnections());
       timedBucketClientConnections.expireConnections();
     }
   }
 
   // adds the new connection to the bucket
   public void putInBucket(ClientConnection b) {
-    discardTimerBuckets
-        .computeIfAbsent(timerSlice, k -> new TimedBucket(timerSlice))
+    if (dropAfterSeconds > 0) {
+      log.trace("Adding client connection at {}", dropConnectionTimer);
+      discardTimerBuckets
+        .computeIfAbsent(dropConnectionTimer, k -> new TimedBucket(TimerBucketPurpose.DROP_CONNECTIONS, dropConnectionTimer))
         .addConnection(b);
-  }
-
-  public void shuftyBucketsBecauseDachaIsUnavailable(ClientConnection b) {
-    int newSlot = (timerSlice - 10 - (int) (Math.random() * delaySlots));
-
-    if (newSlot < 0) {
-      newSlot = maxSlots - newSlot;
     }
 
-    log.debug("shifting into bucket {}", newSlot);
+    if (heartbeatAfterSeconds > 0) {
+      log.trace("Adding to heartbeat timer {}", heartbeatConnectionTimer);
+      heartbeatTimerBuckets.computeIfAbsent(heartbeatConnectionTimer, k -> new TimedBucket(TimerBucketPurpose.HEARTBEAT,
+          heartbeatConnectionTimer))
+        .addConnection(b);
+    }
+  }
 
-    int finalNewSlot = newSlot;
-    b.getTimedBucketSlot()
-        .swapConnection(
-            b, discardTimerBuckets.computeIfAbsent(newSlot, k -> new TimedBucket(finalNewSlot)));
+  public void dachaIsUnavailable(ClientConnection b) {
+    int newSlot = (int) (Math.random() * delaySlots);
+
+    final List<ClientConnection> dachaDropConnections = dachaNotReadyConnections.computeIfAbsent(newSlot,
+      k -> new ArrayList<>());
+
+    dachaDropConnections.add(b);
   }
 }

--- a/backend/edge-full/src/main/java/io/featurehub/edge/bucket/TimedBucketSlot.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/bucket/TimedBucketSlot.java
@@ -6,4 +6,6 @@ public interface TimedBucketSlot {
   void addConnection(ClientConnection conn);
 
   void swapConnection(ClientConnection conn, TimedBucket newBucket);
+
+  Object numConnections();
 }

--- a/backend/edge-full/src/main/java/io/featurehub/edge/bucket/TimerBucketPurpose.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/bucket/TimerBucketPurpose.java
@@ -1,0 +1,6 @@
+package io.featurehub.edge.bucket;
+
+public enum TimerBucketPurpose {
+  DROP_CONNECTIONS,
+  HEARTBEAT
+}

--- a/backend/edge-full/src/main/java/io/featurehub/edge/client/ClientConnection.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/client/ClientConnection.java
@@ -23,6 +23,8 @@ public interface ClientConnection {
 
   KeyParts getKey();
 
+  void heartbeat();
+
   ClientContext getClientContext();
 
   void writeMessage(SSEResultState name, String data) throws IOException;

--- a/backend/edge-full/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/client/TimedBucketClientConnection.java
@@ -113,6 +113,16 @@ public class TimedBucketClientConnection implements ClientConnection {
   }
 
   @Override
+  public void heartbeat() {
+    try {
+      writeMessage(SSEResultState.ACK, "\"❤️\"");
+    } catch (IOException ignored) {
+      log.trace("connection dropped when attempting heartbeat");
+      close(false);
+    }
+  }
+
+  @Override
   public ClientContext getClientContext() {
     return attributesForStrategy;
   }
@@ -238,7 +248,7 @@ public class TimedBucketClientConnection implements ClientConnection {
             statRecorder.recordHit(apiKey, EdgeHitResultType.MISSED, EdgeHitSourceType.EVENTSOURCE);
 
             // move it to a random number of buckets ahead to get a kick-out
-            bucketService.shuftyBucketsBecauseDachaIsUnavailable(this);
+            bucketService.dachaIsUnavailable(this);
             break;
         }
       } catch (IOException iex) {

--- a/backend/party-server/src/test/resources/log4j2-test.xml
+++ b/backend/party-server/src/test/resources/log4j2-test.xml
@@ -8,6 +8,7 @@
 
   <Loggers>
     <AsyncLogger name="io.featurehub" level="debug"/>
+    <AsyncLogger name="io.featurehub.edge" level="trace"/>
     <AsyncLogger name="io.ebean.SQL" level="trace"/>
     <AsyncLogger name="io.ebean.TXN" level="trace"/>
     <AsyncLogger name="io.ebean.SUM" level="trace"/>


### PR DESCRIPTION
# Description

Dropping connections for SSE is best used for when SSE is being cached and for dealing with ghost
connections. If there is no cache layer, it is worthwhile to be able to remove the drop connections
and simply use a heartbeat to manage connections instead. This PR adds heartbeat capability to allow
both a heartbeat and dropping connections, and _only_ a heartbeat to manage connections for SSE.

