### PR TITLE
[feature/support-maria-db] Formally support MariaDB

### DIFF
--- a/adks/e2e-sdk/app/steps/flag_steps.ts
+++ b/adks/e2e-sdk/app/steps/flag_steps.ts
@@ -34,6 +34,7 @@ Given(/^There is a feature flag with the key (.*)$/, async function (key: string
 
 Then(/^the feature flag is (locked|unlocked) and (off|on)$/, async function (lockedStatus, value) {
   await waitForExpect(() => {
+    expect(this.repository).to.not.be.undefined;
     expect(this.repository.readyness).to.eq(Readyness.Ready);
     const f = this.featureState(this.feature.key) as FeatureStateHolder;
     // console.log('key is val', this.feature.key, f.getBoolean(), value, f.isLocked(), lockedStatus);

--- a/adks/e2e-sdk/app/steps/setup.ts
+++ b/adks/e2e-sdk/app/steps/setup.ts
@@ -13,6 +13,7 @@ import { makeid, sleep } from '../support/random';
 import { EdgeFeatureHubConfig, FeatureHubPollingClient } from 'featurehub-javascript-node-sdk';
 import waitForExpect from 'wait-for-expect';
 import { logger } from '../support/logging';
+import { SdkWorld } from '../support/world';
 
 Given(/^I create a new portfolio$/, async function () {
   const portfolioService: PortfolioServiceApi = this.portfolioApi;
@@ -135,7 +136,7 @@ Given('the edge connection is no longer available', async function () {
 
 Given(/^I connect to the feature server$/, function () {
   const serviceAccountPerm: ServiceAccountPermission = this.serviceAccountPermission;
-  const world = this;
+  const world = this as SdkWorld;
 
   waitForExpect(async () => {
     const url = `${world.featureUrl}/features?apiKey=${serviceAccountPerm.sdkUrlClientEval}`;
@@ -143,10 +144,14 @@ Given(/^I connect to the feature server$/, function () {
     logger.info('Waiting for successful connection to feature server at `%s`', url);
 
     let found = false;
-    await (FeatureHubPollingClient.pollingClientProvider({}, url, 0, (data) => {
-      found = true;
-      console.log('initial data is ', data);
-    }).poll());
+    try {
+      await (FeatureHubPollingClient.pollingClientProvider({}, url, 0, (data) => {
+        found = true;
+        console.log('initial data is ', data);
+      }).poll());
+    } catch (e) {
+      console.log('failed to poll', e);
+    }
 
     expect(found).to.be.true;
     logger.info('Successfully completed poll');

--- a/backend/common-db/src/main/kotlin/io/featurehub/app/db/utils/CommonDbFeature.kt
+++ b/backend/common-db/src/main/kotlin/io/featurehub/app/db/utils/CommonDbFeature.kt
@@ -98,23 +98,27 @@ open class CommonDbFeature : Feature {
 
     if (databaseUrl.contains("postgres")) {
       migrationConfig.migrationPath = "classpath:/dbmigration/postgres"
-      migrationConfig.platformName = DbPlatformNames.POSTGRES
+      migrationConfig.platform = DbPlatformNames.POSTGRES
       defaultDriver = "org.postgresql.Driver"
-    } else if (databaseUrl.contains("mysql") || databaseUrl.contains("mariadb")) {
+    } else if (databaseUrl.contains("mariadb")) {
+      migrationConfig.migrationPath = "classpath:/dbmigration/mariadb"
+      migrationConfig.platform = DbPlatformNames.MARIADB
+      defaultDriver = "com.mysql.jdbc.Driver"
+  } else if (databaseUrl.contains("mysql")) {
       migrationConfig.migrationPath = "classpath:/dbmigration/mysql"
-      migrationConfig.platformName = DbPlatformNames.MYSQL
+      migrationConfig.platform = DbPlatformNames.MYSQL
       defaultDriver = "com.mysql.jdbc.Driver"
     } else if (databaseUrl.contains("sqlserver")) {
       migrationConfig.migrationPath = "classpath:/dbmigration/mssql"
-      migrationConfig.platformName = DbPlatformNames.SQLSERVER
+      migrationConfig.platform = DbPlatformNames.SQLSERVER
       defaultDriver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     } else if (databaseUrl.contains("oracle")) {
       migrationConfig.migrationPath = "classpath:/dbmigration/oracle"
-      migrationConfig.platformName = DbPlatformNames.ORACLE
+      migrationConfig.platform = DbPlatformNames.ORACLE
       defaultDriver = "oracle.jdbc.OracleDriver"
     } else {
       migrationConfig.migrationPath = "classpath:/dbmigration/h2"
-      migrationConfig.platformName = DbPlatformNames.H2
+      migrationConfig.platform = DbPlatformNames.H2
       defaultDriver = "org.h2.Driver"
     }
 

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.0__initial.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.0__initial.sql
@@ -1,0 +1,260 @@
+-- apply changes
+create table fh_acl (
+  id                            varchar(40) not null,
+  environment_id                varchar(40),
+  application_id                varchar(40),
+  group_id                      varchar(40),
+  roles                         varchar(255),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint pk_fh_acl primary key (id)
+);
+
+create table fh_application (
+  id                            varchar(40) not null,
+  name                          varchar(100) not null,
+  description                   varchar(400),
+  fk_person_who_created         varchar(40) not null,
+  fk_portfolio_id               varchar(40) not null,
+  when_archived                 datetime(6),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint pk_fh_application primary key (id)
+);
+
+create table fh_app_feature (
+  id                            varchar(40) not null,
+  fk_app_id                     varchar(40) not null,
+  when_archived                 datetime(6),
+  feature_key                   varchar(255),
+  alias                         varchar(255),
+  name                          varchar(255),
+  secret                        tinyint(1) default 0 not null,
+  link                          varchar(600),
+  value_type                    varchar(7),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint idx_app_features unique (fk_app_id,feature_key),
+  constraint pk_fh_app_feature primary key (id)
+);
+
+create table fh_environment (
+  id                            varchar(40) not null,
+  is_prod_environment           tinyint(1) default 0 not null,
+  fk_prior_env_id               varchar(40),
+  fk_app_id                     varchar(40) not null,
+  name                          varchar(150) not null,
+  description                   varchar(400),
+  when_archived                 datetime(6),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint pk_fh_environment primary key (id)
+);
+
+create table fh_env_feature_strategy (
+  id                            varchar(40) not null,
+  fk_who_updated                varchar(40),
+  what_updated                  varchar(400),
+  fk_environment_id             varchar(40) not null,
+  fk_feature_id                 varchar(40) not null,
+  feature_state                 varchar(8),
+  default_value                 longtext,
+  enabled_strategy              varchar(10),
+  locked                        tinyint(1) default 0 not null,
+  rollout_strat                 json,
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint pk_fh_env_feature_strategy primary key (id)
+);
+
+create table fh_group (
+  id                            varchar(40) not null,
+  when_archived                 datetime(6),
+  fk_person_who_created         varchar(40) not null,
+  fk_portfolio_id               varchar(40),
+  is_admin_group                tinyint(1) default 0 not null,
+  fk_organization_id            varchar(40),
+  group_name                    varchar(255),
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  version                       bigint not null,
+  constraint idx_group_names unique (fk_portfolio_id,group_name),
+  constraint pk_fh_group primary key (id)
+);
+
+create table fh_login (
+  token                         varchar(255) not null,
+  person_id                     varchar(40),
+  last_seen                     datetime(6),
+  constraint pk_fh_login primary key (token)
+);
+
+create table fh_cache (
+  cache_name                    varchar(255) not null,
+  constraint pk_fh_cache primary key (cache_name)
+);
+
+create table fh_organization (
+  id                            varchar(40) not null,
+  when_archived                 datetime(6),
+  name                          varchar(255),
+  fk_named_cache                varchar(255),
+  group_id                      varchar(40),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint uq_fh_organization_group_id unique (group_id),
+  constraint pk_fh_organization primary key (id)
+);
+
+create table fh_person (
+  id                            varchar(40) not null,
+  when_last_authenticated       datetime(6),
+  name                          varchar(100),
+  email                         varchar(100) not null,
+  password                      varchar(255),
+  password_requires_reset       tinyint(1) default 0 not null,
+  token                         varchar(255),
+  token_expiry                  datetime(6),
+  who_changed_id                varchar(40),
+  when_archived                 datetime(6),
+  fk_person_who_created         varchar(40),
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint idx_person_email unique (email),
+  constraint pk_fh_person primary key (id)
+);
+
+create table fh_person_group_link (
+  fk_person_id                  varchar(40) not null,
+  fk_group_id                   varchar(40) not null,
+  constraint pk_fh_person_group_link primary key (fk_person_id,fk_group_id)
+);
+
+create table fh_portfolio (
+  id                            varchar(40) not null,
+  when_archived                 datetime(6),
+  fk_person_who_created         varchar(40) not null,
+  fk_org_id                     varchar(40) not null,
+  name                          varchar(255),
+  description                   varchar(255),
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  version                       bigint not null,
+  constraint idx_portfolio_name unique (name,fk_org_id),
+  constraint pk_fh_portfolio primary key (id)
+);
+
+create table fh_service_account (
+  id                            varchar(40) not null,
+  name                          varchar(40),
+  description                   varchar(400),
+  fk_person_who_created         varchar(40) not null,
+  api_key                       varchar(100) not null,
+  when_archived                 datetime(6),
+  fk_portfolio_id               varchar(40) not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  version                       bigint not null,
+  constraint uq_fh_service_account_api_key unique (api_key),
+  constraint idx_service_name unique (fk_portfolio_id,name),
+  constraint pk_fh_service_account primary key (id)
+);
+
+create table fh_service_account_env (
+  id                            varchar(40) not null,
+  fk_environment_id             varchar(40) not null,
+  permissions                   varchar(200),
+  fk_service_account_id         varchar(40) not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  version                       bigint not null,
+  constraint pk_fh_service_account_env primary key (id)
+);
+
+create index ix_fh_acl_environment_id on fh_acl (environment_id);
+alter table fh_acl add constraint fk_fh_acl_environment_id foreign key (environment_id) references fh_environment (id) on delete restrict on update restrict;
+
+create index ix_fh_acl_application_id on fh_acl (application_id);
+alter table fh_acl add constraint fk_fh_acl_application_id foreign key (application_id) references fh_application (id) on delete restrict on update restrict;
+
+create index ix_fh_acl_group_id on fh_acl (group_id);
+alter table fh_acl add constraint fk_fh_acl_group_id foreign key (group_id) references fh_group (id) on delete restrict on update restrict;
+
+create index ix_fh_application_fk_person_who_created on fh_application (fk_person_who_created);
+alter table fh_application add constraint fk_fh_application_fk_person_who_created foreign key (fk_person_who_created) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_application_fk_portfolio_id on fh_application (fk_portfolio_id);
+alter table fh_application add constraint fk_fh_application_fk_portfolio_id foreign key (fk_portfolio_id) references fh_portfolio (id) on delete restrict on update restrict;
+
+create index ix_fh_app_feature_fk_app_id on fh_app_feature (fk_app_id);
+alter table fh_app_feature add constraint fk_fh_app_feature_fk_app_id foreign key (fk_app_id) references fh_application (id) on delete restrict on update restrict;
+
+create index ix_fh_environment_fk_prior_env_id on fh_environment (fk_prior_env_id);
+alter table fh_environment add constraint fk_fh_environment_fk_prior_env_id foreign key (fk_prior_env_id) references fh_environment (id) on delete set null on update set null;
+
+create index ix_fh_environment_fk_app_id on fh_environment (fk_app_id);
+alter table fh_environment add constraint fk_fh_environment_fk_app_id foreign key (fk_app_id) references fh_application (id) on delete restrict on update restrict;
+
+create index ix_fh_env_feature_strategy_fk_who_updated on fh_env_feature_strategy (fk_who_updated);
+alter table fh_env_feature_strategy add constraint fk_fh_env_feature_strategy_fk_who_updated foreign key (fk_who_updated) references fh_person (id) on delete set null on update set null;
+
+create index ix_fh_env_feature_strategy_fk_environment_id on fh_env_feature_strategy (fk_environment_id);
+alter table fh_env_feature_strategy add constraint fk_fh_env_feature_strategy_fk_environment_id foreign key (fk_environment_id) references fh_environment (id) on delete restrict on update restrict;
+
+create index ix_fh_env_feature_strategy_fk_feature_id on fh_env_feature_strategy (fk_feature_id);
+alter table fh_env_feature_strategy add constraint fk_fh_env_feature_strategy_fk_feature_id foreign key (fk_feature_id) references fh_app_feature (id) on delete restrict on update restrict;
+
+create index ix_fh_group_fk_person_who_created on fh_group (fk_person_who_created);
+alter table fh_group add constraint fk_fh_group_fk_person_who_created foreign key (fk_person_who_created) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_group_fk_portfolio_id on fh_group (fk_portfolio_id);
+alter table fh_group add constraint fk_fh_group_fk_portfolio_id foreign key (fk_portfolio_id) references fh_portfolio (id) on delete restrict on update restrict;
+
+create index ix_fh_group_fk_organization_id on fh_group (fk_organization_id);
+alter table fh_group add constraint fk_fh_group_fk_organization_id foreign key (fk_organization_id) references fh_organization (id) on delete restrict on update restrict;
+
+create index ix_fh_login_person_id on fh_login (person_id);
+alter table fh_login add constraint fk_fh_login_person_id foreign key (person_id) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_organization_fk_named_cache on fh_organization (fk_named_cache);
+alter table fh_organization add constraint fk_fh_organization_fk_named_cache foreign key (fk_named_cache) references fh_cache (cache_name) on delete set null on update set null;
+
+alter table fh_organization add constraint fk_fh_organization_group_id foreign key (group_id) references fh_group (id) on delete restrict on update restrict;
+
+create index ix_fh_person_who_changed_id on fh_person (who_changed_id);
+alter table fh_person add constraint fk_fh_person_who_changed_id foreign key (who_changed_id) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_person_fk_person_who_created on fh_person (fk_person_who_created);
+alter table fh_person add constraint fk_fh_person_fk_person_who_created foreign key (fk_person_who_created) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_person_group_link_fh_person on fh_person_group_link (fk_person_id);
+alter table fh_person_group_link add constraint fk_fh_person_group_link_fh_person foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_person_group_link_fh_group on fh_person_group_link (fk_group_id);
+alter table fh_person_group_link add constraint fk_fh_person_group_link_fh_group foreign key (fk_group_id) references fh_group (id) on delete restrict on update restrict;
+
+create index ix_fh_portfolio_fk_person_who_created on fh_portfolio (fk_person_who_created);
+alter table fh_portfolio add constraint fk_fh_portfolio_fk_person_who_created foreign key (fk_person_who_created) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_portfolio_fk_org_id on fh_portfolio (fk_org_id);
+alter table fh_portfolio add constraint fk_fh_portfolio_fk_org_id foreign key (fk_org_id) references fh_organization (id) on delete restrict on update restrict;
+
+create index ix_fh_service_account_fk_person_who_created on fh_service_account (fk_person_who_created);
+alter table fh_service_account add constraint fk_fh_service_account_fk_person_who_created foreign key (fk_person_who_created) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_service_account_fk_portfolio_id on fh_service_account (fk_portfolio_id);
+alter table fh_service_account add constraint fk_fh_service_account_fk_portfolio_id foreign key (fk_portfolio_id) references fh_portfolio (id) on delete restrict on update restrict;
+
+create index ix_fh_service_account_env_fk_environment_id on fh_service_account_env (fk_environment_id);
+alter table fh_service_account_env add constraint fk_fh_service_account_env_fk_environment_id foreign key (fk_environment_id) references fh_environment (id) on delete restrict on update restrict;
+
+create index ix_fh_service_account_env_fk_service_account_id on fh_service_account_env (fk_service_account_id);
+alter table fh_service_account_env add constraint fk_fh_service_account_env_fk_service_account_id foreign key (fk_service_account_id) references fh_service_account (id) on delete restrict on update restrict;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.1.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.1.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_portfolio modify fk_person_who_created varchar(40);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.10.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.10.sql
@@ -1,0 +1,4 @@
+-- apply changes
+alter table fh_strat_for_feature rename column enabled TO fv_enabled;
+alter table fh_strat_for_feature rename column value to fv_value;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.11.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.11.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_env_feature_strategy add constraint idx_fv_unique unique  (fk_environment_id,fk_feature_id);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.12.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.12.sql
@@ -1,0 +1,3 @@
+-- apply changes
+alter table fh_env_feature_strategy add column retired tinyint(1);
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.13.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.13.sql
@@ -1,0 +1,4 @@
+-- apply changes
+alter table fh_app_feature add column description varchar(300);
+alter table fh_app_feature add column meta_data longtext;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.14.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.14.sql
@@ -1,0 +1,7 @@
+-- ignore migration
+-- drop dependencies
+-- alter table fh_person_group_link drop foreign key fk_fh_person_group_link_fh_person;
+-- alter table fh_person_group_link drop foreign key fk_fh_person_group_link_fh_group;
+-- foreign keys and indices
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_person_id foreign key (fk_person_id) references fh_person (id) on delete restrict on update restrict;
+-- alter table fh_person_group_link add constraint fk_fh_person_group_link_fk_group_id foreign key (fk_group_id) references fh_group (id) on delete restrict on update restrict;

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.15.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.15.sql
@@ -1,0 +1,2 @@
+-- apply alter tables
+alter table fh_person add column person_type varchar(100) default 'PERSON';

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.2.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.2.sql
@@ -1,0 +1,28 @@
+-- apply changes
+create table fh_userstate (
+  id                            varchar(40) not null,
+  fk_person                     varchar(40) not null,
+  fk_portfolio_id               varchar(40),
+  fk_app_id                     varchar(40),
+  fk_env_id                     varchar(40),
+  user_state                    varchar(15),
+  data                          longtext,
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint idx_user_state unique (fk_person,fk_portfolio_id,fk_app_id,fk_env_id),
+  constraint pk_fh_userstate primary key (id)
+);
+
+create index ix_fh_userstate_fk_person on fh_userstate (fk_person);
+alter table fh_userstate add constraint fk_fh_userstate_fk_person foreign key (fk_person) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_userstate_fk_portfolio_id on fh_userstate (fk_portfolio_id);
+alter table fh_userstate add constraint fk_fh_userstate_fk_portfolio_id foreign key (fk_portfolio_id) references fh_portfolio (id) on delete restrict on update restrict;
+
+create index ix_fh_userstate_fk_app_id on fh_userstate (fk_app_id);
+alter table fh_userstate add constraint fk_fh_userstate_fk_app_id foreign key (fk_app_id) references fh_application (id) on delete restrict on update restrict;
+
+create index ix_fh_userstate_fk_env_id on fh_userstate (fk_env_id);
+alter table fh_userstate add constraint fk_fh_userstate_fk_env_id foreign key (fk_env_id) references fh_environment (id) on delete restrict on update restrict;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.4.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.4.sql
@@ -1,0 +1,37 @@
+-- apply changes
+create table fh_app_strategy (
+  id                            varchar(40) not null,
+  fk_app_id                     varchar(40) not null,
+  when_archived                 datetime(6),
+  strategy_name                 varchar(255) not null,
+  strategy                      json not null,
+  fk_person_who_changed         varchar(40) not null,
+  version                       bigint not null,
+  when_updated                  datetime(6) not null,
+  when_created                  datetime(6) not null,
+  constraint idx_app_strategies unique (fk_app_id,strategy_name),
+  constraint pk_fh_app_strategy primary key (id)
+);
+
+create table fh_strat_for_feature (
+  id                            varchar(40) not null,
+  fk_fv_id                      varchar(40) not null,
+  fk_rs_id                      varchar(40) not null,
+  enabled                       tinyint(1) default 0 not null,
+  value                         longtext,
+  constraint idx_feature_strat unique (fk_fv_id,fk_rs_id),
+  constraint pk_fh_strat_for_feature primary key (id)
+);
+
+create index ix_fh_app_strategy_fk_app_id on fh_app_strategy (fk_app_id);
+alter table fh_app_strategy add constraint fk_fh_app_strategy_fk_app_id foreign key (fk_app_id) references fh_application (id) on delete restrict on update restrict;
+
+create index ix_fh_app_strategy_fk_person_who_changed on fh_app_strategy (fk_person_who_changed);
+alter table fh_app_strategy add constraint fk_fh_app_strategy_fk_person_who_changed foreign key (fk_person_who_changed) references fh_person (id) on delete restrict on update restrict;
+
+create index ix_fh_strat_for_feature_fk_fv_id on fh_strat_for_feature (fk_fv_id);
+alter table fh_strat_for_feature add constraint fk_fh_strat_for_feature_fk_fv_id foreign key (fk_fv_id) references fh_env_feature_strategy (id) on delete restrict on update restrict;
+
+create index ix_fh_strat_for_feature_fk_rs_id on fh_strat_for_feature (fk_rs_id);
+alter table fh_strat_for_feature add constraint fk_fh_strat_for_feature_fk_rs_id foreign key (fk_rs_id) references fh_app_strategy (id) on delete restrict on update restrict;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.5.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.5.sql
@@ -1,0 +1,3 @@
+-- apply changes
+alter table fh_service_account add column api_key_client_eval varchar(100);
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.6.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.6.sql
@@ -1,0 +1,2 @@
+-- apply changes
+alter table fh_service_account modify name varchar(100);

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.7__dropsFor_1.3.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.7__dropsFor_1.3.sql
@@ -1,0 +1,3 @@
+-- apply changes
+alter table fh_env_feature_strategy drop column enabled_strategy;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.8.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.8.sql
@@ -1,0 +1,3 @@
+-- apply changes
+alter table fh_person add column password_alg varchar(60) default 'PBKDF2WithHmacSHA1' not null;
+

--- a/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.9.sql
+++ b/backend/mr-db-ebean/src/main/resources/dbmigration/mariadb/1.9.sql
@@ -1,0 +1,5 @@
+-- apply changes
+alter table fh_environment add column when_unpublished datetime(6);
+
+alter table fh_service_account add column when_unpublished datetime(6);
+

--- a/backend/mr-db-ebean/src/test/java/io/featurehub/db/GenerateDbMigration.java
+++ b/backend/mr-db-ebean/src/test/java/io/featurehub/db/GenerateDbMigration.java
@@ -9,6 +9,7 @@ public class GenerateDbMigration {
 //    dbMigration.addPlatform(Platform.SQLSERVER17, "mssql");
     dbMigration.addPlatform(Platform.POSTGRES, "postgres");
     dbMigration.addPlatform(Platform.MYSQL, "mysql");
+    dbMigration.addPlatform(Platform.MARIADB, "mariadb");
     dbMigration.addPlatform(Platform.H2, "h2");
     dbMigration.addPlatform(Platform.ORACLE, "oracle");
 

--- a/backend/mr/src/main/resources/deploy-defaults/log4j2.xml
+++ b/backend/mr/src/main/resources/deploy-defaults/log4j2.xml
@@ -1,13 +1,14 @@
 <Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
-    <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
-            <ConnectJsonLayout/>
-<!--            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>-->
-        </Console>
-    </Appenders>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <ConnectJsonLayout/>
+      <DisableLogsFilter/>
+      <!--            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>-->
+    </Console>
+  </Appenders>
 
-    <Loggers>
-      <!--
+  <Loggers>
+    <!--
 <AsyncLogger name="io.featurehub" level="debug"/>
 <AsyncLogger name="io.ebean.SQL" level="trace"/>
 <AsyncLogger name="io.ebean.TXN" level="trace"/>
@@ -21,13 +22,13 @@
 
 <AsyncLogger name="jersey-logging" level="trace"/>
 -->
-      <AsyncLogger name="io.featurehub.edge.features" level="debug"/>
-      <AsyncLogger name="net.stickycode" level="warn"/>
-      <AsyncLogger name="org.glassfish.jersey.server.wadl" level="error"/>
-      <AsyncLogger name="io.avaje.config"  level="warn"/>
-      <AsyncLogger name="org.hibernate" level="error"/>
-      <AsyncRoot level="info">
-        <AppenderRef ref="STDOUT"/>
-      </AsyncRoot>
-    </Loggers>
+    <AsyncLogger name="io.featurehub.edge.features" level="debug"/>
+    <AsyncLogger name="net.stickycode" level="warn"/>
+    <AsyncLogger name="org.glassfish.jersey.server.wadl" level="error"/>
+    <AsyncLogger name="io.avaje.config" level="warn"/>
+    <AsyncLogger name="org.hibernate" level="error"/>
+    <AsyncRoot level="info">
+      <AppenderRef ref="STDOUT"/>
+    </AsyncRoot>
+  </Loggers>
 </Configuration>

--- a/backend/party-server/src/main/resources/deploy-defaults/log4j2.xml
+++ b/backend/party-server/src/main/resources/deploy-defaults/log4j2.xml
@@ -1,12 +1,13 @@
 <Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
-    <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
-            <ConnectJsonLayout/>
-        </Console>
-    </Appenders>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <ConnectJsonLayout/>
+      <DisableLogsFilter/>
+    </Console>
+  </Appenders>
 
-    <Loggers>
-      <!--
+  <Loggers>
+    <!--
 <AsyncLogger name="io.featurehub" level="debug"/>
 <AsyncLogger name="io.ebean.SQL" level="trace"/>
 <AsyncLogger name="io.ebean.TXN" level="trace"/>
@@ -20,13 +21,13 @@
 
 <AsyncLogger name="jersey-logging" level="trace"/>
 -->
-      <AsyncLogger name="io.featurehub.edge.features" level="debug"/>
-      <AsyncLogger name="net.stickycode" level="warn"/>
-      <AsyncLogger name="org.glassfish.jersey.server.wadl" level="error"/>
-      <AsyncLogger name="io.avaje.config"  level="warn"/>
-      <AsyncLogger name="org.hibernate" level="error"/>
-      <AsyncRoot level="info">
-        <AppenderRef ref="STDOUT"/>
-      </AsyncRoot>
-    </Loggers>
+    <AsyncLogger name="io.featurehub.edge.features" level="debug"/>
+    <AsyncLogger name="net.stickycode" level="warn"/>
+    <AsyncLogger name="org.glassfish.jersey.server.wadl" level="error"/>
+    <AsyncLogger name="io.avaje.config" level="warn"/>
+    <AsyncLogger name="org.hibernate" level="error"/>
+    <AsyncRoot level="info">
+      <AppenderRef ref="STDOUT"/>
+    </AsyncRoot>
+  </Loggers>
 </Configuration>


### PR DESCRIPTION
# Description

Existing MariaDB users should see no change in migrations, they were copied from
MySQL migrations, but moving forward we will support MySQL 8+ and MariaDB 10.5+
as separate databases with separate database drivers and separate sample installs.

