### PR TITLE
[bugfix/perms-feature-create] Unable to set create feature perms on multiple apps

### DIFF
--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -272,6 +272,7 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
             includeGroupRoles: true,
             includeMembers: false,
             updateMembers: false,
+            applicationId: applicationId,
             updateApplicationGroupRoles: true,
             updateEnvironmentGroupRoles: true)
         .catchError((e, s) {

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -1997,16 +1997,26 @@ paths:
           in: query
           schema:
             type: boolean
+          required: false
         - name: updateEnvironmentGroupRoles
           description: "update environment group roles, deleting any not passed"
           in: query
           schema:
             type: boolean
+          required: false
         - name: updateApplicationGroupRoles
           description: "update application group roles, deleting any not passed"
           in: query
           schema:
             type: boolean
+          required: false
+        - name: applicationId
+          description: "if updating the application group roles, and the application id is passed, then the changes are limited to that application"
+          in: query
+          schema:
+            type: string
+            format: uuid
+          required: false
       requestBody:
         required: true
         content:

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
@@ -48,6 +48,7 @@ interface GroupApi {
   fun updateGroup(
     gid: UUID,
     group: Group,
+    appId: UUID?,
     updateMembers: Boolean,
     updateApplicationGroupRoles: Boolean,
     updateEnvironmentGroupRoles: Boolean,

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -373,9 +373,9 @@ open class ConvertUtils : Conversions {
       var aclQuery = QDbAcl().group.eq(dbg)
       if (appIdFilter != null) {
         aclQuery = aclQuery
-          .or().environment.parentApplication.id
-          .eq(appIdFilter).application.id
-          .eq(appIdFilter)
+          .or()
+          .environment.parentApplication.id.eq(appIdFilter)
+          .application.id.eq(appIdFilter)
           .endOr()
       }
       aclQuery.findEach { acl: DbAcl ->
@@ -691,7 +691,7 @@ open class ConvertUtils : Conversions {
         if (appIdFilter != null) {
           permQuery = permQuery.environment.parentApplication.id.eq(appIdFilter)
         }
-        account.permissions = permQuery.findList().stream()
+        account.permissions = permQuery.findList()
           .map { sae: DbServiceAccountEnvironment ->
             toServiceAccountPermission(
               sae,
@@ -701,7 +701,6 @@ open class ConvertUtils : Conversions {
             )
           }
           .filter { obj: ServiceAccountPermission? -> Objects.nonNull(obj) }
-          .collect(Collectors.toList())
       }
     }
     return account

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
@@ -1,6 +1,7 @@
 package io.featurehub.db.services
 
 import io.featurehub.db.api.DBLoginSession
+import io.featurehub.db.api.GroupApi
 import io.featurehub.db.api.Opts
 import io.featurehub.mr.events.common.CacheSource
 import io.featurehub.mr.model.Application
@@ -212,7 +213,7 @@ class AuthenticationSpec extends BaseSpec {
         new Group().name("admin-group").admin(true)
           .applicationRoles([new ApplicationGroupRole().applicationId(app1.id)
                                .roles([ApplicationRoleType.FEATURE_EDIT])]), superPerson)
-      groupSqlApi.updateGroup(portfolioGroup.id, portfolioGroup.members([p2]),
+      groupSqlApi.updateGroup(portfolioGroup.id, portfolioGroup.members([p2]), null,
         true, false, false, Opts.empty())
     when: "i login"
       def user = auth.login(p2.email, "hooray")

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
@@ -3,6 +3,7 @@ package io.featurehub.db.services
 import groovy.transform.CompileStatic
 import io.featurehub.db.api.EnvironmentApi
 import io.featurehub.db.api.FillOpts
+import io.featurehub.db.api.GroupApi
 import io.featurehub.db.api.Opts
 import io.featurehub.db.model.DbEnvironment
 import io.featurehub.db.model.DbOrganization
@@ -294,7 +295,7 @@ class Environment2Spec extends Base2Spec {
       def g = groupSqlApi.getGroup(groupInPortfolio1.id, Opts.opts(FillOpts.Members), superPerson)
 //      g.members.add(averageJoeMemberOfPortfolio1)
       g.environmentRoles.add(new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.CHANGE_VALUE]))
-      groupSqlApi.updateGroup(g.id, g, false, false, true, Opts.empty())
+      groupSqlApi.updateGroup(g.id, g, null, false, false, true, Opts.empty())
       def perms2 = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
       def permsAdmin = envApi.personRoles(superPerson, env.id)
     then: "the permissions to the portfolio are empty"

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
@@ -4,6 +4,7 @@ package io.featurehub.db.services
 import io.featurehub.db.api.ApplicationApi
 import io.featurehub.db.api.FeatureApi
 import io.featurehub.db.api.FillOpts
+import io.featurehub.db.api.GroupApi
 import io.featurehub.db.api.OptimisticLockingException
 import io.featurehub.db.api.Opts
 import io.featurehub.db.api.PersonFeaturePermission
@@ -326,7 +327,7 @@ class FeatureSpec extends Base2Spec {
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(env2.id)
       ])
       g1.members = [averageJoeMemberOfPortfolio1]
-      groupSqlApi.updateGroup(g1.id, g1, true, true, true, Opts.empty());
+      groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, Opts.empty());
     and: "i create a feature value called FEATURE_BUNCH and unlock the feature in all branches"
       String k = 'FEATURE_BUNCH'
       appApi.createApplicationFeature(app2Id, new Feature().name(k).key(k).valueType(FeatureValueType.BOOLEAN), superPerson, Opts.empty())
@@ -456,7 +457,7 @@ class FeatureSpec extends Base2Spec {
     and: "i add permissions and members to the group"
       group.environmentRoles([new EnvironmentGroupRole().environmentId(env1.id).roles([RoleType.LOCK, RoleType.UNLOCK, RoleType.READ])])
       group.members([person])
-      group = groupSqlApi.updateGroup(group.id, group, true, false, true, Opts.empty())
+      group = groupSqlApi.updateGroup(group.id, group, null, true, false, true, Opts.empty())
     when: "i try and unlock the feature with the person, it will let me"
       def fv = featureSqlApi.getFeatureValueForEnvironment(env1.id, key)
       if (fv == null) {

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ServiceAccount2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ServiceAccount2Spec.groovy
@@ -72,7 +72,7 @@ class ServiceAccount2Spec extends Base2Spec {
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(environment2.id),
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(environment3.id),
       ]
-    ), false, false, true, Opts.empty())
+    ), null, false, false, true, Opts.empty())
 
     if (db.currentTransaction() != null && db.currentTransaction().active) {
       db.commitTransaction()

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/GroupResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/GroupResource.java
@@ -12,6 +12,7 @@ import io.featurehub.mr.auth.AuthManagerService;
 import io.featurehub.mr.model.Group;
 import io.featurehub.mr.model.Person;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
@@ -218,7 +219,7 @@ public class GroupResource implements GroupServiceDelegate {
       isAdminOfGroup(group, securityContext, "No permission to rename group.",  adminGroup -> {
         try {
           groupHolder.group = groupApi.updateGroup(gid, renameDetails,
-            Boolean.TRUE.equals(holder.updateMembers),
+            holder.applicationId, Boolean.TRUE.equals(holder.updateMembers),
             Boolean.TRUE.equals(holder.updateApplicationGroupRoles),
             Boolean.TRUE.equals(holder.updateEnvironmentGroupRoles),
             new Opts().add(FillOpts.Members, holder.includeMembers).add(FillOpts.Acls, holder.includeGroupRoles));


### PR DESCRIPTION
# Description

Incongruity in behaviour on front end. It requests only the application's roles and updates all roles, wiping out other application's roles. This has been extended via an extra optional API parameter which now passes the applicationId  the roles should be limited to comparing against. The existing API works as per original definition, the new API addition also has full tests. The extra test picked up a minor error in the Java->Kotlin migration introduced in 1.5.10.

Fixes #879

