### PR TITLE
Minor refactoring

### DIFF
--- a/backend/edge-full/src/main/java/io/featurehub/edge/NamedCacheFeatureStreamListener.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/NamedCacheFeatureStreamListener.java
@@ -18,7 +18,7 @@ class NamedCacheFeatureStreamListener {
   private int listenerCount;
   private final String subject;
   private final String cacheName;
-  Dispatcher dispatcher;
+  private final Dispatcher dispatcher;
 
   private static final Map<String, Gauge> cacheGauge = new HashMap<>();
 

--- a/backend/edge-full/src/main/java/io/featurehub/edge/StreamingFeatureSource.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/StreamingFeatureSource.java
@@ -140,7 +140,7 @@ public class StreamingFeatureSource implements StreamingFeatureController {
   //  private Map<String, InflightSdkUrlRequest> expired
 
   public void requestFeatures(final ClientConnection client) {
-    Collection<ClientConnection> clientConnections = null;
+    Collection<ClientConnection> clientConnections;
 
     synchronized (notifyOnIncomingFeatureUpdate) {
       clientConnections =

--- a/backend/edge-full/src/main/java/io/featurehub/edge/rest/SSEHeaderFilter.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/rest/SSEHeaderFilter.java
@@ -6,14 +6,12 @@ import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.ext.Provider;
 
-import java.io.IOException;
-
 @Provider
 @PreMatching
 public class SSEHeaderFilter implements ContainerResponseFilter {
 
   @Override
-  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
     if (requestContext.getUriInfo().getPath().startsWith("features/")) {
       responseContext.getHeaders().add("X-Accel-Buffering", "no");
     }

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/Stat.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/Stat.kt
@@ -14,7 +14,7 @@ class Stat {
   var hitSourceType: EdgeHitSourceType = EdgeHitSourceType.EVENTSOURCE
 
   companion object {
-    val DEFAULT_UUID = UUID.randomUUID() // we don't care what it is, we just want it to never be null
+    val DEFAULT_UUID: UUID = UUID.randomUUID() // we don't care what it is, we just want it to never be null
 
     fun create(apiKey: KeyParts, resultType: EdgeHitResultType, hitSourceType: EdgeHitSourceType): Stat{
       val s = Stat()

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatDisruptor.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatDisruptor.kt
@@ -40,11 +40,11 @@ open class StatDisruptor @Inject constructor(eventHandler: EventHandler<Stat>) :
     ringBuffer = disruptor.ringBuffer
   }
 
-  open protected fun getThreadFactory(): ThreadFactory {
+  protected open fun getThreadFactory(): ThreadFactory {
     return DaemonThreadFactory.INSTANCE
   }
 
-  private val TRANSLATOR: EventTranslatorThreeArg<Stat, KeyParts, EdgeHitResultType, EdgeHitSourceType> =
+  private val translator: EventTranslatorThreeArg<Stat, KeyParts, EdgeHitResultType, EdgeHitSourceType> =
     EventTranslatorThreeArg<Stat, KeyParts, EdgeHitResultType, EdgeHitSourceType> { event, _, apiKey, resultType, hitType ->
       event.apiKey = apiKey
       event.resultType = resultType
@@ -53,7 +53,7 @@ open class StatDisruptor @Inject constructor(eventHandler: EventHandler<Stat>) :
 
   override fun recordHit(apiKey: KeyParts, resultType: EdgeHitResultType, hitSourceType: EdgeHitSourceType) {
     if (resultType != EdgeHitResultType.MISSED || publishMisses == true) {
-      ringBuffer.publishEvent(TRANSLATOR, apiKey, resultType, hitSourceType)
+      ringBuffer.publishEvent(translator, apiKey, resultType, hitSourceType)
     }
   }
 }

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatKeyEventCollection.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatKeyEventCollection.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong
 /**
  * This represents a single API key and its list of possible stats
  */
-class StatKeyEventCollection(val apiKey: KeyParts) {
+class StatKeyEventCollection(private val apiKey: KeyParts) {
   private val counters = ConcurrentHashMap<StatType, AtomicLong>()
 
   private class StatType(val resultType: EdgeHitResultType, val hitSourceType: EdgeHitSourceType) {
@@ -44,7 +44,7 @@ class StatKeyEventCollection(val apiKey: KeyParts) {
   }
 
   fun size(): Int {
-    return counters.size;
+    return counters.size
   }
 
   fun squash(): EdgeStatApiKey? {

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatTimeTrigger.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatTimeTrigger.kt
@@ -15,7 +15,7 @@ class StatTimeTrigger @Inject constructor(private val statCollector: StatCollect
   @ConfigKey("edge.stats.publish-interval-ms")
   var publishBundleInterval: Long? = 0
 
-  var timer: Timer? = null
+  private var timer: Timer? = null
 
   init {
     DeclaredConfigResolver.resolve(this)
@@ -36,7 +36,7 @@ class StatTimeTrigger @Inject constructor(private val statCollector: StatCollect
     }
   }
 
-  public fun shutdownTimer() {
+  fun shutdownTimer() {
 
   }
 }

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatsCollectionOrchestrator.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatsCollectionOrchestrator.kt
@@ -24,9 +24,9 @@ class StatsCollectionOrchestrator @Inject constructor(private val publisher: Sta
   var maxApiKeysPerPublish: Long? = 300
 
   companion object Prometheus {
-    val publishTimeHistogram = Histogram.build("edge_publish_time", "Time taken to publish stats to NATS").register()
-    val successfulPublishing = Counter.build("edge_publish_success", "Number of successes for publishing").register()
-    val failedPublishing = Counter.build("edge_publish_failure", "Number of failures for publishing").register()
+    val publishTimeHistogram: Histogram = Histogram.build("edge_publish_time", "Time taken to publish stats to NATS").register()
+    val successfulPublishing: Counter = Counter.build("edge_publish_success", "Number of successes for publishing").register()
+    val failedPublishing: Counter = Counter.build("edge_publish_failure", "Number of failures for publishing").register()
   }
 
   init {
@@ -39,8 +39,8 @@ class StatsCollectionOrchestrator @Inject constructor(private val publisher: Sta
       return true
     }
 
-    var returnVal = true;
-    publishTimeHistogram?.time {
+    var returnVal = true
+    publishTimeHistogram.time {
       log.trace("stats: {} records to process", stats.size)
       // split by cache
       val perCachePublish = HashMap<String, EdgeStatsBundle>()

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatsFeature.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/stats/StatsFeature.kt
@@ -30,7 +30,7 @@ class StatsFeature : Feature {
 
         bind(StatDisruptor::class.java).to(StatRecorder::class.java).`in`(Singleton::class.java)
 
-        if (whichStatsPublisherToUse.equals("nats")) {
+        if (whichStatsPublisherToUse == "nats") {
           bind(NATSStatPublisher::class.java).to(StatPublisher::class.java).`in`(Singleton::class.java)
         }
 


### PR DESCRIPTION
# Description

In SSEHeaderFilter, removed unwanted IOException
In Stat.kt and StatsCollectionOrchestrator.kt - Specified type explicitly to avoid unchecked nullability issues from a declaration where the type was inferred from a platform call.
In StatEventHandler, replaced .map(){}.toMap() with associateWith()
In StatTimeTrigger, made timer private to avoid indecent exposure code smell. Also, public access specifier was redundant for shutdownTimer()

Fixes # (issue)

## Type of change

- [x] Refactoring

# How Has This Been Tested?

- [x] Ran all the unit tests