### PR TITLE
[internal/strategy-id] Front end cannot change strategy ids

### DIFF
--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/individual_strategy_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/individual_strategy_bloc.dart
@@ -42,7 +42,7 @@ class IndividualStrategyBloc extends Bloc {
 
   void createAttribute({StrategyAttributeWellKnownNames? type}) {
     final rs = RolloutStrategyAttribute(
-      id: _individualBlocUUidGenerator.v4(),
+      id: makeStrategyId(),
       fieldName: type?.name,
     );
 
@@ -66,7 +66,7 @@ class IndividualStrategyBloc extends Bloc {
   }
 
   void addAttribute(RolloutStrategyAttribute rs) {
-    rs.id ??= _individualBlocUUidGenerator.v4();
+    rs.id ??= makeStrategyId();
     rolloutStrategy.attributes.add(rs);
     _rolloutStrategyAttributeSource.add(rolloutStrategy.attributes);
   }

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/custom_strategy_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/custom_strategy_bloc.dart
@@ -27,7 +27,7 @@ class CustomStrategyBloc extends Bloc {
       rs.id ??= makeStrategyId(existing: featureValue.rolloutStrategies);
       if (rs.attributes.isNotEmpty == true) {
         for (var rsa in rs.attributes) {
-          rsa.id = makeStrategyId();
+          rsa.id ??= makeStrategyId();
         }
       }
     }
@@ -71,7 +71,7 @@ class CustomStrategyBloc extends Bloc {
 
   void addStrategyAttribute() {
     final rsa = RolloutStrategyAttribute();
-    rsa.id = makeStrategyId(existing: _strategySource.value);
+    rsa.id ??= makeStrategyId(existing: _strategySource.value);
     final attributes = _strategySource.value.last.attributes;
     attributes.add(rsa);
     _rolloutStrategyAttributeList.add(attributes);


### PR DESCRIPTION
# Description

Strategy ids must be 4 digits (not uuids) and they cannot be changed once set as the backend relies on them.

Fixes #970
