### PR TITLE
[bugfix/missing-webhooks] Concurrent hashmap webhook issue

### DIFF
--- a/adks/e2e-sdk/Dockerfile
+++ b/adks/e2e-sdk/Dockerfile
@@ -1,7 +1,21 @@
 FROM node:18-buster-slim as build
 
+ARG branch=main
+# install the latest javascript SDK
+WORKDIR /jssdk
+RUN apt-get update && apt-get install -y git
+
+RUN git clone https://github.com/featurehub-io/featurehub-javascript-sdk.git
+# try and checkout this external named branch or leave on main if not
+RUN git checkout $branch || true
+RUN cd featurehub-javascript-sdk/featurehub-javascript-client-sdk && \
+    npm install && npm run compile && \
+    cd ../featurehub-javascript-node-sdk && \
+    npm install && npm run link && npm run compile
+
 WORKDIR /app
+
 ADD app /app/app/
 ADD features /app/features/
-COPY package.json package-lock.json tsconfig.json run.sh /app/
-RUN npm install && npm run build
+COPY package.json package-lock.json tsconfig.json run.sh run-e2e.sh /app/
+RUN npm install && npm run link && npm run build

--- a/adks/e2e-sdk/app/steps/setup.ts
+++ b/adks/e2e-sdk/app/steps/setup.ts
@@ -50,6 +50,8 @@ Given(/^I update the environment for feature webhooks$/, async function() {
     world.environment = app.data.environments[0];
   }
 
+  // console.log("ensure previous environment has propagated");
+  // await sleep(3);
   const env = world.environment;
 
   const webhookAddress = getWebserverExternalAddress();
@@ -63,6 +65,9 @@ Given(/^I update the environment for feature webhooks$/, async function() {
   }));
 
   world.environment = (await world.applicationApi.getApplication(world.application.id, true)).data.environments[0];
+
+  console.log('sleeping to ensure it is propagated');
+  await sleep(3000);
 });
 
 Given(/^I create a new environment$/, async function () {

--- a/adks/e2e-sdk/package.json
+++ b/adks/e2e-sdk/package.json
@@ -6,7 +6,9 @@
     "clean": "rm -rf target/dist",
     "build": "npm run clean && node ./node_modules/typescript/bin/tsc",
     "debug-test": "PUBSUB_EMULATOR_HOST=localhost:8075 npm run clean && node --inspect node_modules/.bin/cucumber-js --require-module ts-node/register --require 'app/**/*.ts' ",
+    "link": "npm link featurehub-javascript-client-sdk featurehub-javascript-node-sdk",
     "test": "npm run clean && node node_modules/.bin/cucumber-js --require-module ts-node/register --require 'app/**/*.ts' ",
+    "e2e-test": "npm run clean && npm run link && node node_modules/.bin/cucumber-js --require-module ts-node/register --require 'app/**/*.ts' ",
     "lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
   "author": "FeatureHub.io",

--- a/adks/e2e-sdk/run-e2e.sh
+++ b/adks/e2e-sdk/run-e2e.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+mkdir -p logs
+rm -rf logs/*
+if [ $# -eq 0 ]
+  then
+  echo DEBUG=true npm run e2e-test
+  DEBUG=true npm run e2e-test
+else
+  echo DEBUG=true npm run e2e-test -- --tags $1
+  DEBUG=true npm run e2e-test -- --tags $1
+fi
+

--- a/backend/common-web/src/main/kotlin/io/featurehub/health/CommonFeatureHubFeatures.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/health/CommonFeatureHubFeatures.kt
@@ -4,6 +4,7 @@ import cd.connect.jersey.common.LoggingConfiguration
 import cd.connect.jersey.prometheus.PrometheusDynamicFeature
 import cd.connect.openapi.support.ReturnStatusContainerResponseFilter
 import io.featurehub.info.ApplicationVersionFeatures
+import io.featurehub.jersey.ManagedAsyncThreadPoolExecutorProvider
 import io.featurehub.jersey.config.CommonConfiguration
 import io.featurehub.jersey.config.EndpointLoggingListener
 import io.featurehub.utils.*
@@ -45,6 +46,8 @@ class CommonFeatureHubFeatures @Inject constructor(private val locator: ServiceL
         bind(ConfigInjectionResolver())
       }
     })
+
+    context.register(ManagedAsyncThreadPoolExecutorProvider::class.java)
 
     return true
   }

--- a/backend/common-web/src/main/kotlin/io/featurehub/jersey/ManagedAsyncThreadPoolExecutorProvider.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/jersey/ManagedAsyncThreadPoolExecutorProvider.kt
@@ -1,0 +1,37 @@
+package io.featurehub.jersey
+
+import io.featurehub.utils.ExecutorSupplier
+import io.featurehub.utils.ExecutorUtil
+import io.opentelemetry.context.Context
+import jakarta.inject.Inject
+import org.glassfish.jersey.server.ManagedAsyncExecutor
+import org.glassfish.jersey.spi.ThreadPoolExecutorProvider
+import java.util.concurrent.*
+
+@ManagedAsyncExecutor
+class ManagedAsyncThreadPoolExecutorProvider
+  : ThreadPoolExecutorProvider("fh-jersey-managed-async") {
+  private val executorSupplier: ExecutorSupplier = ExecutorUtil()
+
+  /**
+   * This ensures the context is wrapped in OpenTelemetry and the context is passed along
+   */
+  override fun getExecutorService(): ExecutorService {
+    return Context.taskWrapping(super.getExecutorService())
+  }
+
+  /**
+   * this ensures the MDC is passed along with the request so we don't lose the logging
+   */
+  override fun createExecutor(
+    corePoolSize: Int,
+    maximumPoolSize: Int,
+    keepAliveTime: Long,
+    workQueue: BlockingQueue<Runnable>?,
+    threadFactory: ThreadFactory?,
+    handler: RejectedExecutionHandler?
+  ): ThreadPoolExecutor {
+    return executorSupplier.executorService(corePoolSize, maximumPoolSize, keepAliveTime, TimeUnit.SECONDS,
+      workQueue, threadFactory, handler)
+  }
+}

--- a/backend/common-web/src/main/kotlin/io/featurehub/utils/ExecutorUtil.kt
+++ b/backend/common-web/src/main/kotlin/io/featurehub/utils/ExecutorUtil.kt
@@ -3,45 +3,131 @@ package io.featurehub.utils
 import io.opentelemetry.context.Context
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import java.util.concurrent.*
 
 interface ExecutorSupplier {
   fun executorService(nThreads: Int): ExecutorService
+  fun executorService(nThreads: Int,
+                      maximumPoolSize: Int,
+                      keepAliveTime: Long,
+                      unit: TimeUnit,
+                      workQueue: BlockingQueue<Runnable>?,
+                      threadFactory: ThreadFactory?,
+                      handler: RejectedExecutionHandler?): ThreadPoolExecutor
+}
+
+internal class MDCRunnable (private var runnable: Runnable) : Runnable {
+  private val copy: Map<String,String> = MDC.getCopyOfContextMap()
+
+  override fun run() {
+    MDC.setContextMap(copy)
+    runnable.run()
+  }
+}
+
+internal class MDCCallable<T>(private val callable: Callable<T>): Callable<T> {
+  private val copy: Map<String,String> = MDC.getCopyOfContextMap()
+  override fun call(): T {
+    MDC.setContextMap(copy)
+    return callable.call()
+  }
 }
 
 class ExecutorUtil : ExecutorSupplier {
   private val log: Logger = LoggerFactory.getLogger(ExecutorUtil::class.java)
 
   override fun executorService(nThreads: Int): ExecutorService {
+    return Context.taskWrapping(executorService(nThreads, nThreads, 0L,
+      TimeUnit.MILLISECONDS, null, null, null))
+  }
 
+  override fun executorService(nThreads: Int,
+                               maximumPoolSize: Int,
+                               keepAliveTime: Long,
+                               unit: TimeUnit,
+                               workQueue: BlockingQueue<Runnable>?,
+                               threadFactory: ThreadFactory?,
+                               handler: RejectedExecutionHandler?): ThreadPoolExecutor {
     val tpe = object : ThreadPoolExecutor(
-      nThreads, nThreads,
-      0L, TimeUnit.MILLISECONDS,
-      LinkedBlockingQueue()
+      nThreads, maximumPoolSize,
+      keepAliveTime, unit, workQueue ?: LinkedBlockingQueue()
     ) {
-      override fun afterExecute(r: Runnable?, t: Throwable?) {
-        var t = t
-        super.afterExecute(r, t)
+      override fun <T> submit(task: Callable<T>): Future<T> {
+        return super.submit(MDCCallable(task))
+      }
 
-        if (t == null && r is Future<*>) {
-          try {
-            val future = r
-            if (future.isDone) {
-              future.get()
+      override fun <T> submit(task: Runnable, result: T): Future<T> {
+        return super.submit(MDCRunnable(task), result)
+      }
+
+      override fun submit(task: Runnable): Future<*> {
+        return super.submit(MDCRunnable(task))
+      }
+
+      @Throws(InterruptedException::class)
+      override fun <T> invokeAll(tasks: Collection<Callable<T>>): List<Future<T>?> {
+        return super.invokeAll(tasks.map { MDCCallable(it) })
+      }
+
+      @Throws(InterruptedException::class)
+      override fun <T : Any?> invokeAll(
+        tasks: MutableCollection<out Callable<T>>,
+        timeout: Long,
+        unit: TimeUnit
+      ): MutableList<Future<T>> {
+        return super.invokeAll(tasks.map { MDCCallable(it) }, timeout, unit)
+      }
+
+      @Throws(InterruptedException::class, ExecutionException::class)
+      override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>): T {
+        return super.invokeAny(tasks.map { MDCCallable(it) })
+      }
+
+      @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
+      override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>, timeout: Long, unit: TimeUnit): T {
+        return super.invokeAny(tasks.map { MDCCallable(it) }, timeout, unit)
+      }
+
+      override fun execute(command: Runnable) {
+        super.execute(MDCRunnable(command))
+      }
+
+      override fun afterExecute(r: Runnable?, originalThrowable: Throwable?) {
+        try {
+          var t = originalThrowable
+
+          super.afterExecute(r, t)
+
+          if (t == null && r is Future<*>) {
+            try {
+              if (r.isDone) {
+                r.get()
+              }
+            } catch (ce: CancellationException) {
+              t = ce
+            } catch (ee: ExecutionException) {
+              t = ee.cause
+            } catch (ie: InterruptedException) {
+              Thread.currentThread().interrupt()
             }
-          } catch (ce: CancellationException) {
-            t = ce
-          } catch (ee: ExecutionException) {
-            t = ee.cause
-          } catch (ie: InterruptedException) {
-            Thread.currentThread().interrupt()
           }
-        }
 
-        t?.let { log.error("Thread execution failed", t) }
+          t?.let { log.error("Thread execution failed", t) }
+        } finally {
+          MDC.clear()
+        }
       }
     }
 
-    return Context.taskWrapping(tpe)
+    threadFactory?.let {
+      tpe.threadFactory = it
+    }
+
+    handler?.let {
+      tpe.rejectedExecutionHandler = it
+    }
+
+    return tpe
   }
 }

--- a/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
+++ b/backend/dacha/src/main/java/io/featurehub/dacha/EnvironmentFeatures.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -20,8 +21,8 @@ public class EnvironmentFeatures implements InternalCache.FeatureValues {
   public EnvironmentFeatures(PublishEnvironment env) {
     this.env = env;
 
-    this.features = env.getFeatureValues().stream()
-      .collect(Collectors.toMap(f -> f.getFeature().getId(), Function.identity()));
+    this.features = new ConcurrentHashMap<>(env.getFeatureValues().stream()
+      .collect(Collectors.toMap(f -> f.getFeature().getId(), Function.identity())));
 
     calculateEtag();
   }

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CloudEventListenerImpl.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CloudEventListenerImpl.kt
@@ -36,6 +36,7 @@ class Dacha2CloudEventListenerImpl @Inject constructor(
     executorService = executorSupplier.executorService(nThreads!!)
 
     if (featureEnricher.isEnabled()) {
+      log.trace("registering enricher for ping")
       register.listen(EnricherPing::class.java) { ep, ce ->
         featureEnricher.enricherPing(ce, ep)
       }

--- a/backend/dacha2/src/test/groovy/io/featurehub/dacha2/Dacha2CacheImplSpec.groovy
+++ b/backend/dacha2/src/test/groovy/io/featurehub/dacha2/Dacha2CacheImplSpec.groovy
@@ -274,7 +274,7 @@ class Dacha2CacheImplSpec extends Specification {
       def result = cache.isEnvironmentPresent(envId)
     and: "we republish the environment"
       cache.updateEnvironment(new PublishEnvironment().action(PublishAction.UPDATE)
-          .environment(new CacheEnvironment().id(envId))
+          .environment(new CacheEnvironment().id(envId).version(2))
           .featureValues([envFeature])
       )
       def resultWith = cache.getFeatureCollection(envId, apiKeyServerSide)

--- a/backend/dacha2/src/test/groovy/io/featurehub/dacha2/EnvironmentFeaturesSpec.groovy
+++ b/backend/dacha2/src/test/groovy/io/featurehub/dacha2/EnvironmentFeaturesSpec.groovy
@@ -1,0 +1,23 @@
+package io.featurehub.dacha2
+
+import io.featurehub.dacha.model.CacheEnvironmentFeature
+import io.featurehub.dacha.model.CacheFeature
+import io.featurehub.dacha.model.PublishEnvironment
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+class EnvironmentFeaturesSpec extends Specification {
+  def "multi-threaded access to EnvironmentFeatures does not trigger a concurrent modification exception"() {
+    given: "we have an environment features object with no data"
+      def env = new EnvironmentFeatures(new PublishEnvironment().featureValues([]))
+    and: "we have 20 threads"
+      def futures = (1..20).collect { new FeatureHolderThread(env, new CacheEnvironmentFeature().feature(new CacheFeature().id(UUID.randomUUID()))) }
+    when: "we update with 20 threads"
+      futures.each { it.start() }
+    and: "we wait for them to finish"
+      futures.each { it.future.join() }
+    then:
+      1 == 1
+  }
+}

--- a/backend/dacha2/src/test/groovy/io/featurehub/dacha2/FeatureHolderThread.groovy
+++ b/backend/dacha2/src/test/groovy/io/featurehub/dacha2/FeatureHolderThread.groovy
@@ -1,0 +1,26 @@
+package io.featurehub.dacha2
+
+import io.featurehub.dacha.model.CacheEnvironmentFeature
+
+import java.util.concurrent.CompletableFuture
+
+class FeatureHolderThread extends Thread {
+  public final EnvironmentFeatures env;
+  public final CacheEnvironmentFeature feature;
+  public final CompletableFuture<Boolean> future;
+
+  FeatureHolderThread(EnvironmentFeatures env, CacheEnvironmentFeature feature) {
+    this.env = env;
+    this.feature = feature;
+    this.future = new CompletableFuture<>();
+  }
+
+  @Override
+  void run() {
+    10.times {
+      env.setFeature(feature)
+    }
+    future.complete(true)
+  }
+}
+

--- a/backend/edge-common/src/main/java/io/featurehub/edge/strategies/ApplyFeature.java
+++ b/backend/edge-common/src/main/java/io/featurehub/edge/strategies/ApplyFeature.java
@@ -7,11 +7,13 @@ import io.featurehub.sse.model.FeatureRolloutStrategyAttribute;
 import io.featurehub.strategies.matchers.MatcherRepository;
 import io.featurehub.strategies.percentage.PercentageCalculator;
 import jakarta.inject.Inject;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,21 +89,21 @@ public class ApplyFeature {
   // This applies the rules as an AND. If at any point it fails it jumps out.
   private boolean matchAttributes(ClientContext cac, FeatureRolloutStrategy rsi) {
     for(FeatureRolloutStrategyAttribute attr : rsi.getAttributes()) {
-      String suppliedValue = cac.get(attr.getFieldName(), null);
+      List<String> suppliedValues = cac.get(attr.getFieldName());
 
       // "now" for dates and date-times are not passed by the client, so we create them in-situ
-      if (suppliedValue == null && "now".equalsIgnoreCase(attr.getFieldName())) {
+      if (suppliedValues == null && "now".equalsIgnoreCase(attr.getFieldName())) {
         if (attr.getType() == RolloutStrategyFieldType.DATE) {
-          suppliedValue = DateTimeFormatter.ISO_DATE.format(LocalDateTime.now());
+          suppliedValues = List.of(DateTimeFormatter.ISO_DATE.format(LocalDateTime.now()));
         } else if (attr.getType() == RolloutStrategyFieldType.DATETIME) {
-          suppliedValue = DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now());
+          suppliedValues = List.of(DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now()));
         }
       }
 
       Object val = attr.getValues();
 
       // both are null, just check against equals
-      if (val == null && suppliedValue == null) {
+      if (val == null && suppliedValues == null) {
         if (attr.getConditional() != RolloutStrategyAttributeConditional.EQUALS) {
           return false;
         }
@@ -110,12 +112,12 @@ public class ApplyFeature {
       }
 
       // either of them are null, check against not equals as we can't do anything else
-      if (val == null || suppliedValue == null) {
+      if (val == null || suppliedValues == null) {
         return false;
       }
 
-      // find the appropriate matcher based on type and match against the supplied value
-      if (!matcherRepository.findMatcher(attr).match(suppliedValue, attr)) {
+      // if none of the supplied values match against the associated matcher,
+      if (suppliedValues.stream().noneMatch(sv -> matcherRepository.findMatcher(attr).match(sv, attr) )) {
         return false;
       }
     }
@@ -128,7 +130,10 @@ public class ApplyFeature {
       return cac.defaultPercentageKey();
     }
 
-    return percentageAttributes.stream().map(pa -> cac.get(pa, "<none>")).collect(Collectors.joining("$"));
+    return percentageAttributes.stream()
+      .map(pa -> cac.get(pa, "<none>"))
+      .flatMap(Collection::stream).collect(Collectors.joining(
+      "$"));
   }
 
 

--- a/backend/edge-common/src/main/java/io/featurehub/edge/strategies/ClientContext.java
+++ b/backend/edge-common/src/main/java/io/featurehub/edge/strategies/ClientContext.java
@@ -1,6 +1,8 @@
 package io.featurehub.edge.strategies;
 
 import io.featurehub.edge.KeyParts;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -65,14 +67,26 @@ public class ClientContext {
     return strategy;
   }
 
-  public String get(String key, String defaultValue) {
+  @Nullable
+  public List<String> get(String key) {
     List<String> val = attributes.get(key);
 
     if (val == null || val.isEmpty()) {
-      return defaultValue;
+      return null;
     }
 
-    return val.get(0);
+    return val;
+  }
+
+  @NotNull
+  public List<String> get(String key, @NotNull String defaultValue) {
+    List<String> val = attributes.get(key);
+
+    if (val == null || val.isEmpty()) {
+      return List.of(defaultValue);
+    }
+
+    return val;
   }
 
   public String makeEtag() {

--- a/backend/edge-common/src/test/groovy/io/featurehub/edge/strategies/ApplyFeatureSpec.groovy
+++ b/backend/edge-common/src/test/groovy/io/featurehub/edge/strategies/ApplyFeatureSpec.groovy
@@ -105,6 +105,62 @@ class ApplyFeatureSpec extends Specification {
       !val.matched
   }
 
+  @Unroll
+  def 'array matcher works as expected'() {
+    given:
+      def rollout = [
+        new FeatureRolloutStrategy().value("sausage")
+          .id("1234")
+          .percentage(0)
+          .attributes([
+            new FeatureRolloutStrategyAttribute()
+              .fieldName("warehouseId")
+              .conditional(conditional)
+              .values(val)
+              .type(RolloutStrategyFieldType.STRING)
+          ])
+      ]
+    and:
+      def calc = Mock(PercentageCalculator)
+      def matcherRepo = new MatcherRegistry()
+      def applier = new ApplyFeature(calc, matcherRepo)
+    and:
+      def cac = new ClientContext(true)
+      cac.attributes[ClientContext.SESSIONKEY] = ['poorple']
+      List<String> values = (suppliedValues instanceof String) ? [suppliedValues.toString()] : suppliedValues.toList()
+      cac.attributes['warehouseId'] = values
+    when:
+      def theResult = applier.applyFeature(rollout, 'feature', 'id', cac)
+    then:
+      theResult.matched == result
+    where:
+      suppliedValues     | conditional                                        | val                          || result
+      'Android'          | RolloutStrategyAttributeConditional.EQUALS         | ['Android']                  || true
+      'Android'          | RolloutStrategyAttributeConditional.EQUALS         | ['android']                  || false
+      'Android'          | RolloutStrategyAttributeConditional.NOT_EQUALS     | ['Android']                  || false
+      'Android'          | RolloutStrategyAttributeConditional.NOT_EQUALS     | ['android']                  || true
+      'ios'              | RolloutStrategyAttributeConditional.INCLUDES       | ['android', 'ios', 'chrome'] || true
+      'linux'            | RolloutStrategyAttributeConditional.INCLUDES       | ['android', 'ios', 'chrome'] || false
+      'ios'              | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || false
+      'linux'            | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || true
+      'peaches'          | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['peaches']                  || true
+      'peaches'          | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['zebras']                   || false
+      'peaches'          | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['cream', 'zebras']          || true
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['mammal']                   || true
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.LESS           | ['mammal']                   || true
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['aardvark']                 || false
+      '1'                | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['a', 'b']                   || true
+      'c'                | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['a', 'b']                   || false
+      'a'                | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['a', 'b']                   || true
+      'b'                | RolloutStrategyAttributeConditional.LESS_EQUALS    | ['a', 'b']                   || true
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.LESS           | ['aardvark', 'aardshark']    || false
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.REGEX          | ['(.*)gold(.*)']              | true
+      'actapus (gold)'   | RolloutStrategyAttributeConditional.REGEX          | ['(.*)purple(.*)']            | false
+      ['ios', 'Android'] | RolloutStrategyAttributeConditional.EQUALS         | ['Android']                  || true
+      ['ios', 'Android'] | RolloutStrategyAttributeConditional.EQUALS         | ['ios']                      || true
+      ['ios', 'Android'] | RolloutStrategyAttributeConditional.EQUALS         | ['linux']                    || false
+  }
+
   def "we have a CAC with no percentage data at all but a match via attributes"() {
     given: "we have a strategy set"
       def rollout = [

--- a/backend/edge-full/src/main/java/io/featurehub/edge/Application.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/Application.java
@@ -5,6 +5,7 @@ import cd.connect.lifecycle.ApplicationLifecycleManager;
 import cd.connect.lifecycle.LifecycleStatus;
 import io.featurehub.dacha.api.DachaClientFeature;
 import io.featurehub.dacha.api.DachaClientServiceRegistry;
+import io.featurehub.events.CloudEventsFeature;
 import io.featurehub.events.pubsub.GoogleEventFeature;
 import io.featurehub.health.MetricsHealthRegistration;
 import io.featurehub.jersey.FeatureHubJerseyHost;
@@ -31,6 +32,7 @@ public class Application {
         new ResourceConfig(
             DachaClientFeature.class,
             EdgeFeature.class,
+            CloudEventsFeature.class,
             GoogleEventFeature.class,
             NATSFeature.class,
             EdgeResourceFeature.class,

--- a/backend/edge-full/src/main/java/io/featurehub/edge/EdgeFeature.java
+++ b/backend/edge-full/src/main/java/io/featurehub/edge/EdgeFeature.java
@@ -26,7 +26,6 @@ public class EdgeFeature implements Feature {
   @Override
   public boolean configure(FeatureContext context) {
     context.register(TelemetryFeature.class);
-    context.register(CloudEventsFeature.class);
     context
         .register(StatsFeature.class)
         .register(EdgeCommonFeature.class)

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/client/EventOutputHolder.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/client/EventOutputHolder.kt
@@ -1,0 +1,42 @@
+package io.featurehub.edge.client
+
+import jakarta.ws.rs.core.MediaType
+import org.glassfish.jersey.media.sse.EventOutput
+import org.glassfish.jersey.media.sse.OutboundEvent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import kotlin.jvm.Throws
+
+interface EventOutputHolder {
+  @Throws(IOException::class)
+  fun write(name: String, mediaType: MediaType, etags: String?, data: String)
+  fun isClosed(): Boolean
+  fun close()
+}
+
+class InternalEventOutput(private val output: EventOutput) : EventOutputHolder {
+  private val log: Logger = LoggerFactory.getLogger(InternalEventOutput::class.java)
+
+  override fun write(name: String, mediaType: MediaType, etags: String?, data: String) {
+    val eventBuilder = OutboundEvent.Builder()
+    log.trace("data is  etag `{}`: name: `{}` data `{}`", etags, name, data)
+    eventBuilder.name(name)
+    eventBuilder.mediaType(mediaType)
+    if (etags != null) {
+      eventBuilder.id(etags)
+    }
+    eventBuilder.data(data)
+    val event = eventBuilder.build()
+    output.write(event)
+  }
+
+  override fun isClosed(): Boolean {
+    return output.isClosed
+  }
+
+  override fun close() {
+    output.close()
+  }
+
+}

--- a/backend/edge-full/src/main/kotlin/io/featurehub/edge/client/TimedBucketClientFactory.kt
+++ b/backend/edge-full/src/main/kotlin/io/featurehub/edge/client/TimedBucketClientFactory.kt
@@ -24,5 +24,6 @@ class TimedBucketClientFactoryImpl @Inject constructor(
     etag: String?,
     extraContext: String?
   ): TimedBucketClientConnection =
-    TimedBucketClientConnection(output, apiKey, featureTransformer, statRecorder, featureHubAttributes, etag, extraContext, bucketService)
+    TimedBucketClientConnection(InternalEventOutput(output), apiKey, featureTransformer,
+      statRecorder, featureHubAttributes, etag, extraContext, bucketService)
 }

--- a/backend/edge-full/src/test/groovy/io/featurehub/edge/client/TimedBucketClientConnectionSpec.groovy
+++ b/backend/edge-full/src/test/groovy/io/featurehub/edge/client/TimedBucketClientConnectionSpec.groovy
@@ -1,0 +1,82 @@
+package io.featurehub.edge.client
+
+import io.featurehub.dacha.model.CacheEnvironmentFeature
+import io.featurehub.dacha.model.CacheFeature
+import io.featurehub.dacha.model.CacheFeatureValue
+import io.featurehub.dacha.model.PublishAction
+import io.featurehub.dacha.model.PublishFeatureValue
+import io.featurehub.edge.FeatureTransformer
+import io.featurehub.edge.KeyParts
+import io.featurehub.edge.bucket.BucketService
+import io.featurehub.edge.features.FeatureRequestResponse
+import io.featurehub.edge.features.FeatureRequestSuccess
+import io.featurehub.edge.stats.StatRecorder
+import io.featurehub.mr.model.FeatureValueType
+import io.featurehub.sse.model.FeatureEnvironmentCollection
+import io.featurehub.sse.model.FeatureState
+import spock.lang.Specification
+
+class TimedBucketClientConnectionSpec extends Specification {
+  EventOutputHolder output
+  KeyParts apiKey
+  FeatureTransformer featureTransformer
+  StatRecorder statRecorder
+  BucketService bucketService
+
+  TimedBucketClientConnection conn
+
+  def setup() {
+    output = Mock()
+    featureTransformer = Mock()
+    statRecorder = Mock()
+    bucketService = Mock()
+
+    apiKey = new KeyParts("cache", UUID.randomUUID(), "key")
+
+    conn = new TimedBucketClientConnection(output, apiKey, featureTransformer,
+      statRecorder, null, null, null, bucketService)
+  }
+
+  // IGNORE: too much parallelism makes this too expensive a check, do in client
+  // if we get create featuer (1), update feature (2), retire feature (3), unretire feature (4)
+  // and it turns up as 1 2 4 3, then (3) won't be passed down the wire
+//  def "an out of order retiring of a feature is ignored"() {
+//    given: "i pass the initial set of feature states as a single feature"
+//      def state = new FeatureState().id(UUID.randomUUID()).version(1).type(FeatureValueType.BOOLEAN)
+//        .value(Boolean.FALSE).key("x").l(false)
+//      def coll = new FeatureEnvironmentCollection().id(UUID.randomUUID())
+//          .features([state])
+//      def publishedFeature = new PublishFeatureValue()
+//        .action(PublishAction.CREATE)
+//        .environmentId(UUID.randomUUID())
+//        .feature(new CacheEnvironmentFeature()
+//          .feature(new CacheFeature().id(state.id).valueType(FeatureValueType.BOOLEAN))
+//          .value(new CacheFeatureValue().id(UUID.randomUUID())
+//            .retired(false)
+//            .value(Boolean.TRUE).version(2).locked(false))
+//        )
+////    and: "i mock out the feature transformer"
+////      featureTransformer.transform(_, _) >> new HashMap()
+//    when: "i send the initial response"
+//      conn.initResponse(new FeatureRequestResponse(coll, FeatureRequestSuccess.SUCCESS, apiKey, "etag", null))
+//    then: "i get some data written out"
+//      1 * output.write('features', _, 'etag', _)
+//    when: 'i send an update to the feature'
+//      conn.notifyFeature([publishedFeature])
+//    then: "i get an update"
+//      1 * output.write('feature', _, null, _)
+//    when: 'i get an out of order 4th version'
+//      publishedFeature.feature.value.version = 4
+//      publishedFeature.action = PublishAction.UPDATE
+//      conn.notifyFeature([publishedFeature])
+//    then: "i get an update"
+//      1 * output.write('feature', _, null, _)
+//    when: 'i get the 3rd version, it is ignored'
+//      publishedFeature.feature.value.version = 3
+//      publishedFeature.action = PublishAction.DELETE
+//      publishedFeature.feature.value.retired(true)
+//      conn.notifyFeature([publishedFeature])
+//    then: "i do NOT get an update"
+//      0 * output.write(_, _, _, _)
+//  }
+}

--- a/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventPublisherRegistry.kt
+++ b/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventPublisherRegistry.kt
@@ -60,7 +60,7 @@ class CloudEventPublisherRegistry @Inject constructor(
         val event = eventBuilder.build()
         threadPool.submit {
           if (log.isTraceEnabled) {
-            log.trace("cloudevent publish: {}", event)
+            log.trace("cloudevent publish: type {}, subject={}, id={}", event.type, event.subject, event.id)
           }
           handler.handler(event)
         }

--- a/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventReceiverRegistry.kt
+++ b/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventReceiverRegistry.kt
@@ -93,11 +93,11 @@ constructor(private val openTelemetryReader: CloudEventsTelemetryReader, executo
       return
     }
 
-    if (log.isTraceEnabled) {
-      log.debug("cloudevent: {}", event.subject)
-    }
-
     val handlers = eventHandlers[event.type]?.get(event.subject!!)
+
+    if (log.isTraceEnabled) {
+      log.debug("cloudevent: {} / {} has {} handlers", event.type, event.subject, handlers?.size ?: 0)
+    }
 
     if (handlers == null) {
       event.subject?.let { it ->
@@ -114,7 +114,7 @@ constructor(private val openTelemetryReader: CloudEventsTelemetryReader, executo
     openTelemetryReader.receive(event) {
       CacheJsonMapper.fromEventData(event, handlers[0].clazz)?.let { eventData ->
         if (log.isTraceEnabled) {
-          log.trace("cloudevent: incoming message on {}/{} : {}", event.type, event.subject, eventData.toString())
+          log.debug("cloudevent: incoming message on {}/{} : {}", event.type, event.subject, eventData.toString())
         }
 
         handlers.forEach { handler ->

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/ManagementRepositoryFeature.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/ManagementRepositoryFeature.kt
@@ -3,6 +3,7 @@ package io.featurehub.mr
 import io.featurehub.app.db.utils.CommonDbFeature
 import io.featurehub.db.utils.ApiToSqlApiBinder
 import io.featurehub.db.utils.ComplexUpdateMigrations
+import io.featurehub.lifecycle.WebBaggageSource
 import io.featurehub.messaging.MessagingFeature
 import io.featurehub.mr.api.*
 import io.featurehub.mr.auth.*
@@ -76,6 +77,7 @@ class ManagementRepositoryFeature : Feature {
           bind(NoAuthProviders::class.java).to(AuthProviderCollection::class.java).`in`(Singleton::class.java)
         }
 
+        bind(BaggageSourceAuth::class.java).to(WebBaggageSource::class.java).`in`(Singleton::class.java)
         bind(OAuth2MRAdapter::class.java).to(SSOCompletionListener::class.java).`in`(Singleton::class.java)
         bind(DatabaseAuthRepository::class.java).to(AuthenticationRepository::class.java).`in`(
           Singleton::class.java

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/auth/BaggageSourceAuth.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/auth/BaggageSourceAuth.kt
@@ -1,0 +1,18 @@
+package io.featurehub.mr.auth
+
+import io.featurehub.lifecycle.WebBaggageSource
+import jakarta.ws.rs.container.ContainerRequestContext
+
+
+class BaggageSourceAuth: WebBaggageSource {
+  override fun sourceBaggage(carrier: ContainerRequestContext): List<Pair<String, String>> {
+    carrier.securityContext?.userPrincipal?.let {
+      val holder = it as AuthHolder;
+      holder.person.id?.let {  id ->
+        return listOf(Pair("x-fh-uid", id.id.toString()))
+      }
+    }
+
+    return listOf()
+  }
+}

--- a/backend/party-server/src/test/resources/log4j2-test.xml
+++ b/backend/party-server/src/test/resources/log4j2-test.xml
@@ -1,8 +1,8 @@
 <Configuration packages="cd.connect.logging" monitorInterval="30" verbose="true">
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-<!--      <ConnectJsonLayout/>-->
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>
+      <ConnectJsonLayout/>
+<!--      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%M %logger{36} - %msg%n"/>-->
     </Console>
   </Appenders>
 
@@ -10,6 +10,8 @@
     <AsyncLogger name="io.featurehub" level="debug"/>
     <AsyncLogger name="io.featurehub.edge" level="trace"/>
     <AsyncLogger name="io.featurehub.dacha2" level="trace"/>
+    <AsyncLogger name="io.features.webhooks.features" level="trace"/>
+    <AsyncLogger name="io.featurehub.enricher" level="trace"/>
     <AsyncLogger name="io.ebean.SQL" level="trace"/>
     <AsyncLogger name="io.ebean.TXN" level="trace"/>
     <AsyncLogger name="io.ebean.SUM" level="trace"/>

--- a/backend/sdk-strategy-matchers/src/test/groovy/io/featurehub/strategies/matchers/StringArrayMatcherSpec.groovy
+++ b/backend/sdk-strategy-matchers/src/test/groovy/io/featurehub/strategies/matchers/StringArrayMatcherSpec.groovy
@@ -29,8 +29,8 @@ class StringArrayMatcherSpec extends Specification {
         'Android'        | RolloutStrategyAttributeConditional.NOT_EQUALS     | ['android']                  || true
         'ios'            | RolloutStrategyAttributeConditional.INCLUDES       | ['android', 'ios', 'chrome'] || true
         'linux'          | RolloutStrategyAttributeConditional.INCLUDES       | ['android', 'ios', 'chrome'] || false
-        'ios'            | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || false
-        'linux'          | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || true
+        'ios'            | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || false // val does not contain "ios" == false, it does
+        'linux'          | RolloutStrategyAttributeConditional.EXCLUDES       | ['android', 'ios', 'chrome'] || true // val does not contain "linux" == true, it doesn't
         'peaches'        | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['peaches']                  || true
         'peaches'        | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['zebras']                   || false
         'peaches'        | RolloutStrategyAttributeConditional.GREATER_EQUALS | ['cream', 'zebras']          || true

--- a/backend/webhook-feature-update/src/main/kotlin/io/features/webhooks/features/WebhookFeature.kt
+++ b/backend/webhook-feature-update/src/main/kotlin/io/features/webhooks/features/WebhookFeature.kt
@@ -84,6 +84,7 @@ class WebhookEnricherListener @Inject constructor(
   init {
     DeclaredConfigResolver.resolve(this)
 
+    log.debug("listening for webhooks on enriched feature channel")
     cloudEventReceiverRegistry.listen(EnrichedFeatures::class.java, this::process)
 
     client = ClientBuilder.newClient()


### PR DESCRIPTION
# Description

Adds in full support for Open Telemetry based logging

Introduces request-id from Web client and auto-adds user id into baggage to for logs and OTEL.
and the Baggage headers if configured to be logged to the output logs across the system.

Fixes edge cases where very fast updates are being applied in the wrong order or are failing and causing missed webhooks.

Removes the duplicate cloud events occurring in Party Server.

Considerably more diagnostics when in trace mode for logs.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

