### PR TITLE
[bugfix/SAML] Single login bugfix

### DIFF
--- a/backend/mr/pom.xml
+++ b/backend/mr/pom.xml
@@ -37,7 +37,6 @@
 
   <properties>
     <app.entrypoint>io.featurehub.Application</app.entrypoint>
-    <app.baseimage>adoptopenjdk/openjdk11@sha256:faa097729e4904c80b982ef6962803210db032564c9850d70b5b2a52f0a02200</app.baseimage>
     <app.port>8085</app.port>
     <build.version>0.0.1</build.version>
   </properties>

--- a/backend/party-server-ish/pom.xml
+++ b/backend/party-server-ish/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <app.entrypoint>io.featurehub.party.Application</app.entrypoint>
-    <app.baseimage>adoptopenjdk/openjdk11@sha256:faa097729e4904c80b982ef6962803210db032564c9850d70b5b2a52f0a02200</app.baseimage>
     <app.port>8085</app.port>
     <build.version>0.0.1</build.version>
   </properties>

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -13,11 +13,11 @@ else
   BUILD_PARAMS="$BUILD_PARAMS -Djib.to.tags=latest"
 fi
 DOCKER_PREFIX="${OVERRIDE_DOCKER_PREFIX:-featurehub}"
-echo mvn -f pom-packages.xml -DskipTests $BUILD_PARAMS -Ddocker.project.prefix=$DOCKER_PREFIX -Dcloud-build=true -Dbuild.version=$VERSION clean install
+echo mvn -f pom-packages.xml -DskipTests $BUILD_PARAMS -Dapp.baseimage.prefix=featurehub/ -Ddocker.project.prefix=$DOCKER_PREFIX -Dcloud-build=true -Dbuild.version=$VERSION clean install
 while true; do
     read -p "Are you sure you wish to release (y/n): " yn
     case $yn in
-        [Yy]* ) mvn -f pom-packages.xml -DskipTests $BUILD_PARAMS -Ddocker.project.prefix=$DOCKER_PREFIX -Dcloud-build=true -Dbuild.version=$VERSION clean install; break;;
+        [Yy]* ) mvn -f pom-packages.xml -DskipTests $BUILD_PARAMS  -Dapp.baseimage.prefix=featurehub/  -Ddocker.project.prefix=$DOCKER_PREFIX -Dcloud-build=true -Dbuild.version=$VERSION clean install; break;;
         [Nn]* ) exit;;
         * ) echo "Please answer yes or no.";;
     esac

--- a/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2Feature.kt
+++ b/backend/security-oauth/src/main/kotlin/io/featurehub/web/security/oauth/OAuth2Feature.kt
@@ -2,6 +2,7 @@ package io.featurehub.web.security.oauth
 
 import cd.connect.app.config.ConfigKey
 import cd.connect.app.config.DeclaredConfigResolver
+import io.featurehub.utils.FallbackPropertyConfig
 import io.featurehub.web.security.oauth.providers.*
 import io.featurehub.web.security.oauth.providers.GithubProvider.Companion.PROVIDER_NAME
 import jakarta.inject.Singleton
@@ -52,25 +53,21 @@ class OAuth2Feature : Feature {
             SSOProviderCollection::class.java
           ).`in`(Singleton::class.java)
 
-          bind(AuthProviders::class.java).to(AuthProviderCollection::class.java).`in`(Singleton::class.java)
-
           // now the outbound http request to validate authorization flow
           bind(OAuth2JerseyClient::class.java).to(OAuth2Client::class.java).`in`(Singleton::class.java)
         }
       })
-    } else {
-      log.info("No oauth2 providers in config, skipping oauth2.")
-      context.register(object: AbstractBinder() {
-        override fun configure() {
-          bind(NoAuthProviders::class.java).to(AuthProviderCollection::class.java).`in`(Singleton::class.java)
-        }
-      })
     }
+
     return true
   }
 
   companion object {
     private val log = LoggerFactory.getLogger(OAuth2Feature::class.java)
+
+    fun oauth2ProvidersExist(): Boolean {
+      return FallbackPropertyConfig.getConfig("oauth2.providers") != null
+    }
   }
 
   init {

--- a/backend/security-saml/src/main/kotlin/io/featurehub/web/security/saml/EnvironmentalSamlServiceProviderConfig.kt
+++ b/backend/security-saml/src/main/kotlin/io/featurehub/web/security/saml/EnvironmentalSamlServiceProviderConfig.kt
@@ -4,7 +4,6 @@ import cd.connect.jersey.common.LoggingConfiguration
 import com.onelogin.saml2.settings.Saml2Settings
 import io.featurehub.jersey.config.CommonConfiguration
 import io.featurehub.utils.FallbackPropertyConfig
-import io.featurehub.utils.FeatureHubConfig
 import io.featurehub.web.security.oauth.AuthProviderInfo
 import io.featurehub.web.security.oauth.SSOProviderCollection
 import io.featurehub.web.security.oauth.providers.SSOProviderCustomisation
@@ -45,6 +44,12 @@ class SamlEnvironmentalFeature : Feature {
     return true
   }
 
+
+  companion object {
+    fun samlProvidersExist(): Boolean {
+      return FallbackPropertyConfig.getConfig("saml.idp-providers") != null
+    }
+  }
 }
 
 class SamlConfigAsAuthProvider(private val config: SamlServiceProviderConfig) : AuthProviderInfo {


### PR DESCRIPTION
# Description

SAML logins were not allowed to exist on their own without OAuth2 also.

This fixes the issue where a SAML login being the only available login, or SAML being available as login separately from local login would not display without OAuth2 also being configured.
