### PR TITLE
[bufgix/internal-urls] Mount metrics and health on /

### DIFF
--- a/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/MetricsHealthRegistration.kt
@@ -58,7 +58,9 @@ class MetricsHealthRegistration {
 
     fun startMetricsEndpoint(resourceConfig: ResourceConfig) {
       val port = FallbackPropertyConfig.getConfig(monitorPortName)!!.toInt()
-      FeatureHubJerseyHost(resourceConfig).disallowWebHosting().start(port)
+      FeatureHubJerseyHost(resourceConfig)
+        .disallowWebHosting()
+        .start(port)
 
       log.info("metric/health endpoint now active on port {}", port)
     }

--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/AdminAppStaticHttpHandler.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/AdminAppStaticHttpHandler.kt
@@ -212,6 +212,11 @@ class AdminAppStaticHttpHandler constructor(private val offsetBaseUrl: String) :
       return false;
     }
 
-    return internal_handle(uri, request, response!!)
+    if (!internal_handle(uri, request, response!!)) {
+      response.setHeader("Cache-Control", indexCacheControlHeader)
+      sendFile(response!!)
+    }
+
+    return true
   }
 }

--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/DelegatingHandler.kt
@@ -8,28 +8,16 @@ import org.glassfish.grizzly.http.server.Response
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer
 
 class DelegatingHandler(
-  private val jerseyHandler: GrizzlyHttpContainer,
   private val staticHttpHandler: AdminAppStaticHttpHandler
 ) : HttpHandler() {
-  private var jerseyPrefixes = listOf("/mr-api/", "/saml/", "/oauth/", "/features", "/health/", "/metrics", "/info", "/dacha2")
-
   private val webRequestCounter = MetricsCollector.counter("web_request_counter", "Amount of requests from serving the front end Admin website")
   private val apiRequestCounter = MetricsCollector.counter("api_request_counter", "Number of API requests received")
   private val featureRequestCounter = MetricsCollector.counter("feature_request_counter", "Number of Feature requests we have received")
-
-  init {
-    var prefixes = FallbackPropertyConfig.getConfig("jersey.prefixes")
-
-    if (prefixes != null) {
-      jerseyPrefixes = prefixes.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toList()
-    }
-  }
 
   override fun start() {
     super.start()
 
     staticHttpHandler.isFileCacheEnabled = false
-    jerseyHandler.start()
     staticHttpHandler.start()
   }
 
@@ -62,28 +50,6 @@ class DelegatingHandler(
       return
     }
 
-    if (url.startsWith("/features")) {
-      featureRequestCounter.inc()
-      return jerseyHandler.service(request, response)
-    }
-
-    if (url.isEmpty() || url == "/" || url.endsWith(".ico") || url.endsWith(".html") || url.endsWith(".js") || url.startsWith("/assets") || url.startsWith("/canvaskit")) {
-      webRequestCounter.inc()
-      return staticHttpHandler.service(request, response)
-    }
-
-    // do the html5 thing and redirect everything else to index.html.
-    if (jerseyPrefixes.none { url.startsWith(it)} ) {
-      webRequestCounter.inc()
-      // this MUST be index.html, as all those random html5 urls are not actual files, e.g. /setup and /dashboard. if we let the
-      // actual request pass through, it will never find the file and so if a user refreshes their page they will get nothing.
-      staticHttpHandler.handle("/index.html", request, response)
-
-      return
-    }
-
-    apiRequestCounter.inc()
-
-    return jerseyHandler.service(request, response)
+    staticHttpHandler.service(request, response)
   }
 }

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/OrganizationApi.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/OrganizationApi.java
@@ -1,7 +1,6 @@
 package io.featurehub.db.api;
 import io.featurehub.mr.model.Organization;
 
-
 public interface OrganizationApi {
 
   /**
@@ -19,4 +18,6 @@ public interface OrganizationApi {
   Organization save(Organization organisation);
 
   Organization get();
+
+  boolean hasOrganisation();
 }

--- a/backend/mr-db-sql/src/main/java/io/featurehub/db/services/OrganizationSqlApi.java
+++ b/backend/mr-db-sql/src/main/java/io/featurehub/db/services/OrganizationSqlApi.java
@@ -8,6 +8,7 @@ import io.featurehub.db.api.OrganizationApi;
 import io.featurehub.db.model.DbNamedCache;
 import io.featurehub.db.model.DbOrganization;
 import io.featurehub.db.model.query.QDbNamedCache;
+import io.featurehub.db.model.query.QDbOrganization;
 import io.featurehub.mr.model.Organization;
 import io.featurehub.publish.ChannelConstants;
 import jakarta.inject.Inject;
@@ -26,6 +27,11 @@ public class OrganizationSqlApi implements OrganizationApi {
 
   public Organization get() {
     return convertUtils.toOrganization(convertUtils.dbOrganization(), Opts.opts(FillOpts.Groups));
+  }
+
+  @Override
+  public boolean hasOrganisation() {
+    return new QDbOrganization().exists();
   }
 
   @Transactional

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/SetupResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/SetupResource.java
@@ -122,9 +122,7 @@ public class SetupResource implements SetupServiceDelegate {
 
   @Override
   public TokenizedPerson setupSiteAdmin(SetupSiteAdmin setupSiteAdmin) {
-    Organization existingOrg = organizationApi.get();
-
-    if (existingOrg != null) {
+    if (organizationApi.hasOrganisation()) {
       throw new WebApplicationException("duplicate", Response.Status.CONFLICT);
     }
 

--- a/backend/mr/src/main/resources/deploy-defaults/common.properties
+++ b/backend/mr/src/main/resources/deploy-defaults/common.properties
@@ -7,7 +7,6 @@ db.password=
 db.username=sa
 db.driver=org.h2.Driver
 db.connections=3
-register.url=http://localhost:8085/register-url?token=%s
 jersey.cors.headers=X-Requested-With,Authorization,Content-type,Accept-Version,Content-MD5,CSRF-Token,x-ijt,cache-control,Baggage
 jersey.logging.exclude-entirely-uris=/health/liveness,/health/readiness,/metrics
 portfolio.admin.group.suffix=Administrators

--- a/backend/party-server/src/test/resources/application.properties
+++ b/backend/party-server/src/test/resources/application.properties
@@ -10,10 +10,12 @@ edge.cache-control.header=max-age=24
 # uncomment these lines and point at your actual compiled asset directory if you want to run the frontend locally
 # served from Party-Server
 #web.asset.location=/Users/X/projects/fh/featurehub/admin-frontend/target/open_admin_app/build/web
-#run.nginx=true
+run.nginx=true
+web.asset.location=/Users/richard/projects/fh/featurehub/admin-frontend/target/open_admin_app/build/web
 
 #if you want to run this locally and still Run and Debug your Flutter code, edit the web/index.html and change
 #the <base> tag to point to the same location but with a / at the end so instead of <base href="/"> it
 #becomes <base href="/your-site/">
 #featurehub.url-path=/your-site
-
+#featurehub.url-path=/foo/featurehub
+#monitor.port=8704


### PR DESCRIPTION
# Description

Regardless of the featurehub.url-path provided to change the context for the application, the metric and health check urls should response on / as, particularly metrics, they are the traditional locations. We also need to leave them where they are so existing deployments don't fail on upgrade.

Fixes #853
