### PR TITLE
[bufgix/intranet-canvaskit] Ensure canvaskit loads using a relative url

### DIFF
--- a/admin-frontend/build/build.sh
+++ b/admin-frontend/build/build.sh
@@ -46,7 +46,7 @@ mv build build_original
 mkdir -p build/web/assets
 
 # Flutter already downloads Canvaskit, this just lets us use what it has already downloaded
-flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/ --target=lib/deploy_main.dart
+flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --target=lib/deploy_main.dart
 
 rename_main_dart
 

--- a/backend/party-server/src/test/resources/application.properties
+++ b/backend/party-server/src/test/resources/application.properties
@@ -10,12 +10,11 @@ edge.cache-control.header=max-age=24
 # uncomment these lines and point at your actual compiled asset directory if you want to run the frontend locally
 # served from Party-Server
 #web.asset.location=/Users/X/projects/fh/featurehub/admin-frontend/target/open_admin_app/build/web
-run.nginx=true
-web.asset.location=/Users/richard/projects/fh/featurehub/admin-frontend/target/open_admin_app/build/web
+#run.nginx=true
 
 #if you want to run this locally and still Run and Debug your Flutter code, edit the web/index.html and change
 #the <base> tag to point to the same location but with a / at the end so instead of <base href="/"> it
 #becomes <base href="/your-site/">
 #featurehub.url-path=/your-site
-#featurehub.url-path=/foo/featurehub
+featurehub.url-path=/foo/featurehub
 #monitor.port=8704


### PR DESCRIPTION
# Description

The canvaskit url for the intranet site needs to be relative.

Fixes #855

