### PR TITLE
[internal/reverse-jaxb] Security updates for dependencies

### DIFF
--- a/backend/composite-common/pom.xml
+++ b/backend/composite-common/pom.xml
@@ -95,17 +95,12 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.4.0-b180830.0359</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>4.0.1</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>4.0.1</version>
+      <version>2.3.7</version>
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>

--- a/backend/composite-db-drivers/pom.xml
+++ b/backend/composite-db-drivers/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.5.0</version>
+      <version>42.5.1</version>
     </dependency>
 
     <dependency>

--- a/backend/composite-parent/pom.xml
+++ b/backend/composite-parent/pom.xml
@@ -54,7 +54,7 @@
     <jackson.version.databind>2.13.2.1</jackson.version.databind> <!-- remove once upgraded jackson.version -->
     <sticky.version>1.3</sticky.version>
     <groovy.version>3.0.13</groovy.version>
-    <ebean.version>13.10.1</ebean.version>
+    <ebean.version>13.10.2</ebean.version>
     <h2.version>2.1.214</h2.version>
   </properties>
 


### PR DESCRIPTION
# Description

The major upgrade to jaxb causes issues with ebean migrations. Will wait for ebean 14 before upgrade.

