### PR TITLE
[internal/feature-history] Allow portfolio group admin full access to feature history

### DIFF
--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/EnvironmentSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/EnvironmentSqlApi.kt
@@ -163,7 +163,7 @@ class EnvironmentSqlApi @Inject constructor(
   }
 
   override fun getEnvironmentsUserCanAccess(appId: UUID, person: UUID): List<UUID>? {
-    if (convertUtils.personIsSuperAdmin(person)) return listOf()
+    if (convertUtils.personIsSuperAdmin(person) || convertUtils.isPersonApplicationAdmin(person, appId)) return listOf()
 
     val envs = QDbEnvironment()
       .select(QDbEnvironment.Alias.id)

--- a/backend/webhook-feature-update/sinatra-example/webhook_app.rb
+++ b/backend/webhook-feature-update/sinatra-example/webhook_app.rb
@@ -3,6 +3,8 @@
 require 'sinatra'
 require 'json'
 
+set :bind, '0.0.0.0'
+
 post "/" do
   raw_data = request.body.read
   puts "raw data is #{raw_data}"


### PR DESCRIPTION
# Description

Portfolio Admins were left off the permission group to automatically gain access to all environments under an application. This fixes this issue.

