### PR TITLE
[feature] OpenTelemetry Upgrade

### DIFF
--- a/backend/common-web/pom.xml
+++ b/backend/common-web/pom.xml
@@ -50,25 +50,36 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>1.24.0</version>
+      <version>1.34.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
-      <version>1.24.0</version>
+      <version>1.34.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-trace</artifactId>
-      <version>1.24.0</version>
+      <version>1.34.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-exporters-logging</artifactId>
-      <version>0.9.1</version>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>1.34.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+      <version>1.34.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-extension-trace-propagators</artifactId>
+      <version>1.34.1</version>
     </dependency>
 
     <dependency>

--- a/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventsTelemetryReaderImpl.kt
+++ b/backend/eventing-cloudevents/src/main/kotlin/io/featurehub/events/CloudEventsTelemetryReaderImpl.kt
@@ -9,9 +9,9 @@ import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapGetter
 import jakarta.inject.Inject
-import org.apache.log4j.MDC
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 
 internal class CloudEventTextMapGetter : TextMapGetter<CloudEvent> {
   override fun keys(carrier: CloudEvent): MutableIterable<String> =

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -333,6 +333,11 @@ audit.logging.user=true
 
 ----
 
+==== OpenTelemetry AutoConfiguration
+
+OpenTelemetry configuration is done using
+the https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure[AutoConfiguration] style definition. It allows
+you to specify your own tracing exporters, propagators, etc based on system properties (in the config files) or by environment variables.
 
 === Common to Party, SSE Edge and Management Repository
 

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.19
+FROM dart:3.2.3
 
 ADD . /e2e
 WORKDIR /e2e


### PR DESCRIPTION
# Description

Supports full client customisation, OLTP exporters, extra header types and Zipkin (defaults to standard W3C headers) support as per https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure

