### PR TITLE
[internal/dart-open-api-upgrade] OpenAPI 6.0.1 / 6.1 Dart upgrade

### DIFF
--- a/admin-frontend/open_admin_app/lib/api/client_api.dart
+++ b/admin-frontend/open_admin_app/lib/api/client_api.dart
@@ -303,7 +303,7 @@ class ManagementRepositoryClientBloc implements Bloc {
       organization = setupResponse.organization;
       identityProviders.identityProviders = setupResponse.providers;
       if (setupResponse.providerInfo != null) {
-        identityProviders.identityInfo = setupResponse.providerInfo!;
+        identityProviders.identityInfo = setupResponse.providerInfo;
       }
 
       // yes its initialised, we may not have logged in yet
@@ -325,7 +325,7 @@ class ManagementRepositoryClientBloc implements Bloc {
               as SetupMissingResponse;
           identityProviders.identityProviders = smr.providers;
           if (smr.providerInfo != null) {
-            identityProviders.identityInfo = smr.providerInfo!;
+            identityProviders.identityInfo = smr.providerInfo;
           }
           routeSlot(RouteSlot.setup);
         } else {

--- a/e2e/lib/superuser_common.dart
+++ b/e2e/lib/superuser_common.dart
@@ -54,7 +54,9 @@ class SuperuserCommon {
 
       tp = await _authServiceApi
           .login(UserCredentials(password: initPassword, email: initUser));
-    } catch (e) {
+    } catch (e, s) {
+      print(e);
+      print(s);
       assert(e is ApiException);
       assert((e as ApiException).code == 404, 'code is not 404 but ${e.code}');
 

--- a/e2e/lib/util.dart
+++ b/e2e/lib/util.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
 
 String baseUrl() {
-  return Platform.environment['FEATUREHUB_BASE_URL'] ?? 'http://localhost:8903';
+  return Platform.environment['FEATUREHUB_BASE_URL'] ?? 'http://localhost:8085';
 }

--- a/e2e/test/steps/ApplicationStepdefs.dart
+++ b/e2e/test/steps/ApplicationStepdefs.dart
@@ -228,7 +228,7 @@ class ApplicationStepdefs {
         .firstWhereOrNull((agr) => agr.applicationId == shared.application.id);
     if (agr == null) {
       agr = api.ApplicationGroupRole(
-          applicationId: shared.application.id!, groupId: group.id!);
+          applicationId: shared.application.id!, groupId: group.id!, roles: []);
       group.applicationRoles.add(agr);
     }
 

--- a/e2e/test/steps/EnvironmentStepdefs.dart
+++ b/e2e/test/steps/EnvironmentStepdefs.dart
@@ -87,7 +87,7 @@ class EnvironmentStepdefs {
     var environment =
         await common.findExactEnvironment(environmentName, application.id);
     EnvironmentGroupRole egr = EnvironmentGroupRole(
-        environmentId: environment!.id!, groupId: group.id!);
+        environmentId: environment!.id!, groupId: group.id!, roles: []);
     perm == "READ" ? egr.roles.add(RoleType.READ) : {};
     perm == "EDIT" ? egr.roles.add(RoleType.CHANGE_VALUE) : {};
     perm == "LOCK" ? egr.roles.add(RoleType.LOCK) : {};
@@ -143,11 +143,8 @@ class EnvironmentStepdefs {
         await common.findExactEnvironment(envName, application.id);
     shared.environment = environment!;
     EnvironmentGroupRole egr = EnvironmentGroupRole(
-        groupId: group.id!, environmentId: environment.id!);
-    egr.roles.add(RoleType.READ);
-    egr.roles.add(RoleType.CHANGE_VALUE);
-    egr.roles.add(RoleType.LOCK);
-    egr.roles.add(RoleType.UNLOCK);
+        groupId: group.id!, environmentId: environment.id!,
+        roles: [RoleType.READ, RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]);
 
     group.environmentRoles.add(egr);
     await common.groupService.updateGroup(group.id!, group,
@@ -171,7 +168,7 @@ class EnvironmentStepdefs {
     assert(environment != null, 'we cannot find environment $envName');
     shared.environment = environment!;
     EnvironmentGroupRole egr = EnvironmentGroupRole(
-        groupId: group.id!, environmentId: environment.id!);
+        groupId: group.id!, environmentId: environment.id!, roles: []);
     perms
         .split(",")
         .map((e) => e.trim())
@@ -339,7 +336,7 @@ class EnvironmentStepdefs {
     await common.findExactEnvironment(envName, shared.application.id);
     shared.environment = environment!;
     EnvironmentGroupRole egr = EnvironmentGroupRole(
-        groupId: group.id!, environmentId: environment.id!);
+        groupId: group.id!, environmentId: environment.id!, roles: []);
     egr.roles.add(RoleType.READ);
     egr.roles.add(RoleType.CHANGE_VALUE);
     egr.roles.add(RoleType.LOCK);

--- a/e2e/test/steps/UserStateStepdefs.dart
+++ b/e2e/test/steps/UserStateStepdefs.dart
@@ -46,7 +46,7 @@ class UserStateStepdefs {
       await userCommon.userStateService.saveHiddenEnvironments(
           shared.application.id!,
           HiddenEnvironments(
-            environmentIds: storedEnvironments,
+            environmentIds: storedEnvironments!,
           ));
       assert(false, 'Should not be able to save');
     } catch (e) {
@@ -77,7 +77,7 @@ class UserStateStepdefs {
     await userCommon.userStateService.saveHiddenEnvironments(
         shared.application.id!,
         HiddenEnvironments(
-          environmentIds: storedEnvironments,
+          environmentIds: storedEnvironments!,
         ));
   }
 }


### PR DESCRIPTION
Upgrade to OpenAPI 6 for Dart introduced minor compatibility issues, these are addressed in this PR.