### PR TITLE
Fixed Helm Repo Link in Documentation

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -139,7 +139,7 @@ how you can use a different URL to serve traffic for feature consumers from your
 
 `docker compose up`
 
-There is also a helm chart available for production Kubernetes deployment for this option. Please follow documentation link:https://github.com/featurehub-io/featurehub-install/tree/master/helm[here]. It doesn't include a Postgres or NATs server as generally your cloud
+There is also a helm chart available for production Kubernetes deployment for this option. Please follow documentation link:https://github.com/featurehub-io/featurehub-helm[here]. It doesn't include a Postgres or NATs server as generally your cloud
 provider will have a managed Postgres service, and NATs have their own Kubernetes Helm charts for scalable, reliable deploys.
 
 === Option 2b - Non-Streaming Scalable Deployment


### PR DESCRIPTION
# Description

The setup instructions present on [this page](https://docs.featurehub.io/featurehub/latest/installation.html#_option_2a_streaming_scalable_deployment) for Kubernetes helm has a broken link. 

Current Link: https://github.com/featurehub-io/featurehub-install/tree/master/helm
Updated Link: https://github.com/featurehub-io/featurehub-helm

I've fixed the correct link in this PR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
