### PR TITLE
[internal/fix-migration] Database migration for person vs admin service account

### DIFF
--- a/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.15.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/h2/1.15.sql
@@ -1,2 +1,2 @@
 -- apply alter tables
-alter table fh_person add column person_type varchar(100) default 'person';
+alter table fh_person add column person_type varchar(100) default 'PERSON';

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.15.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mysql/1.15.sql
@@ -1,2 +1,2 @@
 -- apply alter tables
-alter table fh_person add column person_type varchar(100) default 'person';
+alter table fh_person add column person_type varchar(100) default 'PERSON';

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/oracle/1.15.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/oracle/1.15.sql
@@ -1,2 +1,2 @@
 -- apply alter tables
-alter table fh_person add person_type varchar2(100) default 'person';
+alter table fh_person add person_type varchar2(100) default 'PERSON';

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.15.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/postgres/1.15.sql
@@ -1,2 +1,2 @@
 -- apply alter tables
-alter table fh_person add column person_type varchar(100) default 'person';
+alter table fh_person add column person_type varchar(100) default 'PERSON';


### PR DESCRIPTION
The database migration should have set the field to upper case by default.

