### PR TITLE
[internal] MariaDB driver 3.0.3 is not ready for primetime

### DIFF
--- a/backend/composite-db-drivers/pom.xml
+++ b/backend/composite-db-drivers/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>3.0.3</version>
+      <version>2.7.5</version>
     </dependency>
 
     <dependency>

--- a/e2e/test/features/service_accounts_load.feature
+++ b/e2e/test/features/service_accounts_load.feature
@@ -1,9 +1,9 @@
 Feature: This should test the loading of new service accounts
 
   Scenario Outline: I can create a new portfolio and groups 3
-
     # superuser has to create the portfolio and create the user
-    Given I ensure a portfolio named "<portfolio>" with description "<portfolio_desc>" exists
+    Given the first superuser is used for authentication
+    And I have a randomly named portfolio with the prefix "<portfolio>"
     And I have a fully registered person "<name>" with email "<email>" and password "password123"
     # previous step swapped to that user, so swap back to superuser
     And the first superuser is used for authentication
@@ -13,18 +13,18 @@ Feature: This should test the loading of new service accounts
     And I create an application with the name "Jujitsu for Frogs"
     And I can find environment "production" in the application
     When We create a service account "<service_account>" with the permission READ
-    Then portfolio "<portfolio>" has service account "<service_account>" with attached API keys
+    Then portfolio has service account "<service_account>" with attached API keys
 
     Examples:
-      | portfolio   | portfolio_desc | service_account | name                    | email                                  |
-      | Marketing   | The Fluffers   | SA001           | Marketing Admin         | marketing-admin@mailinator.com         |
-      | Marketing   | The Fluffers   | SA002           | Marketing Admin         | marketing-admin@mailinator.com         |
-      | Engineering | The Eloi       | SA003           | Engineering Admin       | engineering-admin@mailinator.com       |
-      | Engineering | The Eloi       | SA004           | Engineering Admin       | engineering-admin@mailinator.com       |
-      | Engineering | The Eloi       | SA005           | Engineering Admin       | engineering-admin@mailinator.com       |
-      | Platform    | The Morlocks   | SA006           | Platform Admin          | platform-admin@mailinator.com          |
-      | Platform    | The Morlocks   | SA007           | platform testers        | platform_testers-admin@mailinator.com  |
-      | Platform    | The Morlocks   | SA008           | platform_business_users | platform_product-owners@mailinator.com |
+      | portfolio   | service_account | name                    | email                                  |
+      | Marketing   | SA001           | Marketing Admin         | marketing-admin@mailinator.com         |
+      | Marketing   | SA002           | Marketing Admin         | marketing-admin@mailinator.com         |
+      | Engineering | SA003           | Engineering Admin       | engineering-admin@mailinator.com       |
+      | Engineering | SA004           | Engineering Admin       | engineering-admin@mailinator.com       |
+      | Engineering | SA005           | Engineering Admin       | engineering-admin@mailinator.com       |
+      | Platform    | SA006           | Platform Admin          | platform-admin@mailinator.com          |
+      | Platform    | SA007           | platform testers        | platform_testers-admin@mailinator.com  |
+      | Platform    | SA008           | platform_business_users | platform_product-owners@mailinator.com |
 
 
   Scenario Outline: I can create a new portfolio and service account and add permissions

--- a/e2e/test/steps/AdminPortfolioStepdefs.dart
+++ b/e2e/test/steps/AdminPortfolioStepdefs.dart
@@ -172,6 +172,9 @@ class AdminPortfolioStepdefs {
         DateTime.now().millisecondsSinceEpoch.toString();
 
     shared.portfolio = await common.portfolioService.createPortfolio(
-        new Portfolio(name: portfolioName, description: 'A random portfolio'));
+        new Portfolio(name: portfolioName, description: 'A random portfolio'),
+        includeGroups: true);
+
+    shared.portfolioAdminGroup = shared.portfolio.groups[0];
   }
 }

--- a/e2e/test/steps/PortfolioStepdefs.dart
+++ b/e2e/test/steps/PortfolioStepdefs.dart
@@ -112,11 +112,30 @@ class PortfolioStepdefs {
 
   @Then(
       r'portfolio {string} has service account {string} with attached API keys')
-  void portfolioHasServiceAccount(
+  void portfolioByNameHasServiceAccount(
       String portfolioName, String serviceAccountName) async {
     Portfolio? p = await userCommon.findExactPortfolio(portfolioName);
     ServiceAccount? sa =
         await userCommon.findExactServiceAccount(serviceAccountName, p!.id);
+    assert(sa != null,
+        "I couldn't find the service account " + serviceAccountName);
+
+    assert(sa!.permissions.isNotEmpty,
+        'There are no permissions, there should be at least prod');
+
+    assert(sa!.permissions[0].sdkUrlClientEval != null,
+        'Client API Key for $serviceAccountName not available to portfolio admin');
+    assert(sa!.permissions[0].sdkUrlServerEval != null,
+        'Server API Key for $serviceAccountName not available to portfolio admin');
+  }
+
+  @Then(r'portfolio has service account {string} with attached API keys')
+  void portfolioHasServiceAccount(String serviceAccountName) async {
+    Portfolio? p =
+        await userCommon.portfolioService.getPortfolio(shared.portfolio.id!);
+    // assert(p != null, 'The portfolio ${shared.portfolio} could not be found');
+    ServiceAccount? sa =
+        await userCommon.findExactServiceAccount(serviceAccountName, p.id);
     assert(sa != null,
         "I couldn't find the service account " + serviceAccountName);
 


### PR DESCRIPTION
# Description

It was causing database issues for MariaDB applications so we have rolled back to
the latest of the 2.7 series (2.7.5 released 15 Jan, 2022).

This also introduces some resiliency in the e2e tests to be able to run multiple
times.

