### PR TITLE
[internal/icon-fix] icon not being served properly

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
@@ -60,7 +60,7 @@ class DelegatingHandler(
       return jerseyHandler.service(request, response)
     }
 
-    if (url.isEmpty() || url == "/" || url.endsWith(".html") || url.endsWith(".js") || url.startsWith("/assets") || url.startsWith("/canvaskit")) {
+    if (url.isEmpty() || url == "/" || url.endsWith(".ico") || url.endsWith(".html") || url.endsWith(".js") || url.startsWith("/assets") || url.startsWith("/canvaskit")) {
       return staticHttpHandler.service(request, response)
     }
 


### PR DESCRIPTION
Due to a filtering issue, the icon was not being served properly - it was HTML.