### PR TITLE
Allow for landing overlays on App page

### DIFF
--- a/admin-frontend/open_admin_app/lib/api/client_api.dart
+++ b/admin-frontend/open_admin_app/lib/api/client_api.dart
@@ -39,6 +39,7 @@ typedef InitializedCheckState = String;
 bool overrideOrigin = true;
 
 typedef TokenizedPersonHook = void Function(TokenizedPerson person);
+typedef LandingAction = void Function(ManagementRepositoryClientBloc bloc);
 
 List<TokenizedPersonHook> tokenizedPersonHooks = <TokenizedPersonHook>[];
 
@@ -122,6 +123,24 @@ class ManagementRepositoryClientBloc implements Bloc {
       _routerRedrawRouteSource.stream;
 
   RouteChange? get currentRoute => _routerSource.value;
+
+  /*
+   * Landing actions are actions relevant to landing on the main page after login.
+   * When a user gets to the AppsBloc it should check here
+   */
+  List<LandingAction> _landingActions = [];
+
+  void registerLandingAction(LandingAction la) {
+    _landingActions.add(la);
+  }
+
+  void processLandingActions() {
+    final la = _landingActions;
+
+    _landingActions = [];
+
+    la.forEach((action) { action(this); });
+  }
 
   void swapRoutes(RouteChange route) {
     // this is for gross route changes, and causes the widget to redraw

--- a/admin-frontend/open_admin_app/lib/widgets/apps/apps_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/apps_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bloc_provider/bloc_provider.dart';
+import 'package:flutter/widgets.dart';
 import 'package:mrapi/api.dart';
 import 'package:open_admin_app/api/client_api.dart';
 import 'package:rxdart/rxdart.dart';
@@ -17,6 +18,11 @@ class AppsBloc implements Bloc {
         .streamValley.currentPortfolioApplicationsStream
         .listen(_getCurrentPortfolioApplications);
     mrClient.streamValley.includeEnvironmentsInApplicationRequest = true;
+
+
+    // this tells the mrClient to run any callback code after the page has finished loading
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => this.mrClient.processLandingActions());
   }
 
   // make sure we load apps with the features


### PR DESCRIPTION
# Description

This change allows for landing widgets to turn
up when the Applications page shows.

