### PR TITLE
[bugfix/dacha2-reset-api-key] Cache not expiring changing api keys

### DIFF
--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
@@ -247,6 +247,14 @@ class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Service
           stashServiceAccount(sa, sId)
         }
       } else if (sa.version >= existing.version) {
+        if (existing.apiKeyServerSide != sa.apiKeyServerSide) {
+          serviceAccountMissCache.put(existing.apiKeyServerSide, true)
+          serviceAccountApiKeyCache.invalidate(existing.apiKeyServerSide)
+        }
+        if (existing.apiKeyClientSide != sa.apiKeyClientSide) {
+          serviceAccountMissCache.put(existing.apiKeyClientSide, true)
+          serviceAccountApiKeyCache.invalidate(existing.apiKeyClientSide)
+        }
         serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
         stashServiceAccount(sa, sId)
 

--- a/backend/mr-messaging-processor/src/main/kotlin/io/featurehub/messaging/MessagingFeature.kt
+++ b/backend/mr-messaging-processor/src/main/kotlin/io/featurehub/messaging/MessagingFeature.kt
@@ -1,12 +1,9 @@
 package io.featurehub.messaging
 
-import io.featurehub.events.kinesis.KinesisEventFeature
-import io.featurehub.events.pubsub.GoogleEventFeature
 import io.featurehub.messaging.converter.FeatureMessagingConverter
 import io.featurehub.messaging.converter.FeatureMessagingConverterImpl
 import io.featurehub.messaging.service.FeatureMessagingCloudEventPublisher
 import io.featurehub.messaging.service.FeatureMessagingCloudEventPublisherImpl
-import io.featurehub.publish.NATSFeature
 import jakarta.inject.Singleton
 import jakarta.ws.rs.core.Feature
 import jakarta.ws.rs.core.FeatureContext
@@ -19,7 +16,7 @@ class MessagingFeature: Feature {
       override fun configure() {
         bind(FeatureMessagingCloudEventPublisherImpl::class.java).to(FeatureMessagingCloudEventPublisher::class.java).`in`(Singleton::class.java)
         bind(FeatureMessagingConverterImpl::class.java).to(FeatureMessagingConverter::class.java).`in`(Singleton::class.java)
-        
+
       }
 
     })


### PR DESCRIPTION
# Description

API keys in Dacha2 (and hence Party Server) are not  being removed if they changed.

Fixes #998

