### PR TITLE
[feature/oauth2-generic-headers] oauth2 token headers and form

### DIFF
--- a/admin-frontend/src/main/resources/post-build-assembly.xml
+++ b/admin-frontend/src/main/resources/post-build-assembly.xml
@@ -1,0 +1,14 @@
+<assembly>
+  <id>admin-ui-zip</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>target/open_admin_app/build/web</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/admin-frontend/src/main/resources/pre-build-assembly.xml
+++ b/admin-frontend/src/main/resources/pre-build-assembly.xml
@@ -1,0 +1,29 @@
+<assembly>
+  <id>admin-ui-to-build</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>tar</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>open_admin_app</directory>
+      <outputDirectory>open_admin_app</outputDirectory>
+      <excludes>
+        <exclude>.dart_tool/**/*</exclude>
+        <exclude>build/**/*</exclude>
+        <exclude>pom.xml</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>app_mr_layer</directory>
+      <outputDirectory>app_mr_layer</outputDirectory>
+      <excludes>
+        <exclude>.dart_tool/**/*</exclude>
+        <exclude>build/**/*</exclude>
+        <exclude>target/**/*</exclude>
+        <exclude>pom.xml</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2JerseyClient.kt
+++ b/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2JerseyClient.kt
@@ -27,8 +27,11 @@ class OAuth2JerseyClient @Inject constructor(protected val client: Client) : OAu
 
     form.param("redirect_uri", redirectUrl)
     form.param("code", code)
+    val target = client.target(provider.requestTokenUrl())
+    var request = target.request()
+
+    provider.enhanceTokenRequest(request, form)
     val entity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE)
-    var request = client.target(provider.requestTokenUrl()).request()
 
     if (provider.isSecretInHeader()) {
       val code = "${provider.clientId}:${provider.clientSecret}"

--- a/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/providers/OAuth2Provider.kt
+++ b/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/providers/OAuth2Provider.kt
@@ -1,6 +1,8 @@
 package io.featurehub.web.security.oauth.providers
 
 import io.featurehub.web.security.oauth.AuthClientResult
+import jakarta.ws.rs.client.Invocation.Builder
+import jakarta.ws.rs.core.Form
 
 data class OAuth2ProviderCustomisation(val icon: String, val buttonBackgroundColor: String, val buttonText: String)
 
@@ -15,6 +17,11 @@ interface OAuth2Provider {
     // (NOT the web front end) with this token + the secret and get the details of the user. This process will result in a
     // AuthClientResult which gets resolved in discoverProviderUser
   fun requestTokenUrl(): String
+
+  /**
+   * Allows an oauth2 implementation to do "extra stuff"
+   */
+  fun enhanceTokenRequest(request: Builder, form: Form) {}
 
     // 1: if a person chooses this provider, then they get redirected to this url - completely away from our app,
     // NOT SPA. When the user has logged in, it will redirect the user back to our web host (NOT our front end)

--- a/backend/security-oauth/src/test/groovy/io/featurehub/web/security/oauth/providers/GroovyOAuthProviderSpec.groovy
+++ b/backend/security-oauth/src/test/groovy/io/featurehub/web/security/oauth/providers/GroovyOAuthProviderSpec.groovy
@@ -1,0 +1,52 @@
+package io.featurehub.web.security.oauth.providers
+
+import jakarta.ws.rs.client.Invocation
+import jakarta.ws.rs.core.Form
+import spock.lang.Specification
+
+class GroovyOAuthProviderSpec extends Specification {
+  def data = []
+
+  def sp(String key, String val) {
+    System.setProperty(key, val)
+    data.add(key)
+  }
+
+  def cleanup() {
+    data.each { System.clearProperty(it) }
+    data.clear()
+  }
+  def clearProperties() {
+
+  }
+  def "i can configure and augment the request"() {
+    given:
+      sp("oauth2.providers.generic.secret", "client-secret")
+      sp("oauth2.providers.generic.auth-url", "http://blah.com?name=value")
+      sp("oauth2.providers.generic.id", "client-secret")
+      sp("oauth2.providers.generic.secret-in-header", "true")
+      sp("oauth2.providers.generic.scope", "scope+more+scope")
+      sp("oauth2.providers.generic.name-fields", "name")
+      sp("oauth2.providers.generic.token-url", "http://token.com?name=value")
+      sp("oauth2.providers.generic.email-field", "email")
+      sp("oauth2.providers.generic.icon.url", "http://icon.com")
+      sp("oauth2.providers.generic.icon.background-color", "black")
+      sp("oauth2.providers.generic.icon.text", "icon-text")
+      sp("oauth2.redirectUrl", "redirect-url")
+      sp("oauth2.providers.generic.token-header-pairs", "fred=flintstone,child=bambam")
+      sp("oauth2.providers.generic.token-form-pairs", "wilma=boss,betty=rubble")
+    and:
+      def req = Mock(Invocation.Builder)
+      def form = new Form()
+      def gen = new GenericOAuthProvider()
+    when:
+      gen.enhanceTokenRequest(req, form)
+    then:
+      1 * req.header('fred', 'flintstone')
+      1 * req.header('child', 'bambam')
+      form.asMap()['wilma'] == ['boss']
+      form.asMap()['betty'] == ['rubble']
+
+      gen.requestTokenUrl() == "http://token.com?name=value"
+  }
+}

--- a/backend/security-oauth/src/test/groovy/io/featurehub/web/security/oauth/providers/OAuth2JerseyClientSpec.groovy
+++ b/backend/security-oauth/src/test/groovy/io/featurehub/web/security/oauth/providers/OAuth2JerseyClientSpec.groovy
@@ -1,0 +1,48 @@
+package io.featurehub.web.security.oauth.providers
+
+import io.featurehub.web.security.oauth.AuthClientResult
+import io.featurehub.web.security.oauth.OAuth2JerseyClient
+import jakarta.ws.rs.client.Client
+import jakarta.ws.rs.client.Invocation
+import jakarta.ws.rs.client.WebTarget
+import jakarta.ws.rs.core.Form
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import spock.lang.Specification
+
+class OAuth2JerseyClientSpec extends Specification {
+  def cleanup() {
+    System.clearProperty("oauth2.redirectUrl")
+  }
+    def "every oauth2 provider gets asked to enhance the header and form"() {
+      given: "we have a basic setup"
+        System.setProperty("oauth2.redirectUrl", "http://redirect-url")
+        def client = Mock(Client)
+        def provider = Mock(OAuth2Provider)
+        provider.clientId >> "client-id"
+        provider.clientSecret >> "client-secret"
+        provider.secretInHeader >> true
+        provider.requestTokenUrl() >> { ->"http://token.com" }
+      and: "a request"
+        def req = Mock(Invocation.Builder)
+        def target = Mock(WebTarget)
+        def response = Response.status(400).build()
+      and: "a oauth2 jersey client"
+        def jClient = new OAuth2JerseyClient(client)
+      when:
+        jClient.requestAccess("code", provider)
+      then:
+        1 * provider.enhanceTokenRequest(req, { Form f ->
+          f.asMap()["client_id"] == ["client-id"]
+          !f.asMap().containsKey("client_secret")
+        })
+        1 * client.target((String)_) >> target
+        1 * req.header("Authorization", _) >> req
+//        1 * client.target({ String uri ->
+//          uri == "http://redirect-uri"
+//        }) >> target
+        1 * target.request() >> req
+        1 * req.accept(MediaType.APPLICATION_JSON) >> req
+        1 * req.post(_) >> response
+    }
+}

--- a/docs/modules/ROOT/pages/identity.adoc
+++ b/docs/modules/ROOT/pages/identity.adoc
@@ -160,7 +160,11 @@ oauth2.providers.generic.email-field[optional, field to find inside JWT for user
 oauth2.providers.generic.icon.url=[required, full icon url, including https]
 oauth2.providers.generic.icon.background-color=[required, background colour in 0x format, e.g. 0xFFF44336 is a redish colour] 
 oauth2.providers.generic.icon.text=[required,text to appear on button]
+oauth2.providers.generic.token-form-pairs=[optional, map-format, gets added to form body of token request]
+oauth2.providers.generic.token-header-pairs=[optional, map-format, gets added to the token request]
 ----
+
+map-format are key-value pairs separated by `=` - e.g. `auth-key=6152563,specialName=JAHSkk12C`
 
 If your IdP needs the client secret to be Base64 encoded in the header,
 add this  configuration:


### PR DESCRIPTION
Support extra headers and form entries for oauth2
generic provider. fixes #775

