### PR TITLE
[feature/feature-edit-vs-create] Feature permissions edit vs create

### DIFF
--- a/admin-frontend/open_admin_app/lib/api/client_api.dart
+++ b/admin-frontend/open_admin_app/lib/api/client_api.dart
@@ -185,17 +185,16 @@ class ManagementRepositoryClientBloc implements Bloc {
 
   bool get userIsSuperAdmin => personState.userIsSuperAdmin;
 
-  bool get userIsFeatureAdminOfCurrentApplication {
-    final currentAid = getCurrentAid();
+  bool get userHasFeatureEditRoleInCurrentApplication {
+    return personState.personCanEditFeaturesForApplication(getCurrentAid());
+  }
 
-    final result = person.groups.any((g) => g.applicationRoles.any((ar) =>
-        ar.applicationId == currentAid &&
-        ar.roles.contains(ApplicationRoleType.FEATURE_EDIT)));
+  bool get userHasFeatureCreationRoleInCurrentApplication {
+    return personState.personCanCreateFeaturesForApplication(getCurrentAid());
+  }
 
-    // print(
-    //     "checking featureadmin ${currentAid} and result is ${result} from groups ${person.groups}");
-
-    return result;
+  bool get userHasFeaturePermissionsInCurrentApplication {
+    return personState.personCanAnythingFeaturesForApplication(getCurrentAid());
   }
 
   bool get userIsCurrentPortfolioAdmin =>

--- a/admin-frontend/open_admin_app/lib/common/person_state.dart
+++ b/admin-frontend/open_admin_app/lib/common/person_state.dart
@@ -40,15 +40,32 @@ class PersonState {
     _personSource.add(p);
   }
 
-  bool personCanEditFeaturesForCurrentApplication(String? appId) {
+  final _featureCreateRoles = [ApplicationRoleType.EDIT, ApplicationRoleType.EDIT_AND_DELETE, ApplicationRoleType.CREATE];
+  final _featureEditDeleteRoles = [ApplicationRoleType.EDIT, ApplicationRoleType.EDIT_AND_DELETE];
+
+  bool personCanEditFeaturesForApplication(String? appId) {
+    return _personHasApplicationRoleInApp(appId, _featureEditDeleteRoles );
+  }
+
+  bool personCanCreateFeaturesForApplication(String? appId) {
+    return _personHasApplicationRoleInApp(appId, _featureCreateRoles );
+  }
+
+  // if we add roles that are NOT feature related, this will need to change to exclude them
+  bool personCanAnythingFeaturesForApplication(String? appId) {
+    return _isUserIsSuperAdmin ||
+        person.groups.any((gp) => gp.applicationRoles.any((ar) => ar.applicationId == appId && ar.roles.isNotEmpty));
+  }
+
+  bool _personHasApplicationRoleInApp(String? appId, List<ApplicationRoleType> roles) {
     if (appId == null) {
       return _isUserIsSuperAdmin;
     }
 
     return _isUserIsSuperAdmin ||
-        person.groups.any((gp) => gp.applicationRoles.any((ar) =>
-            ar.roles.contains(ApplicationRoleType.FEATURE_EDIT) &&
-            ar.applicationId == appId));
+        person.groups.any((gp) => gp.applicationRoles.any((ar) => ar.applicationId == appId &&
+            ar.roles.any((roleForAppInGroup) => roles.contains(roleForAppInGroup))
+            ));
   }
 
   bool userHasPortfolioPermission(String? pid) {

--- a/admin-frontend/open_admin_app/lib/routes/features_overview_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/features_overview_route.dart
@@ -169,7 +169,7 @@ class _CreateFeatureButton extends StatelessWidget {
         stream: bloc.mrClient.streamValley.currentAppIdStream,
         builder: (context, snapshot) {
           final canEdit = bloc.mrClient.personState
-              .personCanEditFeaturesForCurrentApplication(snapshot.data);
+              .personCanCreateFeaturesForApplication(snapshot.data);
           return !canEdit
               ? const SizedBox.shrink()
               : FHFlatButtonAccent(

--- a/admin-frontend/open_admin_app/lib/widgets/apps/group_permissions_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/group_permissions_widget.dart
@@ -249,7 +249,6 @@ class _GroupPermissionDetailState extends State<_GroupPermissionDetailWidget> {
                     // SizedBox(height: 4.0),
                     Row(
                       children: <Widget>[
-                        // if (currentGroup?.admin != true) // you cannot change this if they are an admin
                           DropdownButton<_AdminFeatureRole>(
                             icon: const Padding(
                               padding: EdgeInsets.only(left: 8.0),

--- a/admin-frontend/open_admin_app/lib/widgets/apps/group_permissions_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/group_permissions_widget.dart
@@ -160,8 +160,8 @@ class _AdminFeatureRole {
 
 final _adminFeatureRoles = [
   _AdminFeatureRole('none', 'No feature permissions', []),
-  _AdminFeatureRole('creator', 'Feature Creator', [ApplicationRoleType.CREATE]),
-  _AdminFeatureRole('editor', 'Feature Admin', [ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE])
+  _AdminFeatureRole('creator', 'Create features', [ApplicationRoleType.CREATE]),
+  _AdminFeatureRole('editor', 'Create / Edit / Delete features', [ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE])
 ];
 
 final _noFeaturePermissionRole = _adminFeatureRoles[0];
@@ -240,11 +240,25 @@ class _GroupPermissionDetailState extends State<_GroupPermissionDetailWidget> {
                 }
 
                 return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
+                    SizedBox(height: 24),
+                    SelectableText(
+                        'Set feature level permissions',
+                        style: Theme.of(context).textTheme.caption),
+                    // SizedBox(height: 4.0),
                     Row(
                       children: <Widget>[
-                        if (currentGroup?.admin != true) // you cannot change this if they are an admin
-                          DropdownButton<_AdminFeatureRole>(items: _adminFeatureRoles.map((role) {
+                        // if (currentGroup?.admin != true) // you cannot change this if they are an admin
+                          DropdownButton<_AdminFeatureRole>(
+                            icon: const Padding(
+                              padding: EdgeInsets.only(left: 8.0),
+                              child: Icon(
+                                Icons.keyboard_arrow_down,
+                                size: 18,
+                              ),
+                            ),
+                            items: _adminFeatureRoles.map((role) {
                             return DropdownMenuItem<_AdminFeatureRole>(
                               value: role,
                               child: Text(role.name, style: Theme.of(context).textTheme.bodyText2, overflow: TextOverflow.ellipsis, ));
@@ -252,24 +266,15 @@ class _GroupPermissionDetailState extends State<_GroupPermissionDetailWidget> {
                             isDense: true,
                             // isExpanded: true,
                             value: adminFeatureRole,
-                            onChanged: (value) {
-                                setState(() {
-                                  adminFeatureRole = value;
-                                });
-                              }),
-                        if (currentGroup?.admin == true) // you can always editing/create/etc if you are in the admin group
-                          SelectableText(
-                              'This admin group can create, edit and delete features for this application',
-                              style: Theme.of(context).textTheme.caption),
+                            onChanged: currentGroup?.admin != true ? (value) => setState(() =>  adminFeatureRole = value) : null,
+                              ),
                       ],
                     ),
                     Container(
-                        padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
-                        child: Center(
-                          child: SelectableText(
-                              'Set the group access to features for each environment',
-                              style: Theme.of(context).textTheme.caption),
-                        )),
+                        padding: const EdgeInsets.fromLTRB(0, 32, 0, 8),
+                        child: SelectableText(
+                            'Set feature value level permissions per environment',
+                            style: Theme.of(context).textTheme.caption)),
                     Table(children: rows),
                     FHButtonBar(children: [
                       FHFlatButtonTransparent(

--- a/admin-frontend/open_admin_app/lib/widgets/features/create_update_feature_dialog_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/create_update_feature_dialog_widget.dart
@@ -52,12 +52,14 @@ class _CreateFeatureDialogWidgetState extends State<CreateFeatureDialogWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final isReadOnly =
-        !widget.bloc.mrClient.userIsFeatureAdminOfCurrentApplication;
+    final weAreCreatingANewFeature = (widget.feature == null);
+    final isReadOnly = weAreCreatingANewFeature ? !widget.bloc.mrClient.userHasFeatureCreationRoleInCurrentApplication
+        : !widget.bloc.mrClient.userHasFeatureEditRoleInCurrentApplication;
+
     return Form(
       key: _formKey,
       child: FHAlertDialog(
-        title: Text(widget.feature == null
+        title: Text(weAreCreatingANewFeature
             ? 'Create new feature'
             : (isReadOnly ? 'View feature' : 'Edit feature')),
         content: SizedBox(

--- a/admin-frontend/open_admin_app/lib/widgets/features/feature_names_left_panel.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/feature_names_left_panel.dart
@@ -181,7 +181,7 @@ class FeatureNamesLeftPanel extends StatelessWidget {
                                       },
                                       itemBuilder: (BuildContext context) {
                                         var isEditor = bloc.mrClient
-                                            .userIsFeatureAdminOfCurrentApplication;
+                                            .userHasFeatureEditRoleInCurrentApplication;
                                         return [
                                           PopupMenuItem(
                                               value: 'edit',

--- a/admin-frontend/open_admin_app/lib/widgets/features/set_feature_metadata.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/set_feature_metadata.dart
@@ -46,8 +46,7 @@ class _SetFeatureMetadataWidgetState extends State<SetFeatureMetadataWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final isReadOnly =
-        !widget.bloc.mrClient.userIsFeatureAdminOfCurrentApplication;
+    final isReadOnly = !widget.bloc.mrClient.userHasFeaturePermissionsInCurrentApplication;
 
     return (FHAlertDialog(
         title: Text(

--- a/admin-frontend/open_admin_app/lib/widgets/service-accounts/service_accounts_env_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/service-accounts/service_accounts_env_bloc.dart
@@ -33,7 +33,7 @@ class ServiceAccountEnvBloc implements Bloc, ManagementRepositoryAwareBloc {
       if (firstCall) {
         firstCall = false;
         // if we aren't an admin, we won't have called this, so lets call it now
-        if (!_mrClient.userIsFeatureAdminOfCurrentApplication) {
+        if (!_mrClient.userHasFeaturePermissionsInCurrentApplication) {
           // ignore: unawaited_futures
           _mrClient.streamValley.getCurrentApplicationEnvironments();
         }

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -3287,8 +3287,14 @@ components:
             $ref: "#/components/schemas/ApplicationRoleType"
     ApplicationRoleType:
       type: string
+      # FEATURE_EDIT is actually a CRUD role, people asked for the role to be separated into two
+      # FEATURE_CREATE is CR - Create and Read
+      # FEATURE_EDIT_AND_DELETE is RUD - FEATURE_CREATE + FEATURE_EDIT_AND_DELETE == FEATURE_EDIT
+      # eventually FEATURE_EDIT will go away and this transition will start to occur in future versions
       enum:
         - FEATURE_EDIT
+        - FEATURE_CREATE
+        - FEATURE_EDIT_AND_DELETE
     EnvironmentGroupRole:
       required:
         - environmentId

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/ApplicationApi.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/ApplicationApi.java
@@ -34,7 +34,17 @@ public interface ApplicationApi {
   List<Feature> deleteApplicationFeature(@NotNull UUID appId, String key);
   Feature getApplicationFeatureByKey(@NotNull UUID appId, @NotNull String key, @NotNull Opts opts);
 
-  Set<UUID> findFeatureEditors(UUID id);
-  Set<UUID> findFeatureReaders(UUID id);
+  @NotNull Set<UUID> findFeatureEditors(@NotNull UUID appId);
+  boolean personIsFeatureEditor(@NotNull UUID appId, @NotNull UUID personId);
+
+  /**
+   * Those who can create features
+   * @param appId
+   * @return
+   */
+  @NotNull Set<UUID> findFeatureCreators(@NotNull UUID appId);
+  boolean personIsFeatureCreator(@NotNull UUID appId, @NotNull UUID personId);
+
+  @NotNull Set<UUID> findFeatureReaders(@NotNull UUID appId);
   boolean personIsFeatureReader(UUID appId, UUID personId);
 }

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/PersonFeaturePermission.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/PersonFeaturePermission.java
@@ -31,15 +31,20 @@ public class PersonFeaturePermission {
   }
 
   public boolean hasWriteRole() {
-    return roles.contains(RoleType.CHANGE_VALUE) || roles.contains(RoleType.UNLOCK) || roles.contains(RoleType.LOCK) || hasCreateFeatureRole();
+    return roles.contains(RoleType.CHANGE_VALUE) || roles.contains(RoleType.UNLOCK) || roles.contains(RoleType.LOCK) || hasCreateFeatureRole() || hasEditFeatureRole();
   }
 
   public boolean hasChangeValueRole() {
     return roles.contains(RoleType.CHANGE_VALUE) || hasCreateFeatureRole();
+
   }
 
   public boolean hasCreateFeatureRole() {
-    return appRoles.contains(ApplicationRoleType.FEATURE_EDIT);
+    return appRoles.contains(ApplicationRoleType.EDIT) || appRoles.contains(ApplicationRoleType.CREATE);
+  }
+
+  public boolean hasEditFeatureRole() {
+    return appRoles.contains(ApplicationRoleType.EDIT) || appRoles.contains(ApplicationRoleType.EDIT_AND_DELETE);
   }
 
   public boolean hasLockRole() {

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/EnvironmentApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/EnvironmentApi.kt
@@ -4,7 +4,7 @@ import io.featurehub.mr.model.*
 import java.util.*
 
 interface EnvironmentApi {
-  fun personRoles(current: Person?, eid: UUID?): EnvironmentRoles?
+  fun personRoles(current: Person, eid: UUID): EnvironmentRoles?
   fun setOrdering(app: Application, environments: List<Environment>): List<Environment>?
   class DuplicateEnvironmentException : Exception()
   class InvalidEnvironmentChangeException : Exception()

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/Conversions.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/Conversions.kt
@@ -38,10 +38,10 @@ interface Conversions {
     opt: Opts?
   ): ServiceAccountPermission?
 
-  fun applicationGroupRoleFromAcl(acl: DbAcl?): ApplicationGroupRole?
-  fun environmentGroupRoleFromAcl(acl: DbAcl?): EnvironmentGroupRole?
-  fun splitEnvironmentRoles(roles: String?): List<RoleType>
-  fun splitApplicationRoles(roles: String?): List<ApplicationRoleType>
+  fun applicationGroupRoleFromAcl(acl: DbAcl?): ApplicationGroupRole
+  fun environmentGroupRoleFromAcl(acl: DbAcl?): EnvironmentGroupRole
+  fun splitEnvironmentRoles(roles: String?): MutableList<RoleType>
+  fun splitApplicationRoles(roles: String?): MutableList<ApplicationRoleType>
   fun convertEnvironmentAcl(dbAcl: DbAcl?): EnvironmentGroupRole?
   fun toOff(ldt: LocalDateTime?): OffsetDateTime?
   fun personName(person: DbPerson): String

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -386,11 +386,21 @@ open class ConvertUtils : Conversions {
       }
 
       // if this is an admin group and we have no roles, add the create/edit feature roles
-      if (group.admin == true && group.applicationRoles?.isEmpty() == true) {
+      if (group.admin == true) {
         appIdFilter?.let { appId ->
-          group.addApplicationRolesItem(ApplicationGroupRole().groupId(group.id!!).applicationId(appId).roles(
-            mutableListOf(ApplicationRoleType.EDIT_AND_DELETE, ApplicationRoleType.CREATE)
-          ))
+          val agr = group.applicationRoles?.find { appId == it.applicationId }
+
+          if (agr != null) {
+            if (agr.roles.isEmpty()) {
+              agr.roles = mutableListOf(ApplicationRoleType.EDIT_AND_DELETE, ApplicationRoleType.CREATE)
+            }
+          } else {
+            group.addApplicationRolesItem(ApplicationGroupRole().groupId(group.id!!).applicationId(appId).roles(
+              mutableListOf(ApplicationRoleType.EDIT_AND_DELETE, ApplicationRoleType.CREATE)
+            ))
+          }
+
+          null
         }
       }
     }

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -209,14 +209,14 @@ open class ConvertUtils : Conversions {
     return sap
   }
 
-  override fun applicationGroupRoleFromAcl(acl: DbAcl?): ApplicationGroupRole? {
+  override fun applicationGroupRoleFromAcl(acl: DbAcl?): ApplicationGroupRole {
     return ApplicationGroupRole()
       .groupId(acl!!.group.id)
       .roles(splitApplicationRoles(acl.roles))
       .applicationId(acl.application.id)
   }
 
-  override fun environmentGroupRoleFromAcl(acl: DbAcl?): EnvironmentGroupRole? {
+  override fun environmentGroupRoleFromAcl(acl: DbAcl?): EnvironmentGroupRole {
     val environmentGroupRole = EnvironmentGroupRole()
       .groupId(acl!!.group.id)
       .roles(splitEnvironmentRoles(acl.roles))
@@ -231,35 +231,34 @@ open class ConvertUtils : Conversions {
     return environmentGroupRole
   }
 
-  override fun splitEnvironmentRoles(roles: String?): List<RoleType> {
+  override fun splitEnvironmentRoles(roles: String?): MutableList<RoleType> {
     val roleTypes = mutableSetOf<RoleType>()
 
     if (roles == null || roles.isEmpty()) {
       return ArrayList(roleTypes)
     }
 
-    for (n in roles.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()) {
+    for (n in roles.split(",").map { it.trim() }.filter { it.isNotBlank() }) {
       try {
         roleTypes.add(RoleType.valueOf(n))
       } catch (ignored: Exception) {
       }
     }
 
-    return ArrayList(roleTypes)
+    return roleTypes.toMutableList()
   }
 
-  override fun splitApplicationRoles(roles: String?): List<ApplicationRoleType> {
+  override fun splitApplicationRoles(roles: String?): MutableList<ApplicationRoleType> {
     val roleTypes = mutableSetOf<ApplicationRoleType>()
     if (roles != null) {
-      for (n in roles.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()) {
+      for (n in roles.split(",").map { it.trim() }.filter { it.isNotBlank() }) {
         try {
           roleTypes.add(ApplicationRoleType.valueOf(n))
-        } catch (e: Exception) {
-          return listOf()
+        } catch (ignored: Exception) {
         }
       }
     }
-    return ArrayList(roleTypes)
+    return roleTypes.toMutableList()
   }
 
   override fun convertEnvironmentAcl(dbAcl: DbAcl?): EnvironmentGroupRole? {

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -384,6 +384,15 @@ open class ConvertUtils : Conversions {
           group.addApplicationRolesItem(applicationGroupRoleFromAcl(acl))
         }
       }
+
+      // if this is an admin group and we have no roles, add the create/edit feature roles
+      if (group.admin == true && group.applicationRoles?.isEmpty() == true) {
+        appIdFilter?.let { appId ->
+          group.addApplicationRolesItem(ApplicationGroupRole().groupId(group.id!!).applicationId(appId).roles(
+            mutableListOf(ApplicationRoleType.EDIT_AND_DELETE, ApplicationRoleType.CREATE)
+          ))
+        }
+      }
     }
     return group
   }

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/EnvironmentSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/EnvironmentSqlApi.kt
@@ -24,13 +24,17 @@ class EnvironmentSqlApi @Inject constructor(
   private val cacheSource: CacheSource,
   private val archiveStrategy: ArchiveStrategy
 ) : EnvironmentApi {
-  override fun personRoles(current: Person?, eid: UUID?): EnvironmentRoles? {
-    Conversions.nonNullPerson(current)
-    Conversions.nonNullEnvironmentId(eid)
+
+  /**
+   * What roles does this person have in this environment?
+   */
+  override fun personRoles(current: Person, eid: UUID): EnvironmentRoles? {
+
     val environment = convertUtils.byEnvironment(eid, Opts.opts(FillOpts.Applications))
     val p = convertUtils.byPerson(current)
     val roles: MutableSet<RoleType> = HashSet()
     val appRoles: MutableSet<ApplicationRoleType> = HashSet()
+
     if (environment != null && p != null) {
       // is this person a portfolio admin? if so, they have all access to all environments in the portfolio
       if (QDbGroup().adminGroup.isTrue.whenArchived.isNull.groupMembers.person.eq(p).owningPortfolio.applications.environments.eq(
@@ -38,9 +42,10 @@ class EnvironmentSqlApi @Inject constructor(
         ).exists()
       ) {
         return EnvironmentRoles.Builder()
-          .applicationRoles(HashSet(listOf(*ApplicationRoleType.values())))
+          .applicationRoles(mutableSetOf(ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE))
           .environmentRoles(HashSet(listOf(*RoleType.values()))).build()
       }
+
       QDbAcl().environment.eq(environment).group.groupMembers.person.eq(p).findList().forEach { fe: DbAcl ->
         val splitRoles = convertUtils.splitEnvironmentRoles(fe.roles)
         roles.addAll(splitRoles)
@@ -49,13 +54,12 @@ class EnvironmentSqlApi @Inject constructor(
           roles.add(RoleType.READ)
         }
       }
+
       QDbAcl().application.eq(environment.parentApplication).group.groupMembers.person.eq(p).findList().forEach { fe: DbAcl ->
-        val splitRoles = convertUtils.splitApplicationRoles(fe.roles)
-        if (splitRoles.contains(ApplicationRoleType.FEATURE_EDIT)) {
-          appRoles.add(ApplicationRoleType.FEATURE_EDIT)
-        }
+        appRoles.addAll(convertUtils.splitApplicationRoles(fe.roles))
       }
     }
+
     return EnvironmentRoles.Builder().applicationRoles(appRoles).environmentRoles(roles).build()
   }
 

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
@@ -185,6 +185,17 @@ class ApplicationSpec extends BaseSpec {
       group5.applicationRoles.find({it.applicationId == app2.id}) == null
   }
 
+  def "the auto-created portfolio group has feature create/edit permissions"() {
+    given: "i create an application"
+      def app1 = appApi.createApplication(portfolio1.id,
+        new Application().name("irinas-perm-create1").description("perm-create"), superPerson)
+    when: "i convert the portfolio group to a model"
+      def group = groupSqlApi.getGroup(adminGroup.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app1.id), superPerson)
+    then:
+      group.applicationRoles.find({ it.applicationId == app1.id }).roles.containsAll([ApplicationRoleType.EDIT_AND_DELETE,
+                                                                                      ApplicationRoleType.CREATE])
+  }
+
   def "application groups can store multiple Acls"() {
     given: "i create an application"
       def app1 = appApi.createApplication(portfolio1.id, new Application().name("perm-create1").description("perm-create"), superPerson)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
@@ -1,6 +1,6 @@
 package io.featurehub.db.services
 
-
+import io.featurehub.db.FilterOptType
 import io.featurehub.db.api.ApplicationApi
 import io.featurehub.db.api.FillOpts
 import io.featurehub.db.api.GroupApi
@@ -15,6 +15,7 @@ import io.featurehub.mr.model.Environment
 import io.featurehub.mr.model.EnvironmentGroupRole
 import io.featurehub.mr.model.Group
 import io.featurehub.mr.model.Person
+import io.featurehub.mr.model.PersonId
 import io.featurehub.mr.model.Portfolio
 import io.featurehub.mr.model.RoleType
 import spock.lang.Shared
@@ -164,12 +165,12 @@ class ApplicationSpec extends BaseSpec {
       def group = groupSqlApi.createGroup(portfolio1.id, new Group().name("loicoudot"), superPerson)
     when:
       def group1 = groupSqlApi.updateGroup(group.id,
-        group.applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_EDIT])]),
+        group.applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.EDIT])]),
         app1.id,
         false, true, false, Opts.opts(FillOpts.Acls))
     and:
       def group2 = groupSqlApi.getGroup(group1.id, Opts.empty(), superPerson)
-      group2.applicationRoles.add(new ApplicationGroupRole().applicationId(app2.id).roles([ApplicationRoleType.FEATURE_EDIT]))
+      group2.applicationRoles.add(new ApplicationGroupRole().applicationId(app2.id).roles([ApplicationRoleType.EDIT]))
       def group3 = groupSqlApi.updateGroup(group.id, group2, app2.id, false, true, false,
         Opts.opts(FillOpts.Acls))
     and: "i delete the role but just from application 2"
@@ -178,10 +179,72 @@ class ApplicationSpec extends BaseSpec {
         Opts.opts(FillOpts.Acls))
     then:
       group3.applicationRoles.size() == 2
-      group3.applicationRoles.find({it.applicationId == app1.id}).roles.contains(ApplicationRoleType.FEATURE_EDIT)
-      group3.applicationRoles.find({it.applicationId == app2.id}).roles.contains(ApplicationRoleType.FEATURE_EDIT)
+      group3.applicationRoles.find({it.applicationId == app1.id}).roles.contains(ApplicationRoleType.EDIT)
+      group3.applicationRoles.find({it.applicationId == app2.id}).roles.contains(ApplicationRoleType.EDIT)
       group5.applicationRoles.size() == 1
       group5.applicationRoles.find({it.applicationId == app2.id}) == null
+  }
+
+  def "application groups can store multiple Acls"() {
+    given: "i create an application"
+      def app1 = appApi.createApplication(portfolio1.id, new Application().name("perm-create1").description("perm-create"), superPerson)
+    and: "i have a new group"
+      def createdGroup = groupSqlApi.createGroup(portfolio1.id, new Group().name("perm-create-group"), superPerson)
+    and: "create a new person to join the group"
+      def deepme = new DbPerson.Builder().email("dj-deepme@featurehub.io").name("DJ DeepMe").build()
+      database.save(deepme)
+      def personIsCreator0 = appApi.personIsFeatureCreator(app1.id, deepme.id)
+      def personIsEditor0 = appApi.personIsFeatureEditor(app1.id, deepme.id)
+      createdGroup.addMembersItem(new Person().id(new PersonId().id(deepme.id)))
+      def group = groupSqlApi.updateGroup(createdGroup.id, createdGroup, null, true, false, false, Opts.opts(FillOpts.Acls))
+    when: "i add create permissions for the app to the group"
+      def groupWithCreatePerms = groupSqlApi.updateGroup(group.id,
+        group.applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.CREATE])]),
+        app1.id,
+        false, true, false, Opts.opts(FillOpts.Acls))
+      def creators1 = appApi.findFeatureCreators(app1.id)
+      def editors1 = appApi.findFeatureEditors(app1.id)
+      def personIsCreator1 = appApi.personIsFeatureCreator(app1.id, deepme.id)
+      def personIsEditor1 = appApi.personIsFeatureEditor(app1.id, deepme.id)
+    and: "i add edit permissions"
+      def group2 = groupSqlApi.getGroup(group.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app1.id), superPerson)
+      group2.applicationRoles[0].roles.add(ApplicationRoleType.EDIT_AND_DELETE)
+      def groupWithEditAndCreatePerms = groupSqlApi.updateGroup(group.id, group2, app1.id, false,
+        true, false, Opts.opts(FillOpts.Acls))
+      def creators2 = appApi.findFeatureCreators(app1.id)
+      def editors2 = appApi.findFeatureEditors(app1.id)
+      def personIsCreator2 = appApi.personIsFeatureCreator(app1.id, deepme.id)
+      def personIsEditor2 = appApi.personIsFeatureEditor(app1.id, deepme.id)
+    and: "i remove the create role"
+      def group3 = groupSqlApi.getGroup(group.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app1.id), superPerson)
+      group3.applicationRoles[0].roles.removeIf { it == ApplicationRoleType.EDIT_AND_DELETE }
+      def groupWithEditPerms = groupSqlApi.updateGroup(group.id, group3, app1.id, false, true, false, Opts.opts(FillOpts.Acls))
+      def creators3 = appApi.findFeatureCreators(app1.id)
+      def editors3 = appApi.findFeatureEditors(app1.id)
+      def personIsCreator3 = appApi.personIsFeatureCreator(app1.id, deepme.id)
+      def personIsEditor3 = appApi.personIsFeatureEditor(app1.id, deepme.id)
+    then:
+      groupWithCreatePerms.applicationRoles.find({it.applicationId == app1.id}).roles.containsAll([ApplicationRoleType.CREATE])
+      groupWithEditAndCreatePerms.applicationRoles.find({it.applicationId == app1.id}).roles.containsAll([ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE])
+      !groupWithEditPerms.applicationRoles.find({it.applicationId == app1.id}).roles.containsAll([ApplicationRoleType.EDIT_AND_DELETE])
+      // admin group always has the superadmin in it with a creator + edit role
+      creators1.size() == 2
+      creators1.contains(deepme.id)
+      editors1.size() == 1
+      !editors1.containsAll(deepme.id)
+      creators2.size() == 2
+      editors2.size() == 2
+      editors2.containsAll(deepme.id)
+      creators3.size() == 2
+      editors3.size() == 1
+      !personIsCreator0
+      personIsCreator1
+      personIsCreator2
+      personIsCreator3
+      !personIsEditor0
+      !personIsEditor1
+      !personIsEditor3
+      personIsEditor2
   }
 
   // based on this article: https://en.wikipedia.org/wiki/Ukrainian_surnames#Cossack_names

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
@@ -212,13 +212,13 @@ class AuthenticationSpec extends BaseSpec {
       def portfolioGroup = groupSqlApi.createGroup(portfolio1.id,
         new Group().name("admin-group").admin(true)
           .applicationRoles([new ApplicationGroupRole().applicationId(app1.id)
-                               .roles([ApplicationRoleType.FEATURE_EDIT])]), superPerson)
+                               .roles([ApplicationRoleType.EDIT])]), superPerson)
       groupSqlApi.updateGroup(portfolioGroup.id, portfolioGroup.members([p2]), null,
         true, false, false, Opts.empty())
     when: "i login"
       def user = auth.login(p2.email, "hooray")
     then: "i have the application role permission to the portfolio"
-      user.groups.find({it.applicationRoles.find({ar -> ar.roles.contains(ApplicationRoleType.FEATURE_EDIT) && ar.applicationId == app1.id})})
+      user.groups.find({it.applicationRoles.find({ar -> ar.roles.contains(ApplicationRoleType.EDIT) && ar.applicationId == app1.id})})
   }
 
   def "We can create a session for a person and then find their session by token"() {

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/BaseSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/BaseSpec.groovy
@@ -20,6 +20,7 @@ class BaseSpec extends Specification {
   @Shared UUID superuser
   @Shared DbArchiveStrategy archiveStrategy
   @Shared Organization org
+  @Shared Group adminGroup
 
   def baseSetupSpec() {
     System.setProperty("ebean.ddl.generate", "true")
@@ -48,8 +49,6 @@ class BaseSpec extends Specification {
       org = organizationSqlApi.save(new Organization().name("org1"))
     }
     // ensure the org is created and we have an admin user in an admin group
-
-    Group adminGroup
 
     superPerson = convertUtils.toPerson(dbSuperPerson, Opts.empty())
 

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
@@ -12,6 +12,7 @@ import io.featurehub.db.model.DbPortfolio
 import io.featurehub.db.model.query.QDbEnvironment
 import io.featurehub.mr.events.common.CacheSource
 import io.featurehub.mr.model.Application
+import io.featurehub.mr.model.ApplicationGroupRole
 import io.featurehub.mr.model.ApplicationRoleType
 import io.featurehub.mr.model.Environment
 import io.featurehub.mr.model.EnvironmentGroupRole
@@ -289,24 +290,29 @@ class Environment2Spec extends Base2Spec {
     and: "i have an environment"
       def env = envApi.create(new Environment().name("env-1-perm-1").description("1"), app1, superPerson)
     when: "i ask for the roles"
-      def perms = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
-      def permsWhenNonAdmin = envApi.personRoles(superPerson, env.id)
+      def permsAverageJoe = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
+      def permsWhenSuperAdmin = envApi.personRoles(superPerson, env.id)
     and: "I change the perms for the environment"
       def g = groupSqlApi.getGroup(groupInPortfolio1.id, Opts.opts(FillOpts.Members), superPerson)
 //      g.members.add(averageJoeMemberOfPortfolio1)
       g.environmentRoles.add(new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.CHANGE_VALUE]))
       groupSqlApi.updateGroup(g.id, g, null, false, false, true, Opts.empty())
-      def perms2 = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
+      def permsAverageJoeAfterAddingPerms = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
       def permsAdmin = envApi.personRoles(superPerson, env.id)
+    and: "I make average joe a feature creator"
+      g = groupSqlApi.getGroup(groupInPortfolio1.id, Opts.opts(FillOpts.Acls), superPerson)
+      g.applicationRoles.add(new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.CREATE]))
+      def permsAverageJoeAfterAdminOfApp1 = groupSqlApi.updateGroup(g.id, g, app1.id, false, true, false, Opts.opts(FillOpts.Acls))
     then: "the permissions to the portfolio are empty"
-      perms.environmentRoles.isEmpty()
-      perms.applicationRoles.isEmpty()
-      perms2.applicationRoles.isEmpty()
-      perms2.environmentRoles.containsAll([RoleType.CHANGE_VALUE, RoleType.READ])
-      permsAdmin.applicationRoles.containsAll(ApplicationRoleType.values() as List)
+      permsAverageJoe.environmentRoles.isEmpty()
+      permsAverageJoe.applicationRoles.isEmpty()
+      permsAverageJoeAfterAddingPerms.applicationRoles.isEmpty()
+      permsAverageJoeAfterAddingPerms.environmentRoles.containsAll([RoleType.CHANGE_VALUE, RoleType.READ])
+      permsAdmin.applicationRoles.containsAll([ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE])
       permsAdmin.environmentRoles.containsAll(RoleType.values() as List)
-      permsWhenNonAdmin.applicationRoles.containsAll(ApplicationRoleType.values() as List)
-      permsWhenNonAdmin.environmentRoles.containsAll(RoleType.values() as List)
+      permsWhenSuperAdmin.applicationRoles.containsAll([ApplicationRoleType.CREATE, ApplicationRoleType.EDIT_AND_DELETE])
+      permsWhenSuperAdmin.environmentRoles.containsAll(RoleType.values() as List)
+      permsAverageJoeAfterAdminOfApp1.applicationRoles.collect({it.roles}).flatten().containsAll([ApplicationRoleType.CREATE])
   }
 
   def "i create an environment and update it using the update2"() {

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
@@ -479,7 +479,7 @@ class GroupSpec extends BaseSpec {
         new Group().name("app acl group1")
           .applicationRoles([
             new ApplicationGroupRole()
-              .roles([ApplicationRoleType.FEATURE_EDIT])
+              .roles([ApplicationRoleType.EDIT])
               .applicationId(commonApplication1.id)
           ]), superPerson)
     and: "i find the group including the acls"
@@ -489,7 +489,7 @@ class GroupSpec extends BaseSpec {
       updating.environmentRoles = [
         new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE]).environmentId(env1App1.id).groupId(g1.id)
       ]
-      updating.applicationRoles.add(new ApplicationGroupRole().roles([ApplicationRoleType.FEATURE_EDIT]).applicationId(commonApplication2.id))
+      updating.applicationRoles.add(new ApplicationGroupRole().roles([ApplicationRoleType.EDIT]).applicationId(commonApplication2.id))
       def up1 = groupSqlApi.updateGroup(g1.id, updating, null, true, true, true, Opts.opts(FillOpts.Acls))
     when: "i find the group"
       def found1 = groupSqlApi.getGroup(g1.id, Opts.opts(FillOpts.Acls), superPerson)

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
@@ -145,7 +145,8 @@ public class FeatureResource implements FeatureServiceDelegate {
 
   @Override
   public List<Feature> updateFeatureForApplication(UUID id, String key, Feature feature, UpdateFeatureForApplicationHolder holder, SecurityContext securityContext) {
-    applicationUtils.check(securityContext, id);
+    applicationUtils.featureEditorCheck(securityContext, id);
+
     try {
       List<Feature> features = applicationApi.updateApplicationFeature(id, key, feature, Opts.empty().add(FillOpts.MetaData, holder.includeMetaData));
 

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/FeatureResource.java
@@ -49,7 +49,7 @@ public class FeatureResource implements FeatureServiceDelegate {
                                                     CreateFeaturesForApplicationHolder holder,
                                                     SecurityContext securityContext) {
     // here we are only calling it to ensure the security check happens
-    final ApplicationPermissionCheck appFeaturePermCheck = applicationUtils.featureAdminCheck(securityContext, id);
+    final ApplicationPermissionCheck appFeaturePermCheck = applicationUtils.featureCreatorCheck(securityContext, id);
 
     try {
       return applicationApi.createApplicationFeature(id, feature, appFeaturePermCheck.getCurrent(), Opts.empty().add(FillOpts.MetaData, holder.includeMetaData));
@@ -61,7 +61,7 @@ public class FeatureResource implements FeatureServiceDelegate {
   @Override
   public List<Feature> deleteFeatureForApplication(UUID id, String key, DeleteFeatureForApplicationHolder holder, SecurityContext securityContext) {
     // here we are only calling it to ensure the security check happens
-    applicationUtils.featureAdminCheck(securityContext, id);
+    applicationUtils.featureEditorCheck(securityContext, id);
 
     List<Feature> features = applicationApi.deleteApplicationFeature(id, key);
     if (features == null) {

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/RolloutStrategyResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/RolloutStrategyResource.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 public class RolloutStrategyResource implements RolloutStrategyServiceDelegate {
   private static final Logger log = LoggerFactory.getLogger(RolloutStrategyResource.class);
-  private final AuthManagerService authManager;
   private final ApplicationUtils applicationUtils;
   private final RolloutStrategyApi rolloutStrategyApi;
   private final RolloutStrategyValidator validator;
@@ -36,7 +35,6 @@ public class RolloutStrategyResource implements RolloutStrategyServiceDelegate {
   @Inject
   public RolloutStrategyResource(AuthManagerService authManager, ApplicationUtils applicationUtils,
                                  RolloutStrategyApi rolloutStrategyApi, RolloutStrategyValidator validator) {
-    this.authManager = authManager;
     this.applicationUtils = applicationUtils;
     this.rolloutStrategyApi = rolloutStrategyApi;
     this.validator = validator;
@@ -46,8 +44,7 @@ public class RolloutStrategyResource implements RolloutStrategyServiceDelegate {
   public RolloutStrategyInfo createRolloutStrategy(UUID appId, RolloutStrategy rolloutStrategy,
                                                    CreateRolloutStrategyHolder holder,
                                                    SecurityContext securityContext) {
-    applicationUtils.featureAdminCheck(securityContext, appId);
-    Person person = authManager.from(securityContext);
+    Person person = applicationUtils.featureCreatorCheck(securityContext, appId).getCurrent();
 
     cleanStrategy(rolloutStrategy);
 
@@ -70,8 +67,8 @@ public class RolloutStrategyResource implements RolloutStrategyServiceDelegate {
   @Override
   public RolloutStrategyInfo deleteRolloutStrategy(UUID appId, String strategyIdOrName, DeleteRolloutStrategyHolder holder,
                                                    SecurityContext securityContext) {
-    applicationUtils.featureAdminCheck(securityContext, appId);
-    Person person = authManager.from(securityContext);
+    Person person = applicationUtils.featureCreatorCheck(securityContext, appId).getCurrent();
+
     final RolloutStrategyInfo rolloutStrategyInfo = rolloutStrategyApi.archiveStrategy(appId, strategyIdOrName, person,
       new Opts().add(FillOpts.SimplePeople,
       holder.includeWhoChanged));
@@ -118,8 +115,7 @@ public class RolloutStrategyResource implements RolloutStrategyServiceDelegate {
   public RolloutStrategyInfo updateRolloutStrategy(UUID appId, String strategyIdOrName, RolloutStrategy rolloutStrategy,
                                                    UpdateRolloutStrategyHolder holder,
                                                    SecurityContext securityContext) {
-    applicationUtils.featureAdminCheck(securityContext, appId);
-    Person person = authManager.from(securityContext);
+    Person person = applicationUtils.featureCreatorCheck(securityContext, appId).getCurrent();
 
     cleanStrategy(rolloutStrategy);
 

--- a/backend/mr/src/main/java/io/featurehub/mr/utils/ApplicationUtils.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/utils/ApplicationUtils.java
@@ -50,15 +50,32 @@ public class ApplicationUtils {
     }
   }
 
-  public ApplicationPermissionCheck featureAdminCheck(SecurityContext securityContext, UUID id) {
+  public ApplicationPermissionCheck featureCreatorCheck(SecurityContext securityContext, UUID appId) {
     Person current = authManager.from(securityContext);
 
-    if (!applicationApi.findFeatureEditors(id).contains(current.getId().getId())) {
-      log.warn("Attempt by person {} to edt features in application {}", current.getId().getId(), id);
+    if (!applicationApi.personIsFeatureCreator(appId, current.getId().getId())) {
+      log.warn("Attempt by person {} to edt features in application {}", current.getId().getId(), appId);
 
-      return check(current, id, Opts.empty());
+      return check(current, appId, Opts.empty());
     } else {
       return new ApplicationPermissionCheck.Builder().current(current).build();
+    }
+  }
+
+  /**
+   * This just checks to see if a person has the Editor/Delete permission and if not, throws an exception. A portfolio
+   * admin or admin will always have it.
+   *
+   * @param securityContext
+   * @param appId
+   */
+  public void featureEditorCheck(SecurityContext securityContext, UUID appId) {
+    Person current = authManager.from(securityContext);
+
+    if (!applicationApi.personIsFeatureEditor(appId, current.getId().getId())) {
+      log.warn("Attempt by person {} to edt features in application {}", current.getId().getId(), appId);
+
+      check(current, appId, Opts.empty());
     }
   }
 

--- a/backend/mr/src/test/groovy/io/featurehub/mr/utils/ApplicationUtilsSpec.groovy
+++ b/backend/mr/src/test/groovy/io/featurehub/mr/utils/ApplicationUtilsSpec.groovy
@@ -1,0 +1,83 @@
+package io.featurehub.mr.utils
+
+import io.featurehub.db.api.ApplicationApi
+import io.featurehub.mr.auth.AuthManagerService
+import io.featurehub.mr.model.Application
+import io.featurehub.mr.model.Person
+import io.featurehub.mr.model.PersonId
+import jakarta.ws.rs.ForbiddenException
+import jakarta.ws.rs.core.SecurityContext
+import spock.lang.Specification
+
+class ApplicationUtilsSpec extends Specification {
+  AuthManagerService authManager
+  ApplicationApi appApi
+  ApplicationUtils  appUtils
+  SecurityContext ctx
+  Person person
+  UUID appId
+
+  def setup() {
+    authManager = Mock()
+    appApi = Mock()
+    ctx = Mock()
+    appId = UUID.randomUUID()
+    person = new Person().id(new PersonId().id(UUID.randomUUID())).name('Prince Frederick 1st').email('pf@fred.com')
+    authManager.from(ctx) >> person
+    appUtils = new ApplicationUtils(authManager, appApi)
+  }
+
+  def "when a person has a creator role, they will pass the creator check"() {
+    when: "we ask for permission check"
+      def result = appUtils.featureCreatorCheck(ctx, appId)
+    then:
+      1 * appApi.personIsFeatureCreator(appId, person.id.id) >> true
+      result.current == person
+      result.app == null
+  }
+
+  def "when a person has an org admin role, they will pass the creator check"() {
+    when: "we ask for permission check"
+      def result = appUtils.featureCreatorCheck(ctx, appId)
+    then:
+      1 * appApi.personIsFeatureCreator(appId, person.id.id) >> false
+      1 * appApi.getApplication(appId, _) >> new Application()
+      1 * authManager.isOrgAdmin(person) >> true
+      result.current == person
+      result.app != null
+  }
+
+  def "when a person has an portfolio admin role, they will pass the creator check"() {
+    given: "we have an app"
+      def app = new Application().portfolioId(UUID.randomUUID())
+    when: "we ask for permission check"
+      def result = appUtils.featureCreatorCheck(ctx, appId)
+    then:
+      1 * appApi.personIsFeatureCreator(appId, person.id.id) >> false
+      1 * appApi.getApplication(appId, _) >> app
+      1 * authManager.isOrgAdmin(person) >> false
+      1 * authManager.isPortfolioAdmin(app.portfolioId, person, null) >> true
+      result.current == person
+      result.app != null
+  }
+
+  def "when a person has no creator role and isn't an admin, they will fail the creator check"() {
+    given: "we have an app"
+      def app = new Application().portfolioId(UUID.randomUUID())
+    when: "we ask for permission check"
+      def result = appUtils.featureCreatorCheck(ctx, appId)
+    then:
+      1 * appApi.personIsFeatureCreator(appId, person.id.id) >> false
+      1 * appApi.getApplication(appId, _) >> app
+      1 * authManager.isOrgAdmin(person) >> false
+      1 * authManager.isPortfolioAdmin(app.portfolioId, person, null) >> false
+      thrown(ForbiddenException)
+  }
+
+  def "when a person has an editor role, it passes the editor check"() {
+    when: "we ask for permission check"
+      appUtils.featureEditorCheck(ctx, appId)
+    then:
+      1 * appApi.personIsFeatureEditor(appId, person.id.id) >> true
+  }
+}

--- a/e2e/test/steps/ApplicationStepdefs.dart
+++ b/e2e/test/steps/ApplicationStepdefs.dart
@@ -250,7 +250,7 @@ class ApplicationStepdefs {
         .getPerson("self", includeAcls: true, includeGroups: true);
 
     final theyDo = me.groups.any((gp) => gp.applicationRoles.any((ar) =>
-        ar.roles.contains(api.ApplicationRoleType.FEATURE_EDIT) &&
+    (ar.roles.contains(api.ApplicationRoleType.EDIT) || ar.roles.contains(api.ApplicationRoleType.EDIT_AND_DELETE) ) &&
         ar.applicationId == shared.application.id));
 
     assert(theyDo,


### PR DESCRIPTION
# Description

Create new application feature level permission, to just "create" features, thus adding ability for a group to only create features, without allowing them to delete or edit. We are keeping the original permission to "Create, edit and delete"- which allows all operations on the feature, also for backwards-compatibility of existing groups. 

Fixes #802

