### PR TITLE
[bugfix/dashboard-refresh] Fix refresh of dashboard

### DIFF
--- a/admin-frontend/open_admin_app/lib/common/fh_shared_prefs.dart
+++ b/admin-frontend/open_admin_app/lib/common/fh_shared_prefs.dart
@@ -1,53 +1,105 @@
+import 'package:mrapi/api.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 abstract class FHSharedPrefsContract {
-  Future<void> saveString(String key, String value);
   Future<void> saveInt(String key, int value);
-  Future<String?> getString(String key);
   Future<int?> getInt(String key);
   Future<bool?> getBool(String key);
   Future<void> saveBool(String key, bool value);
-  Future<void> delete(String key);
-  Future<void> deleteAll();
 
-  static Future<FHSharedPrefsContract> getSharedInstance() async {
-    return await FHSharedPrefs.getSharedInstance();
-  }
+  Future<String?> getEmail();
+  Future<void> setEmail(String value);
+  Future<String?> currentPortfolioId();
+  Future<void> setCurrentPortfolioId(String? id);
+  Future<String?> currentApplicationId();
+  Future<void> setCurrentApplicationId(String? id);
+  Future<void> setPortfolioAndApplicationId(String? portfolioId, String? applicationId);
+  // store the portfolio and return the application id
+  Future<Application?> setPortfolio(Portfolio portfolio);
 }
 
-class FHSharedPrefs extends FHSharedPrefsContract {
-  final SharedPreferences _prefs;
+FHSharedPrefs prefs = FHSharedPrefs();
 
-  static Future<FHSharedPrefs> getSharedInstance(
-      {SharedPreferences? prefs}) async {
-    final sharedPrefs = prefs ?? await SharedPreferences.getInstance();
-    return Future.value(FHSharedPrefs._internal(sharedPrefs));
+_FHSharedPrefs? _prefs;
+
+class FHSharedPrefs extends FHSharedPrefsContract {
+  FHSharedPrefs() {
+    if (_prefs == null) {
+      _FHSharedPrefs.getSharedInstance().then((p) => _prefs = p);
+    }
   }
 
-  FHSharedPrefs._internal(this._prefs);
+  @override
+  Future<String?> currentApplicationId() async => await _prefs?.currentApplicationId();
+
+  @override
+  Future<String?> currentPortfolioId() async => await _prefs?.currentPortfolioId();
+
+  @override
+  Future<bool?> getBool(String key) async => await _prefs?.getBool(key);
+
+  @override
+  Future<String?> getEmail() async => await _prefs?.getEmail();
+
+  @override
+  Future<int?> getInt(String key) async => await _prefs?.getInt(key);
+
+  @override
+  Future<void> saveBool(String key, bool value) async => await _prefs?.saveBool(key, value);
+
+  @override
+  Future<void> saveInt(String key, int value) async => await _prefs?.saveInt(key, value);
+
+  @override
+  Future<void> setCurrentApplicationId(String? id) async => await _prefs?.setCurrentApplicationId(id);
+
+  @override
+  Future<void> setCurrentPortfolioId(String? id) async => await _prefs?.setCurrentPortfolioId(id);
+
+  @override
+  Future<void> setEmail(String value) async => await _prefs?.setEmail(value);
+
+  @override
+  Future<void> setPortfolioAndApplicationId(String? portfolioId, String? applicationId) async => await _prefs?.setPortfolioAndApplicationId(portfolioId, applicationId);
+
+  @override
+  Future<Application?> setPortfolio(Portfolio portfolio) async => await _prefs?.setPortfolio(portfolio);
+
+  void saveCurrentRoute(String json) => _prefs?.saveCurrentRoute(json);
+}
+
+const _KEY_EMAIL = 'lastUsername';
+const _KEY_APPLICATION_ID = 'currentAid';
+const _KEY_PORTFOLIO_ID = 'currentPid';
+const _KEY_CURRENT_ROUTE = 'current-route';
+
+class _FHSharedPrefs extends FHSharedPrefsContract {
+  final SharedPreferences _prefs;
+
+  static Future<_FHSharedPrefs> getSharedInstance(
+      {SharedPreferences? prefs}) async {
+    final sharedPrefs = prefs ?? await SharedPreferences.getInstance();
+    return Future.value(_FHSharedPrefs._internal(sharedPrefs));
+  }
+
+  _FHSharedPrefs._internal(this._prefs);
 
   Future<void> clear() async {
     await _prefs.clear();
   }
 
-  @override
-  Future<bool> saveString(String key, String value) async {
-    return await _prefs.setString(key, value);
+  Future<String?> getEmail() async {
+    return await _prefs.getString(_KEY_EMAIL);
   }
 
-  @override
-  Future<String?> getString(String key) async {
-    return _prefs.getString(key);
-  }
+  Future<void> setEmail(String value) async {
+    final previousPerson = await getEmail();
 
-  @override
-  Future<void> delete(String key) async {
-    await _prefs.remove(key);
-  }
+    if (value != previousPerson) {
+      await clear();
+    }
 
-  @override
-  Future<void> deleteAll() async {
-    await _prefs.clear();
+    await _prefs.setString(_KEY_EMAIL, value);
   }
 
   @override
@@ -68,5 +120,60 @@ class FHSharedPrefs extends FHSharedPrefsContract {
   @override
   Future<void> saveBool(String key, bool value) async {
     await _prefs.setBool(key, value);
+  }
+
+  @override
+  Future<String?> currentApplicationId() async =>
+    await _prefs.getString(_KEY_APPLICATION_ID);
+
+
+  @override
+  Future<String?> currentPortfolioId() async => await _prefs.getString(_KEY_PORTFOLIO_ID);
+
+  @override
+  Future<void> setCurrentApplicationId(String? id) async {
+    if (id == null) {
+      await _prefs.remove(_KEY_APPLICATION_ID);
+    } else {
+      await _prefs.setString(_KEY_APPLICATION_ID, id);
+    }
+  }
+
+  @override
+  Future<void> setCurrentPortfolioId(String? id) async {
+    if (id == null) {
+      await _prefs.remove(_KEY_PORTFOLIO_ID);
+    } else {
+      await _prefs.setString(_KEY_PORTFOLIO_ID, id);
+    }
+  }
+
+  @override
+  Future<void> setPortfolioAndApplicationId(String? portfolioId, String? applicationId) async {
+    await setCurrentPortfolioId(portfolioId);
+    await setCurrentApplicationId(applicationId);
+  }
+
+  @override
+  Future<Application?> setPortfolio(Portfolio portfolio) async {
+    await setCurrentPortfolioId(portfolio.id);
+
+    if (portfolio.applications.isEmpty) {
+      await setCurrentApplicationId(null);
+      return null;
+    }
+
+    final appId = await currentApplicationId();
+    final app = appId == null ? portfolio.applications[0] : portfolio.applications.firstWhere((a) => a.id == appId, orElse: () => portfolio.applications[0]);
+
+    if (app.id != appId) {
+      await setCurrentApplicationId(app.id);
+    }
+
+    return app;
+  }
+
+  saveCurrentRoute(String json) {
+    _prefs.setString(_KEY_CURRENT_ROUTE, json);
   }
 }

--- a/admin-frontend/open_admin_app/lib/common/person_state.dart
+++ b/admin-frontend/open_admin_app/lib/common/person_state.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
 import 'package:mrapi/api.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -9,6 +10,8 @@ List<SetPersonHook> setPersonHooks = <SetPersonHook>[];
 // avoids a null person, this is a person with no permission to anything
 Person _unauthenticatedPerson =
     Person(id: PersonId(id: ''), name: '', email: '');
+
+var _log = Logger("personState");
 
 class PersonState {
   final BehaviorSubject<Person> _personSource =
@@ -69,6 +72,7 @@ class PersonState {
   }
 
   bool userHasPortfolioPermission(String? pid) {
+    // _log.finer("portfolio permission: ${pid} -> person ${person.groups}");
     if (pid == null) return false;
 
     // if any of their groups have that portfolio, they have permission to at least see it

--- a/admin-frontend/open_admin_app/lib/widgets/user/signin/signin_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/user/signin/signin_widget.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:animator/animator.dart';
 import 'package:flutter/material.dart';
 import 'package:open_admin_app/api/client_api.dart';
+import 'package:open_admin_app/common/fh_shared_prefs.dart';
 import 'package:open_admin_app/widgets/common/decorations/fh_page_divider.dart';
 import 'package:open_admin_app/widgets/common/fh_card.dart';
 import 'package:open_admin_app/widgets/common/fh_flat_button_green.dart';
@@ -35,7 +36,7 @@ class _SigninState extends State<SigninWidget> {
 
     // when we are here we know that there are either (a) multiple sign-in providers or (b) at least a local option
 
-    widget.bloc.lastUsername().then((lu) {
+    prefs.getEmail().then((lu) {
       if (lu != null && _email.text.isEmpty) {
         setState(() {
           _email.text = lu;


### PR DESCRIPTION
# Description

The shared state for which currently selected portfolio and application were a bit messy and spread around. This had led to some confusion when the app refreshes about which portfolio and application it should be using. This tidies that code up, centralises it, sorts out how it is initialized and used and makes it work in a predictable way.

Fixes #954
