### PR TITLE
[bugfix/service-account-publish] Some dbs miss newly associated SA/Environments

### DIFF
--- a/adks/admin-typescript/typescript-admin-client/package.json
+++ b/adks/admin-typescript/typescript-admin-client/package.json
@@ -58,7 +58,7 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.24.0"
   },
   "engines": {
     "node": ">=12.12.0"

--- a/adks/e2e-sdk/app/steps/setup.ts
+++ b/adks/e2e-sdk/app/steps/setup.ts
@@ -16,7 +16,9 @@ import { logger } from '../support/logging';
 import { SdkWorld } from '../support/world';
 
 Given(/^I create a new portfolio$/, async function () {
-  const portfolioService: PortfolioServiceApi = this.portfolioApi;
+  const world = this as SdkWorld;
+  world.reset();
+  const portfolioService: PortfolioServiceApi = world.portfolioApi;
 
   const name = makeid(12);
   const pCreate = await portfolioService.createPortfolio(new Portfolio({ name: name, description: name }));
@@ -114,7 +116,7 @@ Given(/^I create a service account and (full|read) permissions based on the appl
 });
 
 Given('the edge connection is no longer available', async function () {
-  const world = this;
+  const world = this as SdkWorld;
 
   waitForExpect(async () => {
     const url = `${world.featureUrl}/features?apiKey=${this.serviceAccountPermission.sdkUrlClientEval}`;
@@ -127,8 +129,7 @@ Given('the edge connection is no longer available', async function () {
         found = true;
         console.log('initial data is ', data);
       }).poll());
-    } catch (ignored) {
-    }
+    } catch (ignored) {}
 
     expect(found).to.be.false;
   });
@@ -147,13 +148,13 @@ Given(/^I connect to the feature server$/, function () {
     try {
       await (FeatureHubPollingClient.pollingClientProvider({}, url, 0, (data) => {
         found = true;
-        console.log('initial data is ', data);
+        logger.info('initial data is %s', JSON.stringify(data));
       }).poll());
     } catch (e) {
-      console.log('failed to poll', e);
+      logger.info('failed to poll %s', JSON.stringify(e));
     }
 
-    expect(found).to.be.true;
+    expect(found, `${serviceAccountPerm.sdkUrlClientEval} failed to connect`).to.be.true;
     logger.info('Successfully completed poll');
     const edge = new EdgeFeatureHubConfig(world.featureUrl, serviceAccountPerm.sdkUrlClientEval);
     this.sdkUrlClientEval = serviceAccountPerm.sdkUrlClientEval;

--- a/adks/e2e-sdk/app/support/logging.ts
+++ b/adks/e2e-sdk/app/support/logging.ts
@@ -54,7 +54,7 @@ export const logger = winston.createLogger({
     // - Write all logs with level `verbose` and below to `combined.log`
     //
     new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
-    new winston.transports.File({ filename: 'logs/combined.log' }),
+    new winston.transports.File({ filename: 'logs/combined.log', level: 'verbose' }),
   ],
 });
 
@@ -75,6 +75,7 @@ if (process.env.DEBUG) {
 
 export const responseToRecord = function (response: AxiosResponse) {
   const reqConfig = response.config;
+  if (reqConfig.url.endsWith('/mr-api/login')) return undefined;
   return {
     type: 'response',
     status: response.status,
@@ -93,7 +94,10 @@ export const responseToRecord = function (response: AxiosResponse) {
 export function axiosLoggingAttachment(axiosInstances: Array<AxiosInstance>) {
   axiosInstances.forEach((axios) => {
     axios.interceptors.response.use((resp: AxiosResponse) => {
-      logger.log({level: 'verbose', message: 'response:', http: JSON.stringify(responseToRecord(resp), undefined, 2)});
+      const responseToLog = responseToRecord(resp)
+      if (responseToLog !== undefined) {
+        logger.log({level: 'verbose', message: 'response:', http: JSON.stringify(responseToLog, undefined, 2)});
+      }
       return resp;
     }, (error) => {
       if (error.response) {

--- a/adks/e2e-sdk/app/support/world.ts
+++ b/adks/e2e-sdk/app/support/world.ts
@@ -28,7 +28,7 @@ import { edgeHost, mrHost } from './discovery';
 
 let apiKey: string;
 
-axiosLoggingAttachment([ globalAxios ]);
+// axiosLoggingAttachment([ globalAxios ]);
 
 export class SdkWorld extends World {
   private _portfolio: Portfolio;
@@ -59,14 +59,25 @@ export class SdkWorld extends World {
     this.adminUrl = mrHost();
     this.featureUrl = edgeHost();
 
-    this.adminApiConfig = new Configuration({ basePath: this.adminUrl, apiKey: apiKey });
+    this.adminApiConfig = new Configuration({ basePath: this.adminUrl, apiKey: apiKey, axiosInstance: globalAxios.create() });
     this.portfolioApi = new PortfolioServiceApi(this.adminApiConfig);
     this.applicationApi = new ApplicationServiceApi(this.adminApiConfig);
     this.environmentApi = new EnvironmentServiceApi(this.adminApiConfig);
     this.featureApi = new FeatureServiceApi(this.adminApiConfig);
-    this.loginApi = new AuthServiceApi(this.adminApiConfig);
+    this.loginApi = new AuthServiceApi(this.adminApiConfig); // too noisy in logs
     this.serviceAccountApi = new ServiceAccountServiceApi(this.adminApiConfig);
     this.featureValueApi = new EnvironmentFeatureServiceApi(this.adminApiConfig);
+
+    axiosLoggingAttachment([this.adminApiConfig.axiosInstance]);
+  }
+
+  public reset(): void {
+    this._application = undefined;
+    this._portfolio = undefined;
+    this.feature = undefined;
+    this.environment = undefined;
+    this.serviceAccountPermission = undefined;
+    this.edgeServer = undefined;
   }
 
   public set repository(r: FeatureHubRepository) {

--- a/adks/e2e-sdk/features/environment.feature
+++ b/adks/e2e-sdk/features/environment.feature
@@ -13,7 +13,7 @@ Feature: We have a grouping of environmental behaviour around features
     And I delete the environment
     Then the edge connection is no longer available
 
-  @feature-delete
+  @featuredelete
   Scenario Outline: When I create multiple features and delete them, the MR list of features should match the Edge list of features
     Given I create a new portfolio
     And I create an application

--- a/adks/e2e-sdk/package-lock.json
+++ b/adks/e2e-sdk/package-lock.json
@@ -34,7 +34,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.4"
+        "axios": "^0.24.0"
       },
       "devDependencies": {
         "@types/chai": "^4.2.18",
@@ -4391,7 +4391,7 @@
         "@types/chai": "^4.2.18",
         "@types/mocha": "^8.0.2",
         "@types/node": "^12.20.12",
-        "axios": "^0.21.4",
+        "axios": "^0.24.0",
         "chai": "^4.2.0",
         "ts-node": "8.10.2",
         "tslint": "6.1.1",
@@ -4474,8 +4474,7 @@
           "dev": true
         },
         "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "version": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
           "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg=="
         },
         "balanced-match": {

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/publish/DbCacheSource.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/publish/DbCacheSource.kt
@@ -83,9 +83,11 @@ open class DbCacheSource @Inject constructor(private val convertUtils: Conversio
       .apiKeyServerSide(sa.apiKeyServerEval)
       .permissions(
         QDbServiceAccountEnvironment()
-          .select(QDbServiceAccountEnvironment.Alias.permissions).serviceAccount.id.eq(sa.id).environment.whenUnpublished.isNull.environment.whenArchived.isNull.environment.fetch(
-            QDbEnvironment.Alias.id
-          )
+          .select(QDbServiceAccountEnvironment.Alias.permissions)
+          .serviceAccount.id.eq(sa.id)
+          .environment.whenUnpublished.isNull
+          .environment.whenArchived.isNull
+          .environment.fetch(QDbEnvironment.Alias.id)
           .findStream().map { sap: DbServiceAccountEnvironment ->
             CacheServiceAccountPermission()
               .permissions(convertUtils.splitServiceAccountPermissions(sap.permissions))


### PR DESCRIPTION
# Description

While testing support for MySQL - it became clear that unless the relationship
between a service account and an environment is committed first, the subsequent
query will not pick up the change. Environment and Feature update publishing
operate by saving first and then async updating, but Service Accounts did not.
This fix ensures that the changes are in the database so that all databases
and their transactional modes will pick up the updating of a service account.

