### PR TITLE
[internal/feature-perm-fixup] Feature perms not remembering past 1st

### DIFF
--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -286,6 +286,8 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
       _mrClient.dialogError(e, s);
     });
 
+    _groupWithRolesPS.add(ApplicationGroupRoles(updatedGroup, applicationId!));
+
     // we need to do this to ensure the list of environments has the right set of ACLs
     if (_mrClient.rocketOpened) {
       await _mrClient.streamValley.getCurrentApplicationEnvironments();


### PR DESCRIPTION
# Description

When you update a feature permission for a group, and then try  and update again, you get the wrong permissions. This corrects the issue.
    
Fixes #965