### PR TITLE
[feature/dacha1-ui-refresh] Allow refresh of Dacha1 cache from UI

### DIFF
--- a/admin-frontend/open_admin_app/lib/api/identity_providers.dart
+++ b/admin-frontend/open_admin_app/lib/api/identity_providers.dart
@@ -43,4 +43,5 @@ class ServerCapabilities {
 
   ///the server supports webhooks if it returns this
   bool get capabilityWebhooks => _capabilities['webhook.features'] == 'true';
+  bool get dacha1Enabled => _capabilities['dacha1Enabled'] == 'true';
 }

--- a/admin-frontend/open_admin_app/lib/routes/manage_portfolios_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/manage_portfolios_route.dart
@@ -2,6 +2,8 @@ import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:open_admin_app/common/ga_id.dart';
 import 'package:open_admin_app/widgets/common/decorations/fh_page_divider.dart';
+import 'package:open_admin_app/widgets/common/fh_alert_dialog.dart';
+import 'package:open_admin_app/widgets/common/fh_flat_button.dart';
 import 'package:open_admin_app/widgets/common/fh_header.dart';
 import 'package:open_admin_app/widgets/portfolio/portfolio_bloc.dart';
 import 'package:open_admin_app/widgets/portfolio/portfolio_widget.dart';
@@ -40,17 +42,57 @@ class PortfolioRoute extends StatelessWidget {
         const SizedBox(height: 8.0),
         const FHPageDivider(),
         const SizedBox(height: 8.0),
-        Container(
-          constraints: const BoxConstraints(maxWidth: 300),
-          child: TextField(
-            decoration: const InputDecoration(hintText: 'Search portfolios',
-                icon: Icon(Icons.search)),
-            onChanged: (val) => bloc.triggerSearch(val),
-          ),
+        Row(
+
+          children: [
+            Container(
+              constraints: const BoxConstraints(maxWidth: 300),
+              child: TextField(
+                decoration: const InputDecoration(hintText: 'Search portfolios',
+                    icon: Icon(Icons.search)),
+                onChanged: (val) => bloc.triggerSearch(val),
+              ),
+            ),
+            if (bloc.mrClient.identityProviders.dacha1Enabled && bloc.mrClient.personState.userIsSuperAdmin)
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Align(alignment: Alignment.topRight,
+                      child: OutlinedButton.icon(onPressed: () => _refreshWholeCacheConfirm(bloc), icon: const Icon(Icons.cached), label: const Text('Republish system cache'))),
+                ),
+              )
+          ],
         ),
         const SizedBox(height: 16.0),
         const PortfolioListWidget(),
       ],
     );
+  }
+
+  _refreshWholeCacheConfirm(PortfolioBloc bloc) {
+    bloc.mrClient.addOverlay((BuildContext context) {
+      return FHAlertDialog(
+        title: const Text(
+          "Warning: Intensive system operation" ,
+          style: TextStyle(fontSize: 22.0),
+        ),
+        content: const Text("Are you sure you want to republish the entire cache?"),
+        actions: <Widget>[
+          FHFlatButton(
+            title: 'OK',
+            onPressed: () {
+              bloc.refreshSystemCache();
+              bloc.mrClient.removeOverlay();
+            },
+          ),
+          FHFlatButton(
+            title: 'Cancel',
+            onPressed: () {
+              bloc.mrClient.removeOverlay();
+            },
+          )
+        ],
+      );
+    });
   }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/apps/apps_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/apps_bloc.dart
@@ -84,4 +84,15 @@ class AppsBloc implements Bloc {
     _currentApplicationsListListener.cancel();
     _currentApplicationsStream.close();
   }
+
+  void refreshPortfolioCache() {
+    final id = mrClient.streamValley.currentPortfolio.portfolio.id;
+    if (id != null) {
+      CacheServiceApi(mrClient.apiClient).cacheRefresh(CacheRefreshRequest(portfolioId: [id]));
+    }
+  }
+
+  void refreshApplicationCache(String appId) {
+    CacheServiceApi(mrClient.apiClient).cacheRefresh(CacheRefreshRequest(applicationId: [appId]));
+  }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/portfolio/portfolio_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/portfolio/portfolio_bloc.dart
@@ -104,4 +104,8 @@ class PortfolioBloc implements Bloc {
   Future refreshPortfolios() async {
     await mrClient.refreshPortfolios();
   }
+
+  void refreshSystemCache() {
+    CacheServiceApi(mrClient.apiClient).cacheRefresh(CacheRefreshRequest(allTheThings: true));
+  }
 }

--- a/backend/composite-ebean/pom.xml
+++ b/backend/composite-ebean/pom.xml
@@ -57,6 +57,37 @@
       <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
       <version>${ebean.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.ebean</groupId>
+          <artifactId>ebean-platform-all</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-h2</artifactId>
+      <version>13.17.0-jakarta</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-mysql</artifactId>
+      <version>13.17.0-jakarta</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-mariadb</artifactId>
+      <version>13.17.0-jakarta</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-oracle</artifactId>
+      <version>13.17.0-jakarta</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-postgres</artifactId>
+      <version>13.17.0-jakarta</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -1,14 +1,51 @@
 openapi: 3.0.1
 info:
   title: ManagementResourceApi
-  description: This describes the API clients use for accessing features. This reflects the API from 1.5.7 onwards.
+  description: This describes the API clients use for accessing features. This reflects the API from 1.6.1 onwards.
   version: "1.1.11"
 #  CRUD for portfolios, environments, features, service account, people, and groups (edited)
 #  roles are fixed
 #  then people<->group association
 #  and group<->role association
 paths:
+  /mr-api/dacha1/cache:
+    post:
+      security:
+        - bearerAuth: [ ]
+      tags:
+        - CacheService
+      description: "Allows superusers to refresh the global Dacha1 cache (if it exists)."
+      operationId: cacheRefresh
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CacheRefreshRequest"
+      responses:
+        200:
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CacheRefreshResponse"
+        400:
+          description: "Bad Request"
+        401:
+          description: "no permission"
+        403:
+          description: "forbidden"
+        404:
+          description: "Dacha1 is not being used and API does not exist"
   /mr-api/organization/{id}/group:
+    parameters:
+      - name: id
+        required: true
+        in: path
+        description: "the id of the organisation"
+        schema:
+          type: string
+          format: uuid
     get:
       security:
         - bearerAuth: [ ]
@@ -16,14 +53,6 @@ paths:
         - GroupService
       description: "Gets the superuser group for this organisation. There is no other way to ascertain which org you are dealing with"
       operationId: getSuperuserGroup
-      parameters:
-        - name: id
-          required: true
-          in: path
-          description: "the id of the organisation"
-          schema:
-            type: string
-            format: uuid
       responses:
         200:
           description: "The superuser group presuming the organization exists"
@@ -3333,7 +3362,34 @@ components:
         sdkUrlServerEval:
           description: "Optional if they have chosen includeSdkUrl"
           type: string
-
+    CacheRefreshRequest:
+      type: object
+      properties:
+        allTheThings:
+          description: "refresh the whole cache"
+          type: boolean
+        applicationId:
+          description: "if provided these applications will be refreshed"
+          type: array
+          items:
+            type: string
+            format: UUID
+        portfolioId:
+          type: array
+          items:
+            type: string
+            format: UUID
+    CacheRefreshResponse:
+      type: object
+      properties:
+        applicationsRefreshed:
+          type: integer
+        portfoliosRefreshed:
+          type: integer
+        environmentsRefreshed:
+          type: integer
+        serviceAccountsRefreshed:
+          type: integer
     Group:
       allOf:
         - $ref: "#/components/schemas/Audit"

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/CacheRefresherApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/CacheRefresherApi.kt
@@ -1,0 +1,9 @@
+package io.featurehub.db.api
+
+import java.util.*
+
+interface CacheRefresherApi {
+  fun refreshPortfolios(portfolioIds: List<UUID>)
+  fun refreshApplications(applicationIds: List<UUID>)
+  fun refreshEntireDatabase()
+}

--- a/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CacheBroadcast.kt
+++ b/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CacheBroadcast.kt
@@ -5,7 +5,7 @@ import io.featurehub.dacha.model.PublishFeatureValues
 import io.featurehub.dacha.model.PublishServiceAccount
 
 interface CacheBroadcast {
-    fun publishEnvironment(cacheName: String, eci: PublishEnvironment)
-    fun publishServiceAccount(cacheName: String, saci: PublishServiceAccount)
-    fun publishFeatures(cacheName: String, features: PublishFeatureValues)
+    fun publishEnvironment(eci: PublishEnvironment)
+    fun publishServiceAccount(saci: PublishServiceAccount)
+    fun publishFeatures(features: PublishFeatureValues)
 }

--- a/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CacheSource.kt
+++ b/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CacheSource.kt
@@ -9,7 +9,7 @@ interface CacheSource {
   /**
    * publish all environments, service accounts and features associated with this cache
    */
-  fun publishObjectsAssociatedWithCache(cacheName: String)
+  fun publishObjectsAssociatedWithCache()
 
   fun deleteFeatureChange(feature: DbApplicationFeature, environmentId: UUID)
 

--- a/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CloudEventCacheBroadcaster.kt
+++ b/backend/mr-eventing-common/src/main/kotlin/io/featurehub/mr/events/common/CloudEventCacheBroadcaster.kt
@@ -17,7 +17,6 @@ class CloudEventCacheBroadcaster @Inject constructor(
   private val log: Logger = LoggerFactory.getLogger(CloudEventCacheBroadcaster::class.java)
 
   fun publish(
-    cacheName: String,
     subject: String,
     data: Any,
     id: String?,
@@ -29,7 +28,6 @@ class CloudEventCacheBroadcaster @Inject constructor(
       event.withId(id ?: "000")
       event.withType(type)
       event.withSource(URI("http://management-service"))
-      event.withContextAttribute("cachename", cacheName)
       event.withTime(OffsetDateTime.now())
 
       cloudEventsPublisher.publish(type, data, event)
@@ -38,19 +36,18 @@ class CloudEventCacheBroadcaster @Inject constructor(
     }
   }
 
-  override fun publishEnvironment(cacheName: String, eci: PublishEnvironment) {
+  override fun publishEnvironment(eci: PublishEnvironment) {
     if (cloudEventsPublisher.hasListeners(PublishEnvironment.CLOUD_EVENT_TYPE)) {
       log.trace("cloudevent: publish environment {}", eci)
-      publish(cacheName, PublishEnvironment.CLOUD_EVENT_SUBJECT, eci, eci.environment.id.toString(),
+      publish(PublishEnvironment.CLOUD_EVENT_SUBJECT, eci, eci.environment.id.toString(),
         PublishEnvironment.CLOUD_EVENT_TYPE)
     }
   }
 
-  override fun publishServiceAccount(cacheName: String, saci: PublishServiceAccount) {
+  override fun publishServiceAccount(saci: PublishServiceAccount) {
     if (cloudEventsPublisher.hasListeners(PublishServiceAccount.CLOUD_EVENT_TYPE)) {
       log.trace("cloudevent: publish service account {}", saci)
       publish(
-        cacheName,
         PublishServiceAccount.CLOUD_EVENT_SUBJECT,
         saci,
         saci.serviceAccount?.id.toString(),
@@ -59,7 +56,7 @@ class CloudEventCacheBroadcaster @Inject constructor(
     }
   }
 
-  override fun publishFeatures(cacheName: String, features: PublishFeatureValues) {
+  override fun publishFeatures(features: PublishFeatureValues) {
     if (features.features.isNotEmpty() && cloudEventsPublisher.hasListeners(PublishFeatureValues.CLOUD_EVENT_TYPE)) {
       // all updates are the same type for the same environment, not that it really matters
       val firstFeature = features.features[0]
@@ -67,7 +64,7 @@ class CloudEventCacheBroadcaster @Inject constructor(
       log.trace("cloudevent: publish features {}", features)
 
       publish(
-        cacheName, PublishFeatureValues.CLOUD_EVENT_SUBJECT, features,
+        PublishFeatureValues.CLOUD_EVENT_SUBJECT, features,
         "${firstFeature.environmentId}/${firstFeature.feature.feature.key}", PublishFeatureValues.CLOUD_EVENT_TYPE
       )
     }

--- a/backend/mr-eventing-nats/src/main/kotlin/io/featurehub/db/publish/nats/NatsDachaBroadcaster.kt
+++ b/backend/mr-eventing-nats/src/main/kotlin/io/featurehub/db/publish/nats/NatsDachaBroadcaster.kt
@@ -7,6 +7,7 @@ import io.featurehub.jersey.config.CacheJsonMapper
 import io.featurehub.mr.events.common.CacheBroadcast
 import io.featurehub.mr.events.common.CacheMetric
 import io.featurehub.mr.events.common.CacheMetrics
+import io.featurehub.publish.ChannelConstants
 import io.featurehub.publish.ChannelNames
 import io.featurehub.publish.NATSSource
 import jakarta.inject.Inject
@@ -17,22 +18,23 @@ class NatsDachaBroadcaster @Inject constructor(private val  nats: NATSSource) : 
   private val envChannelNameCache = mutableMapOf<String, String>()
   private val serviceAccountChannelNameCache = mutableMapOf<String, String>()
   private val featureChannelNameCache = mutableMapOf<String, String>()
+  private val cacheName = ChannelConstants.DEFAULT_CACHE_NAME
 
-  override fun publishEnvironment(cacheName: String, eci: PublishEnvironment) {
+  override fun publishEnvironment(eci: PublishEnvironment) {
     publish(
       envChannelNameCache.getOrPut(cacheName) { ChannelNames.environmentChannel(cacheName) },
       eci, "environment", CacheMetrics.environments)
 
   }
 
-  override fun publishServiceAccount(cacheName: String, saci: PublishServiceAccount) {
+  override fun publishServiceAccount(saci: PublishServiceAccount) {
     publish(
       serviceAccountChannelNameCache.getOrPut(cacheName) { ChannelNames.serviceAccountChannel(cacheName) },
       saci, "service account", CacheMetrics.services
     )
   }
 
-  override fun publishFeatures(cacheName: String, features: PublishFeatureValues) {
+  override fun publishFeatures(features: PublishFeatureValues) {
     val subject = featureChannelNameCache.getOrPut(cacheName) { ChannelNames.featureValueChannel(cacheName) }
 
     // splits out the old way

--- a/backend/mr-eventing-nats/src/main/kotlin/io/featurehub/db/publish/nats/NatsDachaCacheFiller.kt
+++ b/backend/mr-eventing-nats/src/main/kotlin/io/featurehub/db/publish/nats/NatsDachaCacheFiller.kt
@@ -78,7 +78,7 @@ class NatsDachaCacheFiller @Inject constructor(val cacheName: String, val nats: 
       if (cmm.requestType == CacheRequestType.SEEKING_COMPLETE_CACHE) {
         sayHelloToNewNamedCache()
       } else if (id == cmm.destId && cmm.requestType == CacheRequestType.SEEKING_REFRESH) {
-        cacheSource.publishObjectsAssociatedWithCache(cacheName)
+        cacheSource.publishObjectsAssociatedWithCache()
       }
     } catch (e: Exception) {
       log.error("Malformed cache management message", e)

--- a/backend/mr-eventing/src/main/kotlin/io/featurehub/db/publish/DummyPublisher.kt
+++ b/backend/mr-eventing/src/main/kotlin/io/featurehub/db/publish/DummyPublisher.kt
@@ -1,6 +1,7 @@
 package io.featurehub.db.publish
 
 import io.featurehub.dacha.model.PublishAction
+import io.featurehub.db.api.CacheRefresherApi
 import io.featurehub.db.model.*
 import io.featurehub.mr.events.common.CacheBroadcast
 import io.featurehub.mr.events.common.CacheSource
@@ -9,8 +10,8 @@ import java.util.*
 /**
  *
  */
-class DummyPublisher : CacheSource {
-  override fun publishObjectsAssociatedWithCache(cacheName: String) {}
+class DummyPublisher : CacheSource, CacheRefresherApi {
+  override fun publishObjectsAssociatedWithCache() {}
   override fun publishFeatureChange(featureValue: DbFeatureValue) {}
   override fun deleteFeatureChange(feature: DbApplicationFeature, environmentId: UUID) {}
   override fun updateServiceAccount(serviceAccount: DbServiceAccount, publishAction: PublishAction) {}
@@ -20,4 +21,12 @@ class DummyPublisher : CacheSource {
   override fun publishFeatureChange(appFeature: DbApplicationFeature, update: PublishAction) {}
   override fun publishFeatureChange(appFeature: DbApplicationFeature, update: PublishAction, featureKey: String) {}
   override fun publishRolloutStrategyChange(rs: DbRolloutStrategy) {}
+  override fun refreshPortfolios(portfolioIds: List<UUID>) {
+  }
+
+  override fun refreshApplications(applicationIds: List<UUID>) {
+  }
+
+  override fun refreshEntireDatabase() {
+  }
 }

--- a/backend/mr-eventing/src/main/kotlin/io/featurehub/mr/events/EventingFeature.kt
+++ b/backend/mr-eventing/src/main/kotlin/io/featurehub/mr/events/EventingFeature.kt
@@ -1,5 +1,6 @@
 package io.featurehub.mr.events
 
+import io.featurehub.db.api.CacheRefresherApi
 import io.featurehub.mr.events.service.FeatureMessagingCloudEventPublisherImpl
 import io.featurehub.db.publish.DbCacheSource
 import io.featurehub.db.publish.DummyPublisher
@@ -44,7 +45,7 @@ class EventingFeature : Feature {
           bind(CloudEventCacheBroadcaster::class.java).to(CacheBroadcast::class.java).`in`(Singleton::class.java)
 
           bind(FeatureUpdateListenerImpl::class.java).to(FeatureUpdateListener::class.java).`in`(Immediate::class.java)
-          bind(DbCacheSource::class.java).to(CacheSource::class.java).to(CacheApi::class.java)
+          bind(DbCacheSource::class.java).to(CacheSource::class.java).to(CacheApi::class.java).to(CacheRefresherApi::class.java)
             .`in`(
               Singleton::class.java
             )

--- a/backend/mr/src/main/java/io/featurehub/mr/resources/SetupResource.java
+++ b/backend/mr/src/main/java/io/featurehub/mr/resources/SetupResource.java
@@ -21,6 +21,7 @@ import io.featurehub.mr.model.SetupMissingResponse;
 import io.featurehub.mr.model.SetupResponse;
 import io.featurehub.mr.model.SetupSiteAdmin;
 import io.featurehub.mr.model.TokenizedPerson;
+import io.featurehub.mr.utils.ConfigurationUtils;
 import io.featurehub.mr.utils.PortfolioUtils;
 import io.featurehub.web.security.oauth.AuthProviderCollection;
 import io.featurehub.web.security.oauth.AuthProviderSource;
@@ -94,14 +95,13 @@ public class SetupResource implements SetupServiceDelegate {
         sr.redirectUrl(provider.getRedirectUrl());
       }
 
-      boolean enricherEnabled = "true".equalsIgnoreCase(FallbackPropertyConfig.Companion.getConfig("enricher.enabled"
-        , "true"));
-      boolean webhooksEnabled = "true".equalsIgnoreCase(FallbackPropertyConfig.Companion.getConfig("webhooks.features.enabled"
-        , "true"));
+      boolean enricherEnabled = ConfigurationUtils.Companion.getEnricherEnabled();
+      boolean webhooksEnabled = ConfigurationUtils.Companion.getWebhooksEnabled();
+      boolean dacha1Enabled = ConfigurationUtils.Companion.getDacha1Enabled();
 
       sr.capabilityInfo(
         Map.of("webhook.features", (enricherEnabled && webhooksEnabled) ? "true" : "false" ,
-          "trackingId", googleTrackingId)
+          "trackingId", googleTrackingId, "dacha1Enabled", dacha1Enabled ? "true" : "false")
       );
 
       return sr;

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/ManagementRepositoryFeature.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/ManagementRepositoryFeature.kt
@@ -10,6 +10,7 @@ import io.featurehub.mr.events.EventingFeature
 import io.featurehub.mr.resources.*
 import io.featurehub.mr.resources.oauth2.OAuth2MRAdapter
 import io.featurehub.mr.utils.ApplicationUtils
+import io.featurehub.mr.utils.ConfigurationUtils
 import io.featurehub.mr.utils.PortfolioUtils
 import io.featurehub.mr.webhook.ManagementRepositoryWebhookFeature
 import io.featurehub.rest.CacheControlFilter
@@ -49,6 +50,10 @@ class ManagementRepositoryFeature : Feature {
       AuthProvidersFeature::class.java
     ).forEach { componentClass: Class<out Any?>? -> context.register(componentClass) }
 
+    if (ConfigurationUtils.dacha1Enabled) {
+      context.register(CacheServiceDelegator::class.java)
+    }
+
     // only mount the dacha2 endpoints on the public API if the keys exist to protect it.
     if (Dacha2Feature.dacha2ApiKeysExist()) {
       context.register(Dacha2Feature::class.java)
@@ -77,6 +82,9 @@ class ManagementRepositoryFeature : Feature {
         bind(ApplicationResource::class.java).to(ApplicationServiceDelegate::class.java).`in`(
           Singleton::class.java
         )
+        if (ConfigurationUtils.dacha1Enabled) {
+          bind(CacheResource::class.java).to(CacheServiceDelegate::class.java).`in`(Singleton::class.java)
+        }
         bind(AuthResource::class.java).to(AuthServiceDelegate::class.java).`in`(Singleton::class.java)
         bind(WebhookResource::class.java).to(WebhookServiceDelegate::class.java).`in`(Singleton::class.java)
         bind(EnvironmentFeatureResource::class.java).to(

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/CacheResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/CacheResource.kt
@@ -1,0 +1,36 @@
+package io.featurehub.mr.resources
+
+import io.featurehub.db.api.CacheRefresherApi
+import io.featurehub.mr.api.CacheServiceDelegate
+import io.featurehub.mr.auth.AuthManagerService
+import io.featurehub.mr.model.CacheRefreshRequest
+import io.featurehub.mr.model.CacheRefreshResponse
+import jakarta.inject.Inject
+import jakarta.ws.rs.ForbiddenException
+import jakarta.ws.rs.core.SecurityContext
+import java.util.*
+
+class CacheResource @Inject constructor(private val authManager: AuthManagerService, private val cacheRefresherApi: CacheRefresherApi) : CacheServiceDelegate {
+  override fun cacheRefresh(
+    cacheRefreshRequest: CacheRefreshRequest,
+    securityContext: SecurityContext
+  ): CacheRefreshResponse {
+    if (!authManager.isOrgAdmin(authManager.from(securityContext))) {
+      throw ForbiddenException()
+    }
+
+    cacheRefreshRequest.portfolioId?.let {
+      cacheRefresherApi.refreshPortfolios(it)
+    }
+
+    cacheRefreshRequest.applicationId?.let {
+      cacheRefresherApi.refreshApplications(it)
+    }
+
+    cacheRefreshRequest.allTheThings?.let {
+      cacheRefresherApi.refreshEntireDatabase()
+    }
+
+    return CacheRefreshResponse()
+  }
+}

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/utils/ConfigurationUtils.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/utils/ConfigurationUtils.kt
@@ -1,0 +1,26 @@
+package io.featurehub.mr.utils
+
+import io.featurehub.utils.FallbackPropertyConfig
+import io.featurehub.utils.FallbackPropertyConfig.Companion.getConfig
+
+class ConfigurationUtils {
+  companion object {
+    val enricherEnabled = "true".equals(
+      FallbackPropertyConfig.Companion.getConfig(
+        "enricher.enabled", "true"
+      ), ignoreCase = true
+    )
+
+    val dacha1Enabled = !"false".equals(
+      getConfig(
+        "dacha1.enabled", "true"
+      ), ignoreCase = true
+    )
+
+    val webhooksEnabled = "true".equals(
+      getConfig(
+        "webhooks.features.enabled", "true"
+      ), ignoreCase = true
+    )
+  }
+}

--- a/backend/mr/src/main/resources/deploy-defaults/common.properties
+++ b/backend/mr/src/main/resources/deploy-defaults/common.properties
@@ -1,4 +1,3 @@
-cache.name=default
 run.nginx=true
 maxSlots=60
 server.gracePeriodInSeconds=1

--- a/backend/party-server-ish/src/main/kotlin/io.featurehub.party/Application.kt
+++ b/backend/party-server-ish/src/main/kotlin/io.featurehub.party/Application.kt
@@ -28,13 +28,6 @@ import org.slf4j.LoggerFactory
 class Application {
   private val log = LoggerFactory.getLogger(io.featurehub.Application::class.java)
 
-  @ConfigKey("cache.name")
-  var name = ChannelConstants.DEFAULT_CACHE_NAME
-
-  init {
-    DeclaredConfigResolver.resolve(this)
-  }
-
   @Throws(Exception::class)
   private fun run() {
     log.info("starting party-server-ish, wish me luck!")
@@ -47,7 +40,7 @@ class Application {
       TelemetryFeature::class.java,
       CacheControlFilter::class.java
     )
-    
+
     // check if we should list on a different port
     registerMetrics(config)
 

--- a/backend/party-server/src/main/kotlin/io.featurehub.party/Application.kt
+++ b/backend/party-server/src/main/kotlin/io.featurehub.party/Application.kt
@@ -29,13 +29,6 @@ import org.slf4j.LoggerFactory
 class Application {
   private val log = LoggerFactory.getLogger(io.featurehub.Application::class.java)
 
-  @ConfigKey("cache.name")
-  var name = ChannelConstants.DEFAULT_CACHE_NAME
-
-  init {
-    DeclaredConfigResolver.resolve(this)
-  }
-
   @Throws(Exception::class)
   private fun run() {
     // register our resources, try and tag them as singleton as they are instantiated faster
@@ -63,7 +56,7 @@ class Application {
         FeatureHubJerseyHost.withServiceLocator(container) { injector ->
           // make sure Edge talks directly to Dacha for the current cache
           val dachaServiceRegistry = injector.getService(DachaClientServiceRegistry::class.java)
-          dachaServiceRegistry.registerApiKeyService(name, injector.getService(DachaApiKeyService::class.java) )
+          dachaServiceRegistry.registerApiKeyService(ChannelConstants.DEFAULT_CACHE_NAME, injector.getService(DachaApiKeyService::class.java) )
         }
       }
 

--- a/infra/api-bucket/files/mrapi/1.1.11.yaml
+++ b/infra/api-bucket/files/mrapi/1.1.11.yaml
@@ -8,6 +8,35 @@ info:
 servers:
 - url: /
 paths:
+  /mr-api/dacha1/cache:
+    post:
+      tags:
+      - CacheService
+      description: Allows superusers to refresh the global Dacha1 cache (if it exists).
+      operationId: cacheRefresh
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CacheRefreshRequest'
+        required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheRefreshResponse'
+        "400":
+          description: Bad Request
+        "401":
+          description: no permission
+        "403":
+          description: forbidden
+        "404":
+          description: Dacha1 is not being used and API does not exist
+      security:
+      - bearerAuth: []
   /mr-api/organization/{id}/group:
     get:
       tags:
@@ -15,16 +44,6 @@ paths:
       description: Gets the superuser group for this organisation. There is no other
         way to ascertain which org you are dealing with
       operationId: getSuperuserGroup
-      parameters:
-      - name: id
-        in: path
-        description: the id of the organisation
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-          format: uuid
       responses:
         "200":
           description: The superuser group presuming the organization exists
@@ -40,6 +59,16 @@ paths:
           description: not found
       security:
       - bearerAuth: []
+    parameters:
+    - name: id
+      in: path
+      description: the id of the organisation
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string
+        format: uuid
   /mr-api/portfolio:
     get:
       tags:
@@ -3830,6 +3859,34 @@ components:
         sdkUrlServerEval:
           type: string
           description: Optional if they have chosen includeSdkUrl
+    CacheRefreshRequest:
+      type: object
+      properties:
+        allTheThings:
+          type: boolean
+          description: refresh the whole cache
+        applicationId:
+          type: array
+          description: if provided these applications will be refreshed
+          items:
+            type: string
+            format: UUID
+        portfolioId:
+          type: array
+          items:
+            type: string
+            format: UUID
+    CacheRefreshResponse:
+      type: object
+      properties:
+        applicationsRefreshed:
+          type: integer
+        portfoliosRefreshed:
+          type: integer
+        environmentsRefreshed:
+          type: integer
+        serviceAccountsRefreshed:
+          type: integer
     Group:
       allOf:
       - $ref: '#/components/schemas/Audit'


### PR DESCRIPTION
# Description

In the case where for some reason there might be the suspicion of cache poisoning, this change allows republishing the cache of the entire system, individual portfolios or individual applications from the UI.
