### PR TITLE
Internal/split out persongroup

### DIFF
--- a/backend/mr-db-ebean/pom.xml
+++ b/backend/mr-db-ebean/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>io.featurehub.mr</groupId>
-      <artifactId>mr-db-sql</artifactId>
+      <artifactId>mr-db-models</artifactId>
       <version>1.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.14.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.14.sql
@@ -1,0 +1,7 @@
+-- ignore migration
+-- drop dependencies
+-- alter table fh_person_group_link drop constraint if exists fk_fh_person_group_link_fh_person;
+-- alter table fh_person_group_link drop constraint if exists fk_fh_person_group_link_fh_group;
+-- foreign keys and indices
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_person_id foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_group_id foreign key (fk_group_id) references fh_group (id) on delete restrict on update restrict;

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/model/1.14.model.xml
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/model/1.14.model.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<migration xmlns="http://ebean-orm.github.io/xml/ns/dbmigration">
+    <changeSet type="apply">
+        <alterColumn columnName="fk_person_id" tableName="fh_person_group_link" references="fh_person.id" foreignKeyName="fk_fh_person_group_link_fk_person_id" foreignKeyIndex="ix_fh_person_group_link_fk_person_id"/>
+        <alterColumn columnName="fk_group_id" tableName="fh_person_group_link" references="fh_group.id" foreignKeyName="fk_fh_person_group_link_fk_group_id" foreignKeyIndex="ix_fh_person_group_link_fk_group_id"/>
+        <alterForeignKey name="fk_fh_person_group_link_fh_person" columnNames="DROP FOREIGN KEY" indexName="ix_fh_person_group_link_fh_person" tableName="fh_person_group_link"/>
+        <alterForeignKey name="fk_fh_person_group_link_fh_group" columnNames="DROP FOREIGN KEY" indexName="ix_fh_person_group_link_fh_group" tableName="fh_person_group_link"/>
+    </changeSet>
+</migration>

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.14.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.14.sql
@@ -1,0 +1,7 @@
+-- ignore migration
+-- drop dependencies
+-- alter table fh_person_group_link drop foreign key fk_fh_person_group_link_fh_person;
+-- alter table fh_person_group_link drop foreign key fk_fh_person_group_link_fh_group;
+-- foreign keys and indices
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_person_id foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_group_id foreign key (fk_group_id) references fh_group (id) on delete restrict on update restrict;

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/oracle/1.14.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/oracle/1.14.sql
@@ -1,0 +1,6 @@
+-- drop dependencies
+-- alter table fh_person_group_link drop constraint fk_fh_prsn_grp_lnk_fh_prsn;
+-- alter table fh_person_group_link drop constraint fk_fh_prsn_grp_lnk_fh_grp;
+-- foreign keys and indices
+-- alter table fh_person_group_link add constraint fk_fh_prsn_grp_lnk_fk_prsn_d foreign key (fk_person_id) references fh_person (id);
+-- alter table fh_person_group_link add constraint fk_fh_prsn_grp_lnk_fk_grp_d foreign key (fk_group_id) references fh_group (id);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.14.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.14.sql
@@ -1,0 +1,7 @@
+-- ignore this migration
+-- drop dependencies
+-- alter table if exists fh_person_group_link drop constraint if exists fk_fh_person_group_link_fh_person;
+-- alter table if exists fh_person_group_link drop constraint if exists fk_fh_person_group_link_fh_group;
+-- foreign keys and indices
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_person_id foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;alter table fh_person_group_link add constraint fk_fh_person_group_link_fh_person foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_group_id foreign key (fk_group_id) references fh_group (id) on delete restrict on update restrict;

--- a/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroup.java
+++ b/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroup.java
@@ -7,11 +7,11 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Index(unique = true, name = "idx_group_names", columnNames = {"fk_portfolio_id", "group_name"})
@@ -56,8 +56,8 @@ public class DbGroup extends DbVersionedBase {
   @JoinColumn(name = "group_id")
   private Set<DbAcl> groupRolesAcl;
 
-  @ManyToMany(cascade = CascadeType.ALL, mappedBy = "groupsPersonIn")
-  private Set<DbPerson> peopleInGroup;
+  @OneToMany(cascade = CascadeType.ALL)
+  private List<DbGroupMember> groupMembers;
 
 
   public DbGroup() {}
@@ -69,7 +69,6 @@ public class DbGroup extends DbVersionedBase {
     setOwningOrganization(builder.owningOrganization);
     setName(builder.name);
     setGroupRolesAcl(builder.groupRolesAcl);
-    setPeopleInGroup(builder.peopleInGroup);
   }
 
 
@@ -105,14 +104,6 @@ public class DbGroup extends DbVersionedBase {
     this.groupRolesAcl = groupRolesAcl;
   }
 
-  public Set<DbPerson> getPeopleInGroup() {
-    return peopleInGroup;
-  }
-
-  public void setPeopleInGroup(Set<DbPerson> peopleInGroup) {
-    this.peopleInGroup = peopleInGroup;
-  }
-
   public boolean isAdminGroup() {
     return adminGroup;
   }
@@ -137,6 +128,14 @@ public class DbGroup extends DbVersionedBase {
     }
 
     return null;
+  }
+
+  public List<DbGroupMember> getGroupMembers() {
+    return groupMembers;
+  }
+
+  public void setGroupMembers(List<DbGroupMember> groupMembers) {
+    this.groupMembers = groupMembers;
   }
 
   public static final class Builder {
@@ -205,7 +204,7 @@ public class DbGroup extends DbVersionedBase {
       ", owningOrganization=" + owningOrganization +
       ", name='" + name + '\'' +
       ", groupRolesAcl=" + groupRolesAcl +
-      ", peopleInGroup=" + peopleInGroup +
+      ", peopleInGroup=" + groupMembers +
       '}';
   }
 }

--- a/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroup.java
+++ b/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroup.java
@@ -1,6 +1,8 @@
 package io.featurehub.db.model;
 
 import io.ebean.annotation.ChangeLog;
+import io.ebean.annotation.ConstraintMode;
+import io.ebean.annotation.DbForeignKey;
 import io.ebean.annotation.Index;
 
 import javax.persistence.CascadeType;
@@ -56,7 +58,8 @@ public class DbGroup extends DbVersionedBase {
   @JoinColumn(name = "group_id")
   private Set<DbAcl> groupRolesAcl;
 
-  @OneToMany(cascade = CascadeType.ALL)
+  @DbForeignKey(onDelete = ConstraintMode.CASCADE)
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DbGroupMember> groupMembers;
 
 

--- a/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroupMember.java
+++ b/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroupMember.java
@@ -1,0 +1,43 @@
+package io.featurehub.db.model;
+
+import io.ebean.Model;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "fh_person_group_link")
+public class DbGroupMember extends Model {
+  @EmbeddedId
+  private final DbGroupMemberKey id;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name="fk_person_id", referencedColumnName = "id", foreignKey = @ForeignKey(name="fk_fh_person_group_link_fh_person"))
+  private DbPerson person;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name="fk_group_id", referencedColumnName = "id", foreignKey = @ForeignKey(name=
+    "fk_fh_person_group_link_fh_group"))
+  private DbGroup group;
+
+  public DbGroupMember(DbGroupMemberKey id) {
+    this.id = id;
+  }
+
+  public DbGroupMemberKey getId() {
+    return id;
+  }
+
+  public DbPerson getPerson() {
+    return person;
+  }
+
+  public DbGroup getGroup() {
+    return group;
+  }
+}
+

--- a/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroupMemberKey.java
+++ b/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbGroupMemberKey.java
@@ -1,0 +1,43 @@
+package io.featurehub.db.model;
+
+import io.ebean.Model;
+import org.jetbrains.annotations.NotNull;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Embeddable
+public class DbGroupMemberKey extends Model {
+  @Column(name = "fk_person_id")
+  private final UUID personId;
+  @Column(name = "fk_group_id")
+  private final UUID groupId;
+
+  public DbGroupMemberKey(@NotNull UUID personId, @NotNull UUID groupId) {
+    this.personId = personId;
+    this.groupId = groupId;
+  }
+
+  public UUID getPersonId() {
+    return personId;
+  }
+
+  public UUID getGroupId() {
+    return groupId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DbGroupMemberKey that = (DbGroupMemberKey) o;
+    return getPersonId().equals(that.getPersonId()) && getGroupId().equals(that.getGroupId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getPersonId(), getGroupId());
+  }
+}

--- a/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbPerson.java
+++ b/backend/mr-db-models/src/main/java/io/featurehub/db/model/DbPerson.java
@@ -1,7 +1,9 @@
 package io.featurehub.db.model;
 
 import io.ebean.annotation.ChangeLog;
+import io.ebean.annotation.ConstraintMode;
 import io.ebean.annotation.DbDefault;
+import io.ebean.annotation.DbForeignKey;
 import io.ebean.annotation.Index;
 
 import javax.persistence.CascadeType;
@@ -11,9 +13,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Index(unique = true, name = "idx_person_email", columnNames = {"email"})
@@ -53,11 +57,9 @@ public class DbPerson extends DbVersionedBase {
   @Column(name = "fk_person_who_created")
   private DbPerson whoCreated;
 
-  @ManyToMany(cascade = CascadeType.ALL)
-  @JoinTable(name = "fh_person_group_link",
-    joinColumns = @JoinColumn(name = "fk_person_id", referencedColumnName = "id"),
-    inverseJoinColumns = @JoinColumn(name = "fk_group_id", referencedColumnName = "id"))
-  private Set<DbGroup> groupsPersonIn;
+  @DbForeignKey(onDelete = ConstraintMode.CASCADE)
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<DbGroupMember> groupMembers;
 
   public String getPasswordAlgorithm() {
     return passwordAlgorithm;
@@ -123,12 +125,12 @@ public class DbPerson extends DbVersionedBase {
     this.whoCreated = whoCreated;
   }
 
-  public Set<DbGroup> getGroupsPersonIn() {
-    return groupsPersonIn;
+  public List<DbGroupMember> getGroupMembers() {
+    return groupMembers;
   }
 
-  public void setGroupsPersonIn(Set<DbGroup> groupsPersonIn) {
-    this.groupsPersonIn = groupsPersonIn;
+  public void setGroupMembers(List<DbGroupMember> groupMembers) {
+    this.groupMembers = groupMembers;
   }
 
   public String getToken() {

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ApplicationSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ApplicationSqlApi.java
@@ -174,8 +174,10 @@ public class ApplicationSqlApi implements ApplicationApi {
       Conversions.nonNullPerson(current);
       // we need to ascertain which apps they can actually see based on environments
       queryApplicationList =
-          queryApplicationList.environments.groupRolesAcl.group.peopleInGroup.id.eq(
-              current.getId().getId());
+          queryApplicationList
+              .environments.groupRolesAcl
+              .group.groupMembers.person.id.eq(current.getId().getId());
+
     }
 
     return queryApplicationList.findList().stream()
@@ -533,8 +535,7 @@ public class ApplicationSqlApi implements ApplicationApi {
         .whenArchived
         .isNull()
         .group
-        .peopleInGroup
-        .fetch()
+        .groupMembers.person.fetch()
         .findList()
         .forEach(
             acl -> {
@@ -542,10 +543,10 @@ public class ApplicationSqlApi implements ApplicationApi {
 
               if (agr.getRoles().contains(ApplicationRoleType.FEATURE_EDIT)) {
                 acl.getGroup()
-                    .getPeopleInGroup()
+                  .getGroupMembers()
                     .forEach(
                         p -> {
-                          featureEditors.add(p.getId());
+                          featureEditors.add(p.getPerson().getId());
                         });
               }
             });
@@ -571,15 +572,15 @@ public class ApplicationSqlApi implements ApplicationApi {
         .whenArchived
         .isNull()
         .group
-        .peopleInGroup
+        .groupMembers.person
         .fetch()
         .findList()
         .forEach(
             acl -> {
               if (acl.getApplication() != null || acl.getRoles().trim().length() > 0) {
                 acl.getGroup()
-                    .getPeopleInGroup()
-                    .forEach(p -> featureReaders.add(p.getId()));
+                    .getGroupMembers()
+                    .forEach(p -> featureReaders.add(p.getPerson().getId()));
               }
             });
 
@@ -614,7 +615,7 @@ public class ApplicationSqlApi implements ApplicationApi {
               .whenArchived
               .isNull()
               .group
-              .peopleInGroup
+              .groupMembers.person
               .eq(person)
               .findList()) {
         if (acl.getApplication() != null) {

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
@@ -50,6 +50,8 @@ import io.featurehub.mr.model.ServiceAccountPermission;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -68,6 +70,7 @@ import java.util.stream.Collectors;
 
 @Singleton
 public class ConvertUtils implements Conversions {
+  private static final Logger log = LoggerFactory.getLogger(ConvertUtils.class);
 
   @Override
   public DbPerson byPerson(UUID personId) {
@@ -82,7 +85,7 @@ public class ConvertUtils implements Conversions {
 
     QDbPerson finder = new QDbPerson().id.eq(personId);
     if (opts.contains(FillOpts.Groups)) {
-      finder = finder.groupsPersonIn.fetch();
+      finder = finder.groupMembers.fetch();
     }
 
     return finder.findOne();
@@ -427,14 +430,18 @@ public class ConvertUtils implements Conversions {
     }
 
     if (opts.contains(FillOpts.Groups)) {
-      new QDbGroup()
-          .whenArchived
-          .isNull()
-          .groupMembers.person
-          .eq(dbp)
-          .owningOrganization
-          .id.eq(org == null ? getOrganizationId() : org.getId())
-          .findList()
+      final List<DbGroup> groupList = new QDbGroup()
+        .whenArchived
+        .isNull()
+        .groupMembers.person
+        .eq(dbp)
+        .owningOrganization
+        .id.eq(org == null ? getOrganizationId() : org.getId())
+        .findList();
+
+      log.info("groups for person {} are {}", p, groupList);
+
+      groupList
           .forEach(dbg -> p.addGroupsItem(toGroup(dbg, opts.minus(FillOpts.Groups))));
     }
 
@@ -464,7 +471,7 @@ public class ConvertUtils implements Conversions {
               : dbg.getOwningOrganization();
       group.setMembers(
           new QDbPerson()
-              .order().name.asc().whenArchived.isNull().groupsPersonIn.eq(dbg).findList().stream()
+              .order().name.asc().whenArchived.isNull().groupMembers.group.eq(dbg).findList().stream()
                   .map(
                       p ->
                           this.toPerson(

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/ConvertUtils.java
@@ -134,7 +134,7 @@ public class ConvertUtils implements Conversions {
             .isNull()
             .adminGroup
             .isTrue()
-            .peopleInGroup
+            .groupMembers.person
             .id
             .eq(person.getId())
             .exists();
@@ -147,7 +147,7 @@ public class ConvertUtils implements Conversions {
             .isNull()
             .owningPortfolio
             .isNull()
-            .peopleInGroup
+            .groupMembers.person
             .eq(person)
             .adminGroup
             .isTrue()
@@ -430,7 +430,7 @@ public class ConvertUtils implements Conversions {
       new QDbGroup()
           .whenArchived
           .isNull()
-          .peopleInGroup
+          .groupMembers.person
           .eq(dbp)
           .owningOrganization
           .id.eq(org == null ? getOrganizationId() : org.getId())
@@ -794,7 +794,7 @@ public class ConvertUtils implements Conversions {
 
     QDbGroup eq = new QDbGroup().id.eq(gid);
     if (opts.contains(FillOpts.Members)) {
-      eq = eq.peopleInGroup.fetch();
+      eq = eq.groupMembers.person.fetch();
     }
 
     return eq.findOne();
@@ -814,7 +814,7 @@ public class ConvertUtils implements Conversions {
   public boolean isPersonApplicationAdmin(DbPerson dbPerson, DbApplication app) {
     // if a person is in a null portfolio group or portfolio group
     return new QDbGroup()
-            .peopleInGroup
+            .groupMembers.person
             .eq(dbPerson)
             .owningOrganization
             .eq(app.getPortfolio().getOrganization())
@@ -948,7 +948,7 @@ public class ConvertUtils implements Conversions {
             .isTrue()
             .owningPortfolio
             .isNull()
-            .peopleInGroup
+            .groupMembers.person
             .fetch()
             .findOne();
 

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/GroupSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/GroupSqlApi.java
@@ -11,11 +11,14 @@ import io.featurehub.db.model.DbAcl;
 import io.featurehub.db.model.DbApplication;
 import io.featurehub.db.model.DbEnvironment;
 import io.featurehub.db.model.DbGroup;
+import io.featurehub.db.model.DbGroupMember;
+import io.featurehub.db.model.DbGroupMemberKey;
 import io.featurehub.db.model.DbOrganization;
 import io.featurehub.db.model.DbPerson;
 import io.featurehub.db.model.DbPortfolio;
 import io.featurehub.db.model.query.QDbAcl;
 import io.featurehub.db.model.query.QDbGroup;
+import io.featurehub.db.model.query.QDbGroupMember;
 import io.featurehub.db.model.query.QDbOrganization;
 import io.featurehub.db.model.query.QDbPerson;
 import io.featurehub.db.model.query.QDbPortfolio;
@@ -62,7 +65,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     Conversions.nonNullPortfolioId(portfolioId);
     Conversions.nonNullPersonId(personId);
 
-    return new QDbGroup().owningPortfolio.id.eq(portfolioId).peopleInGroup.id.eq(personId).exists();
+    return new QDbGroup().owningPortfolio.id.eq(portfolioId).groupMembers.person.id.eq(personId).exists();
   }
 
   private boolean isPersonMemberOfPortfolioAdminGroup(DbPortfolio portfolio, UUID personId) {
@@ -77,8 +80,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
         .eq(portfolio)
         .adminGroup
         .isTrue()
-        .peopleInGroup
-        .id
+        .groupMembers.person.id
         .eq(personId)
         .exists();
   }
@@ -103,7 +105,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .isTrue()
             .owningPortfolio
             .isNull()
-            .peopleInGroup
+            .groupMembers.person
             .fetch()
             .findOne();
 
@@ -126,7 +128,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .isNull()
             .adminGroup
             .eq(true)
-            .peopleInGroup
+            .groupMembers.person
             .id
             .eq(pId)
             .findList()
@@ -146,7 +148,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .whenArchived
             .isNull()
             .group
-            .peopleInGroup
+            .groupMembers.person
             .id
             .eq(personI)
             .endAnd()
@@ -157,7 +159,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .isNull()
             .portfolios
             .groups
-            .peopleInGroup
+            .groupMembers.person
             .id
             .eq(personI)
             .endAnd()
@@ -311,7 +313,20 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
   private void copySuperusersToPortfolioGroup(DbGroup dbGroup) {
     superuserGroupMembers(dbGroup.getOwningPortfolio().getOrganization())
         .forEach(
-            (p) -> dbGroup.getPeopleInGroup().add(p));
+            (p) -> {
+              if (!new QDbGroupMember()
+                  .person
+                  .id
+                  .eq(p.getId())
+                  .group
+                  .id
+                  .eq(dbGroup.getId())
+                  .exists()) {
+                dbGroup
+                    .getGroupMembers()
+                    .add(new DbGroupMember(new DbGroupMemberKey(p.getId(), dbGroup.getId())));
+              }
+            });
 
     database.save(dbGroup);
   }
@@ -337,24 +352,29 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
       DbPerson person = new QDbPerson().id.eq(personId).whenArchived.isNull().findOne();
 
       if (person != null) {
-        QDbGroup groupFinder = new QDbGroup().id.eq(groupId).peopleInGroup.id.eq(personId);
+        QDbGroup groupFinder = new QDbGroup().id.eq(groupId).groupMembers.person.id.eq(personId);
 
         if (opts.contains(FillOpts.Members)) {
-          groupFinder.peopleInGroup.fetch(); // ensure we prefetch the users in the group
+          groupFinder.groupMembers.person.fetch(); // ensure we prefetch the users in the group
         }
 
         final DbGroup one = groupFinder.findOne();
         if (one == null) {
           // ebean ensures this is never null
-          dbGroup.getPeopleInGroup().add(person);
+          if (!new QDbGroupMember().person.id.eq(person.getId()).group.id.eq(dbGroup.getId()).exists()) {
+            dbGroup
+                .getGroupMembers()
+                .add(new DbGroupMember(new DbGroupMemberKey(person.getId(), dbGroup.getId())));
 
-          saveGroup(dbGroup);
+            saveGroup(dbGroup);
+          }
 
           // they actually got added from the superusers group, so
           // lets update the portfolios
           if (dbGroup.isAdminGroup() && dbGroup.getOwningPortfolio() == null) {
             SuperuserChanges sc = new SuperuserChanges(dbGroup.getOwningOrganization());
             sc.addedSuperusers = Collections.singletonList(person);
+            sc.ignoredGroups.add(dbGroup.getId());
             updateSuperusersFromPortfolioGroups(sc);
           }
 
@@ -373,7 +393,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     Conversions.nonNullGroupId(gid);
     Conversions.nonNullPerson(person);
 
-    QDbGroup eq = new QDbGroup().id.eq(gid).peopleInGroup.fetch();
+    QDbGroup eq = new QDbGroup().id.eq(gid).groupMembers.person.fetch();
 
     if (!opts.contains(FillOpts.Archived)) {
       eq = eq.whenArchived.isNull();
@@ -382,7 +402,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     final DbGroup one = eq.findOne();
 
     if (one != null
-        && (new QDbGroup().id.eq(gid).peopleInGroup.whenArchived.isNull().peopleInGroup.id.eq(person.getId().getId()).exists()
+        && (new QDbGroup().id.eq(gid).groupMembers.person.whenArchived.isNull().groupMembers.person.id.eq(person.getId().getId()).exists()
             || isSuperuser(one.findOwningOrganisation(), convertUtils.byPerson(person))
             || isPersonMemberOfPortfolioAdminGroup(
                 one.getOwningPortfolio(), person.getId().getId()))) {
@@ -404,7 +424,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     QDbGroup groupFinder = new QDbGroup().owningPortfolio.eq(portfolio);
     groupFinder = groupFinder.adminGroup.is(true);
     if (opts.contains(FillOpts.Members)) {
-      groupFinder.peopleInGroup.fetch(); // ensure we prefetch the users in the group
+      groupFinder.groupMembers.person.fetch(); // ensure we prefetch the users in the group
     }
 
     return convertUtils.toGroup(groupFinder.findOne(), opts);
@@ -439,7 +459,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     return new QDbGroup()
             .whenArchived
             .isNull()
-            .peopleInGroup
+            .groupMembers.person
             .id
             .eq(personId)
             .and()
@@ -472,24 +492,30 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
     DbPerson person = convertUtils.byPerson(personId);
 
     if (person != null) {
-      DbGroup group =
-          new QDbGroup().id.eq(groupId).whenArchived.isNull().peopleInGroup.eq(person).findOne();
+
+      final DbGroupMember member = new QDbGroupMember()
+        .person.id.eq(personId)
+        .group.id.eq(groupId)
+        .group.whenArchived.isNull()
+        .group.fetch()
+        .findOne();
+
+      if (member == null) { return null; }
+      DbGroup group = member.getGroup();
+
       // if it is an admin portfolio group and they are a superuser, you can't remove them
-      if (group == null
-          || (group.isAdminGroup()
+      if (group.isAdminGroup()
               && group.getOwningPortfolio() != null
-              && isSuperuser(group.getOwningPortfolio().getOrganization(), person))) {
+              && isSuperuser(group.getOwningPortfolio().getOrganization(), person)) {
         return null;
       }
 
-      group.getPeopleInGroup().remove(person);
-
-      saveGroup(group);
+      deleteMember(member);
 
       // they actually got removed from the superusers group, so lets update the portfolios
       if (group.isAdminGroup() && group.getOwningPortfolio() == null) {
         SuperuserChanges sc = new SuperuserChanges(group.getOwningOrganization());
-        sc.removedSuperusers = Collections.singletonList(person);
+        sc.removedSuperusers = Collections.singletonList(person.getId());
         updateSuperusersFromPortfolioGroups(sc);
       }
 
@@ -500,14 +526,22 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
   }
 
   @Transactional
+  private void deleteMember(DbGroupMember member) {
+    member.delete();
+  }
+
+  @Transactional
   private void saveGroup(DbGroup group) {
     database.save(group);
   }
 
   public static class SuperuserChanges {
     public DbOrganization organization;
-    public List<DbPerson> removedSuperusers = new ArrayList<>();
+    public List<UUID> removedSuperusers = new ArrayList<>();
     public List<DbPerson> addedSuperusers = new ArrayList<>();
+    public List<UUID> ignoredGroups = new ArrayList<>();
+    // if we just added a person to a group, don't add them
+    // again
 
     public SuperuserChanges(DbOrganization organization) {
       this.organization = organization;
@@ -570,7 +604,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
   @Transactional
   protected void updateSuperusersFromPortfolioGroups(
       @NotNull SuperuserChanges superuserChanges) {
-    for (DbGroup pGroups :
+    for (DbGroup group :
         new QDbGroup()
             .adminGroup
             .isTrue()
@@ -581,21 +615,25 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .eq(superuserChanges.organization)
             .findList()) {
 
+      if (superuserChanges.ignoredGroups.contains(group.getId())) {
+        continue;
+      }
+
       // remove any superusers
       if (!superuserChanges.removedSuperusers.isEmpty()) {
-        pGroups.getPeopleInGroup().removeAll(superuserChanges.removedSuperusers);
+        new QDbGroupMember()
+          .group.id.eq(group.getId())
+          .person.id.in(superuserChanges.removedSuperusers).delete();
       }
 
       // add superusers but only if they aren't there already
       if (!superuserChanges.addedSuperusers.isEmpty()) {
         for (DbPerson p : superuserChanges.addedSuperusers) {
-          if (!pGroups.getPeopleInGroup().contains(p)) {
-            pGroups.getPeopleInGroup().add(p);
+          if (!new QDbGroupMember().person.id.eq(p.getId()).group.id.eq(group.getId()).exists()) {
+            new DbGroupMember(new DbGroupMemberKey(p.getId(), group.getId())).save();
           }
         }
       }
-
-      database.save(pGroups);
     }
   }
 
@@ -782,7 +820,7 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
 
     // if this is the superuser group, we will have to remove these people from all portfolio groups
     // as well
-    List<DbPerson> removedPerson = new ArrayList<>();
+    List<UUID> removedPerson = new ArrayList<>();
 
     // ensure no duplicates get through
     Set<UUID> addedPeople =
@@ -792,35 +830,35 @@ public class GroupSqlApi implements io.featurehub.db.api.GroupApi {
             .collect(Collectors.toSet());
 
     boolean isSuperuserGroup = group.isAdminGroup() && group.getOwningPortfolio() == null;
-    List<DbPerson> superusers =
+    List<UUID> superusers =
         group.isAdminGroup() && !isSuperuserGroup
-            ? superuserGroupMembers(group.getOwningPortfolio().getOrganization())
+            ? superuserGroupMembers(group.getOwningPortfolio().getOrganization()).stream().map(DbPerson::getId).collect(Collectors.toList())
             : new ArrayList<>();
 
-    group
-        .getPeopleInGroup()
-        .forEach(
-            person -> {
-              Person p = desiredPeople.get(person.getId());
-              if (p == null) { // delete them
-                // can't delete superusers from portfolio group. if this is the superusergroup or
-                // isn't an admin group, superusers will be empty
-                if (!superusers.contains(person)) {
-                  removedPerson.add(person);
-                }
-              } else {
-                addedPeople.remove(
-                    p.getId().getId()); // they are already there, remove them from list to add
-              }
-            });
-    group.getPeopleInGroup().removeAll(removedPerson);
+    new QDbGroupMember().group.id.eq(group.getId()).person.fetch(QDbPerson.Alias.id).findList().forEach(member -> {
+      final UUID personId = member.getPerson().getId();
+      Person p = desiredPeople.get(personId);
+      if (p == null) { // delete them
+        // can't delete superusers from portfolio group. if this is the superusergroup or
+        // isn't an admin group, superusers will be empty
+        if (!superusers.contains(personId)) {
+          removedPerson.add(personId);
+        }
+      } else {
+        addedPeople.remove(personId); // they are already there, remove them from list to add
+      }
+    });
+    new QDbGroupMember().group.id.eq(group.getId()).person.id.in(removedPerson).delete();
+
     List<DbPerson> actuallyAddedPeople = new ArrayList<>();
     addedPeople.forEach(
         p -> {
           DbPerson person = convertUtils.byPerson(p);
           if (person != null) {
-            group.getPeopleInGroup().add(person);
-            actuallyAddedPeople.add(person);
+            if (!new QDbGroupMember().person.id.eq(person.getId()).group.id.eq(group.getId()).exists()) {
+              new DbGroupMember(new DbGroupMemberKey(person.getId(), group.getId())).save();
+              actuallyAddedPeople.add(person);
+            }
           }
         });
 

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/PortfolioSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/PortfolioSqlApi.java
@@ -66,7 +66,7 @@ public class PortfolioSqlApi implements io.featurehub.db.api.PortfolioApi {
     }
 
     if (convertUtils.personIsNotSuperAdmin(personDoingFind)) {
-      pFinder = pFinder.groups.peopleInGroup.id.eq(personDoingFind.getId());
+      pFinder = pFinder.groups.groupMembers.person.id.eq(personDoingFind.getId());
     }
 
     pFinder = finder(pFinder, opts);
@@ -148,7 +148,7 @@ public class PortfolioSqlApi implements io.featurehub.db.api.PortfolioApi {
 
     QDbPortfolio finder = finder(new QDbPortfolio().id.eq(id), opts);
     if (convertUtils.personIsNotSuperAdmin(personDoingFind)) {
-      finder = finder.groups.peopleInGroup.id.eq(personDoingFind.getId());
+      finder = finder.groups.groupMembers.person.id.eq(personDoingFind.getId());
     }
 
     return finder.findOneOrEmpty().map(portf -> convertUtils.toPortfolio(portf, opts)).orElse(null);

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/FeatureSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/FeatureSqlApi.kt
@@ -360,7 +360,7 @@ class FeatureSqlApi @Inject constructor(
 
     val adminRoles = listOf(*RoleType.values())
     if (!personAdmin) { // is they aren't a portfolio admin, figure out what their permissions are to each environment
-      QDbAcl().environment.parentApplication.eq(app).group.peopleInGroup.eq(dbPerson).findList().forEach { fe: DbAcl ->
+      QDbAcl().environment.parentApplication.eq(app).group.groupMembers.person.eq(dbPerson).findList().forEach { fe: DbAcl ->
           log.debug(
             "Found environment `{}`, app `{}`, group `{}`, roles `{}`",
             if (fe.environment == null) "<none>" else fe.environment.name,
@@ -397,7 +397,7 @@ class FeatureSqlApi @Inject constructor(
       }
     }
     val appRoles = QDbAcl().application.isNotNull
-      .select(QDbAcl.Alias.roles).roles.isNotNull.group.whenArchived.isNull.group.owningPortfolio.eq(app.portfolio).group.peopleInGroup.eq(
+      .select(QDbAcl.Alias.roles).roles.isNotNull.group.whenArchived.isNull.group.owningPortfolio.eq(app.portfolio).group.groupMembers.person.eq(
         dbPerson
       ).findList().stream()
       .map { appAcl: DbAcl -> convertUtils.splitApplicationRoles(appAcl.roles) }
@@ -514,7 +514,13 @@ class FeatureSqlApi @Inject constructor(
       val environmentOrderingMap: MutableMap<UUID, DbEnvironment> = HashMap()
       // the requirement is that we only send back environments they have at least READ access to
       val permEnvs =
-        QDbAcl().environment.whenArchived.isNull.environment.parentApplication.eq(app).environment.parentApplication.whenArchived.isNull.environment.parentApplication.groupRolesAcl.fetch().group.whenArchived.isNull.group.peopleInGroup.eq(
+        QDbAcl()
+          .environment.whenArchived.isNull
+          .environment.parentApplication.eq(app)
+          .environment.parentApplication.whenArchived.isNull
+          .environment.parentApplication.groupRolesAcl.fetch()
+          .group.whenArchived.isNull
+          .group.groupMembers.person.eq(
           dbPerson
         ).findList()
           .stream()

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/ServiceAccountSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/ServiceAccountSqlApi.kt
@@ -157,11 +157,12 @@ class ServiceAccountSqlApi @Inject constructor(
       && application != null && (opts.contains(FillOpts.Permissions) || opts.contains(FillOpts.SdkURL))
     ) {
       environmentPermissions.addAll(
-        QDbAcl().roles.notEqualTo("").environment.parentApplication.eq(application).environment.whenUnpublished.isNull.environment.whenArchived.isNull.group.peopleInGroup.eq(
-          person
-        ).environment.fetch(
-          QDbEnvironment.Alias.id
-        )
+        QDbAcl().roles.notEqualTo("")
+          .environment.parentApplication.eq(application)
+          .environment.whenUnpublished.isNull
+          .environment.whenArchived.isNull
+          .group.groupMembers.person.eq(person)
+          .environment.fetch(QDbEnvironment.Alias.id)
           .findList()
       )
     }


### PR DESCRIPTION
# Description

Remove the many-many for DbGroup and DbPerson and expose it as a standalone class. Unable to control the foreign key generated by ebean however commenting the change out so it doesn't matter.

