### PR TITLE
[internal/noisy-database] Support the disabling noisy database logs

### DIFF
--- a/backend/common-db/src/main/kotlin/io/featurehub/app/db/utils/DatabaseHealthSource.kt
+++ b/backend/common-db/src/main/kotlin/io/featurehub/app/db/utils/DatabaseHealthSource.kt
@@ -3,18 +3,24 @@ package io.featurehub.app.db.utils
 import io.ebean.Database
 import io.featurehub.health.HealthSource
 import jakarta.inject.Inject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 
 class DatabaseHealthSource
 @Inject
 constructor(val database: Database) : HealthSource {
+  private val log: Logger = LoggerFactory.getLogger(DatabaseHealthSource::class.java)
 
   override val healthy: Boolean
     get() {
-      try {
-        database.sqlQuery("/* EbeanHealthCheck */ SELECT 1").findOne()
-        return true
-      } catch (e: Throwable) {
-        return false
+      MDC.putCloseable("connect.disable-logs", "true").use {
+        try {
+          database.sqlQuery("/* EbeanHealthCheck */ SELECT 1").findOne()
+          return true
+        } catch (e: Throwable) {
+          return false
+        }
       }
     }
   override val sourceName: String

--- a/backend/composite-logging/pom.xml
+++ b/backend/composite-logging/pom.xml
@@ -96,25 +96,7 @@
     <dependency>
       <groupId>cd.connect.common</groupId>
       <artifactId>connect-java-logging-log4j2</artifactId>
-      <version>[1.2, 2)</version>
-      <exclusions>
-        <exclusion>
-          <groupId>cd.connect.common</groupId>
-          <artifactId>connect-java-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>cd.connect.composites.java</groupId>
-          <artifactId>connect-composite-jackson</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>cd.connect.composites.java</groupId>
-          <artifactId>connect-composite-log4j2</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>cd.connect.composites.java</groupId>
-          <artifactId>connect-composite-groovy</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Description

Tag the DatabaseHealthCheck so it can be filtered using the `connect.disable-logs` MDC entry. None of the standard log4j2 filter would solve this issue.

