### PR TITLE
[internal] ensure lifecycle listener is registered only once

### DIFF
--- a/backend/common-web/src/main/java/io/featurehub/jersey/config/EndpointLoggingListener.java
+++ b/backend/common-web/src/main/java/io/featurehub/jersey/config/EndpointLoggingListener.java
@@ -1,7 +1,5 @@
 package io.featurehub.jersey.config;
 
-import cd.connect.lifecycle.ApplicationLifecycleManager;
-import cd.connect.lifecycle.LifecycleStatus;
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
 import org.glassfish.jersey.server.model.Resource;
@@ -19,7 +17,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-// from: https://stackoverflow.com/questions/32525699/listing-all-deployed-rest-endpoints-spring-boot-jersey
+// from:
+// https://stackoverflow.com/questions/32525699/listing-all-deployed-rest-endpoints-spring-boot-jersey
 
 public class EndpointLoggingListener implements ApplicationEventListener {
   private static final Logger log = LoggerFactory.getLogger(EndpointLoggingListener.class);
@@ -40,18 +39,12 @@ public class EndpointLoggingListener implements ApplicationEventListener {
       if (log.isDebugEnabled()) {
         final ResourceModel resourceModel = event.getResourceModel();
         final ResourceLogDetails logDetails = new ResourceLogDetails();
-        resourceModel.getResources().stream().forEach((resource) -> {
-          logDetails.addEndpointLogLines(getLinesFromResource(resource));
-        });
+        resourceModel.getResources().stream()
+            .forEach(
+                (resource) -> {
+                  logDetails.addEndpointLogLines(getLinesFromResource(resource));
+                });
         logDetails.log();
-      }
-    } else if (event.getType() == ApplicationEvent.Type.INITIALIZATION_FINISHED) {
-      if (!ApplicationLifecycleManager.isReady()) {
-        ApplicationLifecycleManager.updateStatus(LifecycleStatus.STARTED);
-      }
-    } else if (event.getType() == ApplicationEvent.Type.DESTROY_FINISHED) {
-      if (ApplicationLifecycleManager.getStatus() != LifecycleStatus.TERMINATED) {
-        ApplicationLifecycleManager.updateStatus(LifecycleStatus.TERMINATED);
       }
     }
   }
@@ -77,13 +70,16 @@ public class EndpointLoggingListener implements ApplicationEventListener {
     return logLines;
   }
 
-  private void populate(String basePath, Class<?> klass, boolean isLocator,
-                        Set<EndpointLogLine> endpointLogLines) {
+  private void populate(
+      String basePath, Class<?> klass, boolean isLocator, Set<EndpointLogLine> endpointLogLines) {
     populate(basePath, isLocator, Resource.from(klass), endpointLogLines);
   }
 
-  private void populate(String basePath, boolean isLocator, Resource resource,
-                        Set<EndpointLogLine> endpointLogLines) {
+  private void populate(
+      String basePath,
+      boolean isLocator,
+      Resource resource,
+      Set<EndpointLogLine> endpointLogLines) {
     if (!isLocator) {
       basePath = normalizePath(basePath, resource.getPath());
     }
@@ -111,11 +107,12 @@ public class EndpointLoggingListener implements ApplicationEventListener {
           endpointLogLines.add(new EndpointLogLine(method.getHttpMethod(), path, null));
         } else if (method.getType() == ResourceMethod.JaxrsType.SUB_RESOURCE_LOCATOR) {
           final String path = normalizePath(basePath, childResource.getPath());
-          final ResolvedType responseType = TYPE_RESOLVER
-            .resolve(method.getInvocable().getResponseType());
-          final Class<?> erasedType = !responseType.getTypeBindings().isEmpty()
-            ? responseType.getTypeBindings().getBoundType(0).getErasedType()
-            : responseType.getErasedType();
+          final ResolvedType responseType =
+              TYPE_RESOLVER.resolve(method.getInvocable().getResponseType());
+          final Class<?> erasedType =
+              !responseType.getTypeBindings().isEmpty()
+                  ? responseType.getTypeBindings().getBoundType(0).getErasedType()
+                  : responseType.getErasedType();
           populate(path, erasedType, true, endpointLogLines);
         }
       }
@@ -136,17 +133,19 @@ public class EndpointLoggingListener implements ApplicationEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(ResourceLogDetails.class);
 
-    private static final Comparator<EndpointLogLine> COMPARATOR
-      = Comparator.comparing((EndpointLogLine e) -> e.path)
-      .thenComparing((EndpointLogLine e) -> e.httpMethod);
+    private static final Comparator<EndpointLogLine> COMPARATOR =
+        Comparator.comparing((EndpointLogLine e) -> e.path)
+            .thenComparing((EndpointLogLine e) -> e.httpMethod);
 
     private final Set<EndpointLogLine> logLines = new TreeSet<>(COMPARATOR);
 
     private void log() {
       StringBuilder sb = new StringBuilder("\nAll endpoints for Jersey application\n");
-      logLines.stream().forEach((line) -> {
-        sb.append(line).append("\n");
-      });
+      logLines.stream()
+          .forEach(
+              (line) -> {
+                sb.append(line).append("\n");
+              });
       logger.info(sb.toString());
     }
 

--- a/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
@@ -1,6 +1,7 @@
 package io.featurehub.health
 
 import cd.connect.jersey.common.JerseyPrometheusResource
+import io.featurehub.jersey.ApplicationLifecycleListener
 import io.featurehub.jersey.FeatureHubJerseyHost
 import io.featurehub.utils.FallbackPropertyConfig
 import io.prometheus.client.hotspot.DefaultExports
@@ -33,6 +34,7 @@ class MetricsHealthRegistration {
       if (FallbackPropertyConfig.getConfig(monitorPortName) == null) {
         config.register(JerseyPrometheusResource::class.java)
         config.register(HealthFeature::class.java)
+        config.register(ApplicationLifecycleListener::class.java)
       } else {
         config.register(object : ContainerLifecycleListener {
           override fun onStartup(container: Container) {
@@ -44,7 +46,8 @@ class MetricsHealthRegistration {
             // into our health repository
             val healthSources = injector.getAllServices(HealthSource::class.java);
 
-            val resourceConfig = ResourceConfig(JerseyPrometheusResource::class.java, HealthFeature::class.java, LoadBalancerFeature::class.java)
+            val resourceConfig = ResourceConfig(JerseyPrometheusResource::class.java,
+              HealthFeature::class.java, LoadBalancerFeature::class.java, ApplicationLifecycleListener::class.java)
 
             resourceConfig.register(object: AbstractBinder() {
               override fun configure() {

--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/ApplicationLifecycleListener.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/ApplicationLifecycleListener.kt
@@ -1,0 +1,37 @@
+package io.featurehub.jersey
+
+import cd.connect.lifecycle.ApplicationLifecycleManager
+import cd.connect.lifecycle.LifecycleStatus
+import org.glassfish.jersey.server.monitoring.ApplicationEvent
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener
+import org.glassfish.jersey.server.monitoring.RequestEvent
+import org.glassfish.jersey.server.monitoring.RequestEventListener
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * This triggers the full application lifecycle - only register this on the LAST
+ * context if you have multiple contexts. We register this on the Metrics endpoint by
+ * default as that is always registered as the second context.
+ */
+class ApplicationLifecycleListener : ApplicationEventListener {
+  private val log: Logger = LoggerFactory.getLogger(ApplicationLifecycleListener::class.java)
+  override fun onEvent(event: ApplicationEvent) {
+    log.info("application event received {}", event.type)
+    if (event.type == ApplicationEvent.Type.INITIALIZATION_FINISHED) {
+      if (!ApplicationLifecycleManager.isReady()) {
+        log.info("Application started, triggering started events")
+        ApplicationLifecycleManager.updateStatus(LifecycleStatus.STARTED)
+      }
+    } else if (event.type == ApplicationEvent.Type.DESTROY_FINISHED) {
+      log.info("Application complete, triggering shutdown events")
+      if (ApplicationLifecycleManager.getStatus() != LifecycleStatus.TERMINATED) {
+        ApplicationLifecycleManager.updateStatus(LifecycleStatus.TERMINATED)
+      }
+    }
+  }
+
+  override fun onRequest(requestEvent: RequestEvent?): RequestEventListener? {
+    return null
+  }
+}


### PR DESCRIPTION
# Description

issues exist around the application lifecycle listener being
attached to multiple contexts and triggering before the whole
app is fully registered. This separates the two.

