### PR TITLE
Feature value editing UI improvements, plus fix for unexpected locking error

### DIFF
--- a/admin-frontend/open_admin_app/lib/theme/custom_text_style.dart
+++ b/admin-frontend/open_admin_app/lib/theme/custom_text_style.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class CustomTextStyle {
+  static TextStyle bodySmallLight(BuildContext context) {
+    return Theme.of(context).textTheme.bodySmall!.copyWith(
+        color: Theme.of(context).textTheme.bodySmall!.color!.withOpacity(0.6));
+  }
+
+  static TextStyle bodyMediumBold(BuildContext context) {
+    return TextStyle(fontWeight: FontWeight.bold);
+  }
+}

--- a/admin-frontend/open_admin_app/lib/widgets/apps/service_account_permissions_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/service_account_permissions_widget.dart
@@ -93,13 +93,13 @@ class ServiceAccountPermissionState
                     ),
                     const Padding(
                       padding: EdgeInsets.only(left: 16.0),
-                      child: FHInfoCardWidget(message: '''
-We strongly recommend setting production environments
-with only 'Read' permission for service accounts.
-The 'Lock/Unlock' and 'Change value' permissions
-typically given to service accounts for testing purposes,
-e.g. changing feature values states through the SDK
-when running tests. '''),
+                      child: FHInfoCardWidget(
+                          message:
+                              "We strongly recommend setting production environments "
+                              "with only 'Read' permission for service accounts. "
+                              "The 'Lock/Unlock' and 'Change value' permissions "
+                              "typically given to service accounts for testing purposes, "
+                              "e.g. changing feature values states through the SDK when running tests."),
                     ),
                     const SizedBox(
                       width: 32,
@@ -231,7 +231,8 @@ class _ServiceAccountPermissionDetailState
                     getPermissionCheckbox(env.id, RoleType.LOCK),
                     getPermissionCheckbox(env.id, RoleType.UNLOCK),
                     getPermissionCheckbox(env.id, RoleType.CHANGE_VALUE),
-                    if (widget.bloc.mrClient.identityProviders.featurePropertyExtendedDataEnabled)
+                    if (widget.bloc.mrClient.identityProviders
+                        .featurePropertyExtendedDataEnabled)
                       getPermissionCheckbox(env.id, RoleType.EXTENDED_DATA),
                   ]));
                 }
@@ -333,16 +334,16 @@ class _ServiceAccountPermissionDetailState
           style: headerStyle,
         ),
       )),
-      if (widget.bloc.mrClient.identityProviders.featurePropertyExtendedDataEnabled)
+      if (widget
+          .bloc.mrClient.identityProviders.featurePropertyExtendedDataEnabled)
         Center(
             child: Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: Text(
-                'Read\nExtended\nFeature Data',
-                style: headerStyle,
-              ),
-            )),
-
+          padding: const EdgeInsets.all(12.0),
+          child: Text(
+            'Read\nExtended\nFeature Data',
+            style: headerStyle,
+          ),
+        )),
     ]);
   }
 

--- a/admin-frontend/open_admin_app/lib/widgets/common/decorations/fh_page_divider.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/common/decorations/fh_page_divider.dart
@@ -6,8 +6,9 @@ class FHPageDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        decoration: const BoxDecoration(
-            border:
-                Border(bottom: BorderSide(color: Colors.black87, width: 0.5))));
+        decoration: BoxDecoration(
+            border: Border(
+                bottom: BorderSide(
+                    color: Theme.of(context).dividerColor, width: 0.5))));
   }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/common/fh_info_card.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/common/fh_info_card.dart
@@ -8,27 +8,23 @@ class FHInfoCardWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Tooltip(
-      textStyle: Theme.of(context)
-          .textTheme
-          .bodyMedium!
-          .copyWith(color: Theme.of(context).primaryColor),
-      message: message,
-      padding: const EdgeInsets.all(20),
+      richMessage: WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Container(
+            padding: const EdgeInsets.all(10),
+            constraints: const BoxConstraints(maxWidth: 250),
+            child: Text(message),
+          )),
       decoration: BoxDecoration(
-        color: Theme.of(context).primaryColorLight.withOpacity(0.9),
+        color: Theme.of(context).primaryColorLight,
         borderRadius: const BorderRadius.all(Radius.circular(4)),
       ),
-      verticalOffset: 20,
-      waitDuration: const Duration(milliseconds: 400),
-      child: InkWell(
-        mouseCursor: SystemMouseCursors.click,
-        radius: 36.0,
-        onHover: (_) {},
-        onTap: () {},
-        child: const Icon(
-          Icons.info,
-          size: 22.0,
-        ),
+      preferBelow: false,
+      verticalOffset: 10,
+      child: const Icon(
+        Icons.info_outline,
+        size: 20,
       ),
     );
   }

--- a/admin-frontend/open_admin_app/lib/widgets/environments/env_list_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/environments/env_list_widget.dart
@@ -380,12 +380,10 @@ Widget addEnvWidget(BuildContext context, ManageAppBloc bloc) {
             ),
           ),
         const FHInfoCardWidget(
-          message: '''
-Ordering your environments,
-showing the path to production (top to bottom)
-will be reflected on the "Features" dashboard.\n
-It helps your teams see their changes
-per environment in the correct order.''',
+          message: "Environments can be ordered by dragging the cards below,"
+              " showing the deployment promotion order to production (top to bottom). "
+              "This order will be reflected on the 'Features' dashboard. It helps your teams see"
+              " their feature status per environment in the correct order.",
         ),
         const SizedBox(
           width: 32,

--- a/admin-frontend/open_admin_app/lib/widgets/features/cell-view/value_cell.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/cell-view/value_cell.dart
@@ -64,7 +64,9 @@ class _ValueContainer extends StatelessWidget {
                   builder: (ctx, efvBloc) => EditFeatureValueWidget(
                         bloc: efvBloc,
                       )),
-              width: MediaQuery.of(context).size.width * 0.3,
+              width: MediaQuery.of(context).size.width > 800
+                  ? MediaQuery.of(context).size.width * 0.5
+                  : MediaQuery.of(context).size.width,
               context: context);
         },
         child: Padding(

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/edit_feature_value_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/edit_feature_value_widget.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mrapi/api.dart';
+import 'package:open_admin_app/theme/custom_text_style.dart';
+import 'package:open_admin_app/widgets/common/decorations/fh_page_divider.dart';
+import 'package:open_admin_app/widgets/common/fh_info_card.dart';
 import 'package:open_admin_app/widgets/features/edit-feature-value/feature_value_updated_by.dart';
 import 'package:open_admin_app/widgets/features/edit-feature-value/lock_unlock_switch.dart';
 import 'package:open_admin_app/widgets/features/edit-feature-value/retire_feature_value_checkbox_widget.dart';
@@ -40,7 +43,7 @@ class _EditFeatureValueWidgetState extends State<EditFeatureValueWidget> {
                           color:
                               Theme.of(context).snackBarTheme.backgroundColor,
                           child: ButtonBar(
-                              alignment: MainAxisAlignment.end,
+                              alignment: MainAxisAlignment.start,
                               children: [
                                 const Text('You have unsaved changes, save?'),
                                 TextButton(
@@ -82,113 +85,232 @@ class _EditFeatureValueWidgetState extends State<EditFeatureValueWidget> {
                   }),
               Expanded(
                 child: SingleChildScrollView(
-                    child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          widget.bloc.feature.name,
-                          style: Theme.of(context).textTheme.titleLarge,
+                    child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              widget.bloc.feature.name,
+                              style: CustomTextStyle.bodyMediumBold(context),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.close, size: 20),
+                              onPressed: () => Navigator.of(context).pop(),
+                            ),
+                          ],
                         ),
-                        const SizedBox(height: 8.0),
-                        Text(widget
-                            .bloc.environmentFeatureValue.environmentName),
-                        const SizedBox(height: 16.0),
-                        LockUnlockSwitch(
-                          environmentFeatureValue:
-                              widget.bloc.environmentFeatureValue,
-                          fvBloc: widget.bloc,
+                      ),
+                      const FHPageDivider(),
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "Environment",
+                              style: CustomTextStyle.bodySmallLight(context),
+                            ),
+                            Text(widget
+                                .bloc.environmentFeatureValue.environmentName),
+                          ],
                         ),
-                        StreamBuilder<FeatureValue>(
-                            stream: widget.bloc.currentFv,
-                            builder: (context, featureValueLatest) {
-                              if (featureValueLatest.hasData) {
-                                final canChangeValue = widget
-                                    .bloc.environmentFeatureValue.roles
-                                    .contains(RoleType.CHANGE_VALUE);
-                                var editable =
-                                    !featureValueLatest.data!.locked &&
-                                        canChangeValue;
-                                List<Widget> widgets = [];
-                                if (strategiesLatest.hasData) {
-                                  widgets = strategiesLatest.data!
-                                      .map((RolloutStrategy strategy) {
-                                    return StrategyCard(
-                                        key: ValueKey(strategy),
-                                        strBloc: widget.bloc,
-                                        rolloutStrategy: strategy,
-                                        featureValueType:
-                                            widget.bloc.feature.valueType);
-                                  }).toList();
-                                }
-                                return Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    StrategyCard(
-                                        strBloc: widget.bloc,
-                                        featureValueType:
-                                            widget.bloc.feature.valueType),
-                                    if (strategiesLatest.hasData)
+                      ),
+                      Card(
+                        elevation: 3.0,
+                        shadowColor: Colors.transparent,
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                              top: 8.0, bottom: 16.0, left: 8.0, right: 8.0),
+                          child: Column(
+                            children: [
+                              const SizedBox(height: 16.0),
+                              Row(
+                                children: [
+                                  Text(
+                                    "Locked status",
+                                    style:
+                                        CustomTextStyle.bodySmallLight(context),
+                                  ),
+                                  const SizedBox(
+                                    width: 4.0,
+                                  ),
+                                  const FHInfoCardWidget(
+                                      message:
+                                          "Locking mechanism provides an additional safety net for feature changes when deploying incomplete code to production."
+                                          " Locked status prevents any changes to default value, "
+                                          "strategies, strategy values and 'retired' status. "
+                                          "Typically, developers keep features locked "
+                                          "to indicate they are not ready to be turned on for testers, product owners, customers and other stakeholders."),
+                                ],
+                              ),
+                              const SizedBox(height: 4.0),
+                              LockUnlockSwitch(
+                                environmentFeatureValue:
+                                    widget.bloc.environmentFeatureValue,
+                                fvBloc: widget.bloc,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16.0),
+                      StreamBuilder<FeatureValue>(
+                          stream: widget.bloc.currentFv,
+                          builder: (context, featureValueLatest) {
+                            if (featureValueLatest.hasData) {
+                              final canChangeValue = widget
+                                  .bloc.environmentFeatureValue.roles
+                                  .contains(RoleType.CHANGE_VALUE);
+                              var editable = !featureValueLatest.data!.locked &&
+                                  canChangeValue;
+                              List<Widget> widgets = [];
+                              if (strategiesLatest.hasData) {
+                                widgets = strategiesLatest.data!
+                                    .map((RolloutStrategy strategy) {
+                                  return Column(
+                                    children: [
+                                      StrategyCard(
+                                          key: ValueKey(strategy),
+                                          strBloc: widget.bloc,
+                                          rolloutStrategy: strategy,
+                                          featureValueType:
+                                              widget.bloc.feature.valueType),
+                                    ],
+                                  );
+                                }).toList();
+                              }
+                              return Card(
+                                elevation: 3.0,
+                                shadowColor: Colors.transparent,
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 8.0, vertical: 24.0),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text("Default value",
+                                          style: CustomTextStyle.bodySmallLight(
+                                              context)),
+                                      StrategyCard(
+                                          strBloc: widget.bloc,
+                                          featureValueType:
+                                              widget.bloc.feature.valueType),
+                                      const SizedBox(height: 16.0),
+                                      Row(
+                                        children: [
+                                          Text("Strategy variations",
+                                              style: CustomTextStyle
+                                                  .bodySmallLight(context)),
+                                          const SizedBox(
+                                            width: 4.0,
+                                          ),
+                                          const FHInfoCardWidget(
+                                              message:
+                                                  "Add a strategy variation to serve a value other than default. "
+                                                  "You can change strategies evaluation order by dragging and dropping the cards below. "
+                                                  "Strategies are evaluated in order from top to bottom. Evaluation stops when it hits a matching strategy."
+                                                  " 'Group Strategy' evaluation comes last. If no strategies match, then 'default' feature value is served."),
+                                          const SizedBox(
+                                            width: 8.0,
+                                          ),
+                                          if (editable)
+                                            AddStrategyButton(
+                                              bloc: widget.bloc,
+                                            ),
+                                        ],
+                                      ),
+                                      if (widgets.isEmpty)
+                                        const Text("No strategies"),
                                       buildReorderableListView(
                                           widgets,
                                           featureValueLatest,
                                           canChangeValue,
                                           strategiesLatest,
                                           widget.bloc),
-                                    const SizedBox(height: 16.0),
-                                    if (featureValueLatest
-                                                .data!.featureGroupStrategies !=
-                                            null &&
-                                        featureValueLatest.data!
-                                            .featureGroupStrategies!.isNotEmpty)
-                                      Padding(
-                                        padding:
-                                            const EdgeInsets.only(left: 12.0),
-                                        child: Text("Group Strategy",
-                                            style: Theme.of(context)
-                                                .textTheme
-                                                .labelSmall),
+                                      const SizedBox(height: 24.0),
+                                      Row(
+                                        children: [
+                                          Text("Group strategy variations",
+                                              style: CustomTextStyle
+                                                  .bodySmallLight(context)),
+                                          const SizedBox(
+                                            width: 4.0,
+                                          ),
+                                          const FHInfoCardWidget(
+                                              message:
+                                                  "Feature groups are recommended when you want to set the same strategy for multiple features. "
+                                                  "Feature group strategy can be created and edited from the Feature Groups screen.")
+                                        ],
                                       ),
-                                    if (featureValueLatest
-                                            .data
-                                            ?.featureGroupStrategies
-                                            ?.isNotEmpty ==
-                                        true)
-                                      for (var groupStrategy
-                                          in featureValueLatest
-                                              .data!.featureGroupStrategies!)
-                                        StrategyCard(
-                                            groupRolloutStrategy: groupStrategy,
-                                            strBloc: widget.bloc,
-                                            featureValueType:
-                                                widget.bloc.feature.valueType),
-                                    const SizedBox(height: 8.0),
-                                    if (editable)
-                                      AddStrategyButton(
-                                        bloc: widget.bloc,
+                                      if (featureValueLatest
+                                              .data
+                                              ?.featureGroupStrategies
+                                              ?.isEmpty ==
+                                          true)
+                                        const Text("No group strategies"),
+                                      if (featureValueLatest
+                                              .data
+                                              ?.featureGroupStrategies
+                                              ?.isNotEmpty ==
+                                          true)
+                                        for (var groupStrategy
+                                            in featureValueLatest
+                                                .data!.featureGroupStrategies!)
+                                          StrategyCard(
+                                              groupRolloutStrategy:
+                                                  groupStrategy,
+                                              strBloc: widget.bloc,
+                                              featureValueType: widget
+                                                  .bloc.feature.valueType),
+                                      const SizedBox(height: 24.0),
+                                      Row(
+                                        children: [
+                                          Text(
+                                            "Retired status",
+                                            style:
+                                                CustomTextStyle.bodySmallLight(
+                                                    context),
+                                          ),
+                                          const SizedBox(
+                                            width: 4.0,
+                                          ),
+                                          const FHInfoCardWidget(
+                                              message:
+                                                  "When feature flag is not needed any longer in your application,"
+                                                  " and ready to be removed, you can first 'retire' this feature in a given environment"
+                                                  " to test how your application behaves. This means that the feature won't be visible by the SDKs,"
+                                                  " imitating the 'deleted' state. You can uncheck the box to 'un-retire' a feature if you change your mind"
+                                                  " as this operation is reversible. Once you retire feature values across all the environments"
+                                                  "  and test that your application behaves as expected, you can delete your entire feature.")
+                                        ],
                                       ),
-                                    const SizedBox(height: 16.0),
-                                    RetireFeatureValueCheckboxWidget(
-                                        environmentFeatureValue:
-                                            widget.bloc.environmentFeatureValue,
-                                        fvBloc: widget.bloc,
-                                        editable: editable,
-                                        retired: widget
-                                            .bloc.currentFeatureValue.retired),
-                                    //this is where we need to pass retired from the actual value
-                                    const SizedBox(height: 16.0),
-                                    FeatureValueUpdatedByCell(
-                                      strBloc: widget.bloc,
-                                    ),
-                                  ],
-                                );
-                              } else {
-                                return const SizedBox.shrink();
-                              }
-                            }),
-                      ]),
-                )),
+                                      RetireFeatureValueCheckboxWidget(
+                                          environmentFeatureValue: widget
+                                              .bloc.environmentFeatureValue,
+                                          fvBloc: widget.bloc,
+                                          editable: editable,
+                                          retired: widget.bloc
+                                              .currentFeatureValue.retired),
+                                      //this is where we need to pass retired from the actual value
+                                      const SizedBox(height: 16.0),
+                                      FeatureValueUpdatedByCell(
+                                        strBloc: widget.bloc,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            } else {
+                              return const SizedBox.shrink();
+                            }
+                          }),
+                    ])),
               ),
             ],
           );

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/edit_feature_value_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/edit_feature_value_widget.dart
@@ -42,41 +42,40 @@ class _EditFeatureValueWidgetState extends State<EditFeatureValueWidget> {
                         child: Container(
                           color:
                               Theme.of(context).snackBarTheme.backgroundColor,
-                          child: ButtonBar(
-                              alignment: MainAxisAlignment.start,
-                              children: [
-                                const Text('You have unsaved changes, save?'),
-                                TextButton(
-                                    style: TextButton.styleFrom(
-                                      foregroundColor: Theme.of(context)
-                                          .snackBarTheme
-                                          .actionTextColor,
-                                    ),
-                                    onPressed: () {
-                                      Navigator.pop(
-                                          context); //close the side panel
-                                    },
-                                    child: const Text("Cancel")),
-                                FilledButton(
-                                    onPressed: () async {
-                                      try {
-                                        await widget.bloc
-                                            .saveFeatureValueUpdates();
-                                        Navigator.pop(
-                                            context); //close the side panel
-                                        widget.bloc.perApplicationFeaturesBloc
-                                            .mrClient
-                                            .addSnackbar(Text(
-                                                'Feature ${widget.bloc.feature.name.toUpperCase()} '
-                                                'in the environment ${widget.bloc.environmentFeatureValue.environmentName.toUpperCase()} has been updated!'));
-                                      } catch (e, s) {
-                                        widget.bloc.perApplicationFeaturesBloc
-                                            .mrClient
-                                            .dialogError(e, s);
-                                      }
-                                    },
-                                    child: const Text("Save")),
-                              ]),
+                          child: Row(children: [
+                            const SizedBox(
+                              width: 8.0,
+                            ),
+                            const Text('You have unsaved changes, save?'),
+                            TextButton(
+                                style: TextButton.styleFrom(
+                                  foregroundColor: Theme.of(context)
+                                      .snackBarTheme
+                                      .actionTextColor,
+                                ),
+                                onPressed: () {
+                                  Navigator.pop(context); //close the side panel
+                                },
+                                child: const Text("Cancel")),
+                            FilledButton(
+                                onPressed: () async {
+                                  try {
+                                    await widget.bloc.saveFeatureValueUpdates();
+                                    Navigator.pop(
+                                        context); //close the side panel
+                                    widget.bloc.perApplicationFeaturesBloc
+                                        .mrClient
+                                        .addSnackbar(Text(
+                                            'Feature ${widget.bloc.feature.name.toUpperCase()} '
+                                            'in the environment ${widget.bloc.environmentFeatureValue.environmentName.toUpperCase()} has been updated!'));
+                                  } catch (e, s) {
+                                    widget.bloc.perApplicationFeaturesBloc
+                                        .mrClient
+                                        .dialogError(e, s);
+                                  }
+                                },
+                                child: const Text("Save")),
+                          ]),
                         ),
                       );
                     } else {

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/feature_value_updated_by.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/feature_value_updated_by.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:open_admin_app/widgets/features/editing_feature_value_block.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
-
 class FeatureValueUpdatedByCell extends StatelessWidget {
   final EditingFeatureValueBloc strBloc;
 
@@ -22,20 +21,13 @@ class FeatureValueUpdatedByCell extends StatelessWidget {
       whoUpdated = strBloc.featureValue.whoUpdated!.name!;
     }
 
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        children: [
-          Text(updatedBy,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodySmall!
-                  .copyWith(color: Theme.of(context).colorScheme.primary)),
-          Text(whoUpdated, style: Theme.of(context).textTheme.bodyLarge),
-          const SizedBox(width: 8.0),
-          Text(whenUpdated, style: Theme.of(context).textTheme.bodySmall)
-        ],
-      ),
+    return Row(
+      children: [
+        Text(updatedBy, style: Theme.of(context).textTheme.bodySmall),
+        Text(whoUpdated, style: Theme.of(context).textTheme.bodyLarge),
+        const SizedBox(width: 8.0),
+        Text(whenUpdated, style: Theme.of(context).textTheme.bodySmall)
+      ],
     );
   }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/lock_unlock_switch.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/lock_unlock_switch.dart
@@ -16,11 +16,13 @@ class LockUnlockSwitch extends StatefulWidget {
 
 class _LockUnlockSwitchState extends State<LockUnlockSwitch> {
   bool _locked = false;
+  bool _initiallyLocked = false;
 
   @override
   void initState() {
     super.initState();
-    _locked = widget.fvBloc.currentFeatureValue.locked;
+    _initiallyLocked = widget.fvBloc.currentFeatureValue.locked;
+    _locked = _initiallyLocked;
   }
 
   @override
@@ -35,33 +37,42 @@ class _LockUnlockSwitchState extends State<LockUnlockSwitch> {
       children: <Widget>[
         Row(
           children: [
-            Material(
-              child: IconButton(
-                splashRadius: 20,
-                mouseCursor: disabled
-                    ? SystemMouseCursors.basic
-                    : SystemMouseCursors.click,
-                tooltip: disabled
-                    ? null
-                    : (_locked
-                        ? 'Click the lock to make changes'
-                        : 'Click the lock to prevent further changes'),
-                icon: Icon(_locked ? Icons.lock_outline : Icons.lock_open,
-                    size: 20, color: _locked ? Colors.orange : Colors.green),
-                onPressed: disabled
-                    ? null
-                    : () {
-                        setState(() {
-                          _locked = !_locked;
-                        });
-                        widget.fvBloc.updateFeatureValueLockedStatus(_locked);
-                      },
-              ),
+            IconButton.outlined(
+              tooltip: disabled ||
+                      (_initiallyLocked &&
+                          !_locked) // lock/unlock button will not be displayed if feature value was locked and is set to unlocked by user
+                  // - this is to prevent user sending "locked" to the already "locked" feature)
+                  ? null
+                  : (_locked ? 'Click to unlock' : 'Click to lock'),
+              icon: Icon(_locked ? Icons.lock_outline : Icons.lock_open,
+                  size: 20, color: _locked ? Colors.orange : Colors.green),
+              onPressed: disabled || (_initiallyLocked && !_locked)
+                  ? null
+                  : () {
+                      setState(() {
+                        _locked = !_locked;
+                      });
+                      widget.fvBloc.updateFeatureValueLockedStatus(_locked);
+                    },
             ),
-            Text(
-              _locked ? 'Locked' : 'Unlocked',
-              style: Theme.of(context).textTheme.bodySmall,
-            )
+            const SizedBox(
+              width: 8.0,
+            ),
+            _locked
+                ? Text(
+                    'Feature is locked and cannot be changed',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Colors.orange),
+                  )
+                : Text(
+                    'Feature is unlocked and can be changed',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Colors.green),
+                  )
           ],
         )
       ],

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/split_add.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/split_add.dart
@@ -10,33 +10,29 @@ import 'package:open_admin_app/widgets/strategyeditor/strategy_editing_widget.da
 class AddStrategyButton extends StatelessWidget {
   final EditingFeatureValueBloc bloc;
 
-  const AddStrategyButton(
-      {Key? key, required this.bloc})
-      : super(key: key);
+  const AddStrategyButton({Key? key, required this.bloc}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return TextButton.icon(
-        label: const Text('Add split targeting rules'),
+        label: const Text('Add rollout strategy'),
         icon: const Icon(Icons.call_split_outlined),
-        onPressed:() => showDialog(
-                context: context,
-                builder: (_) {
-                  return AlertDialog(
-                    title: const Text('Add split targeting rule'),
-                    content: BlocProvider.builder(
-                      creator: (c, b) =>
-                          StrategyEditorBloc(
-                              EditingRolloutStrategy.newStrategy(
-                                  id: makeStrategyId(existing: bloc.featureValue.rolloutStrategies!)),
-                              FeatureValueStrategyProvider(bloc)),
-                      builder: (ctx, bloc) {
-                        return StrategyEditingWidget(
-                            bloc: bloc, editable: true);
-                      },
-                    ),
-                  );
-                })
-            );
+        onPressed: () => showDialog(
+            context: context,
+            builder: (_) {
+              return AlertDialog(
+                title: const Text('Add rollout strategy targeting rules'),
+                content: BlocProvider.builder(
+                  creator: (c, b) => StrategyEditorBloc(
+                      EditingRolloutStrategy.newStrategy(
+                          id: makeStrategyId(
+                              existing: bloc.featureValue.rolloutStrategies!)),
+                      FeatureValueStrategyProvider(bloc)),
+                  builder: (ctx, bloc) {
+                    return StrategyEditingWidget(bloc: bloc, editable: true);
+                  },
+                ),
+              );
+            }));
   }
 }

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/strategy_card_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/strategies/strategy_card_widget.dart
@@ -42,7 +42,7 @@ class StrategyCardWidget extends StatelessWidget {
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Expanded(
-                      flex: 3,
+                      flex: 2,
                       child: groupRolloutStrategy != null
                           ? Text(groupRolloutStrategy!.name,
                               maxLines: 2,
@@ -59,9 +59,9 @@ class StrategyCardWidget extends StatelessWidget {
                                   overflow: TextOverflow.ellipsis,
                                   style:
                                       Theme.of(context).textTheme.labelLarge))),
-                  Flexible(flex: 6, child: editableHolderWidget),
+                  Flexible(flex: 3, child: editableHolderWidget),
                   Expanded(
-                      flex: 3,
+                      flex: 1,
                       child: rolloutStrategy != null &&
                               groupRolloutStrategy == null
                           ? Row(

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_json_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_json_value_container.dart
@@ -69,7 +69,7 @@ class _EditJsonValueContainerState extends State<EditJsonValueContainer> {
     }
 
     return SizedBox(
-      width: 200,
+      width: 250,
       height: 30,
       child: InkWell(
         canRequestFocus: false,

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_number_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_number_value_container.dart
@@ -45,7 +45,7 @@ class _EditNumberValueContainerState extends State<EditNumberValueContainer> {
     final debouncer = Debouncer(milliseconds: 1000);
 
     return SizedBox(
-        width: 200,
+        width: 250,
         height: 36,
         child: TextField(
           style: Theme.of(context).textTheme.bodyLarge,

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_number_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_number_value_container.dart
@@ -63,11 +63,13 @@ class _EditNumberValueContainerState extends State<EditNumberValueContainer> {
                 borderSide: BorderSide(
               color: Colors.grey,
             )),
-            hintText: widget.canEdit
-                ? widget.unlocked
-                    ? 'Enter number value'
-                    : 'Unlock to edit'
-                : 'No editing rights',
+            hintText: widget.groupRolloutStrategy == null
+                ? (widget.canEdit
+                    ? (widget.unlocked
+                        ? 'Enter number value'
+                        : 'Unlock to edit')
+                    : 'No editing rights')
+                : 'not set',
             hintStyle: Theme.of(context).textTheme.bodySmall,
             errorText:
                 validateNumber(tec.text) != null ? 'Not a valid number' : null,

--- a/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_string_value_container.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/edit-feature-value/valueeditors/edit_string_value_container.dart
@@ -44,7 +44,7 @@ class _EditStringValueContainerState extends State<EditStringValueContainer> {
     final debouncer = Debouncer(milliseconds: 1000);
 
     return SizedBox(
-        width: 200,
+        width: 250,
         height: 36,
         child: TextField(
           style: Theme.of(context).textTheme.bodyLarge,

--- a/admin-frontend/open_admin_app/lib/widgets/strategyeditor/editing_rollout_strategy.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/strategyeditor/editing_rollout_strategy.dart
@@ -28,46 +28,71 @@ class EditingRolloutStrategyAttribute {
   /* A temporary id used only when validating. Saving strips these out as they are not otherwise necessary */
   String id;
 
-
   @override
   String toString() {
     return "ersa: field $fieldName, values: $values, type: $type, id: $id, conditional: $conditional";
   }
 
-  EditingRolloutStrategyAttribute({
-      this.conditional, this.fieldName, required this.values, this.type, required this.id});
+  EditingRolloutStrategyAttribute(
+      {this.conditional,
+      this.fieldName,
+      required this.values,
+      this.type,
+      required this.id});
 
   RolloutStrategyAttribute? toRolloutStrategyAttribute() {
     if (conditional == null || fieldName == null || type == null) return null;
-    return RolloutStrategyAttribute(conditional: conditional!, fieldName: fieldName!, type: type!, id: id, values: values);
+    return RolloutStrategyAttribute(
+        conditional: conditional!,
+        fieldName: fieldName!,
+        type: type!,
+        id: id,
+        values: values);
   }
 
   EditingRolloutStrategyAttribute copy() {
-    return EditingRolloutStrategyAttribute(conditional: conditional, fieldName: fieldName, values: values.toList(), type: type, id: id);
+    return EditingRolloutStrategyAttribute(
+        conditional: conditional,
+        fieldName: fieldName,
+        values: values.toList(),
+        type: type,
+        id: id);
   }
 
   List<RolloutStrategyViolation> violations() {
     final violations = <RolloutStrategyViolation>[];
 
     if (fieldName == null) {
-      violations.add(RolloutStrategyViolation(violation:  RolloutStrategyViolationType.attrMissingFieldName, id: id));
+      violations.add(RolloutStrategyViolation(
+          violation: RolloutStrategyViolationType.attrMissingFieldName,
+          id: id));
     }
     if (conditional == null) {
-      violations.add(RolloutStrategyViolation(violation:  RolloutStrategyViolationType.attrMissingConditional, id: id));
+      violations.add(RolloutStrategyViolation(
+          violation: RolloutStrategyViolationType.attrMissingConditional,
+          id: id));
     }
     if (type == null) {
-      violations.add(RolloutStrategyViolation(violation:  RolloutStrategyViolationType.attrMissingFieldType, id: id));
+      violations.add(RolloutStrategyViolation(
+          violation: RolloutStrategyViolationType.attrMissingFieldType,
+          id: id));
     }
     if (values.isEmpty) {
-      violations.add(RolloutStrategyViolation(violation:  RolloutStrategyViolationType.attrMissingValue, id: id));
+      violations.add(RolloutStrategyViolation(
+          violation: RolloutStrategyViolationType.attrMissingValue, id: id));
     }
 
     return violations;
   }
 
-
-  static EditingRolloutStrategyAttribute fromRolloutStrategyAttribute(RolloutStrategyAttribute rsa) {
-    return EditingRolloutStrategyAttribute(values: rsa.values, conditional: rsa.conditional, fieldName: rsa.fieldName, type: rsa.type, id: rsa.id!);
+  static EditingRolloutStrategyAttribute fromRolloutStrategyAttribute(
+      RolloutStrategyAttribute rsa) {
+    return EditingRolloutStrategyAttribute(
+        values: [...rsa.values],
+        conditional: rsa.conditional,
+        fieldName: rsa.fieldName,
+        type: rsa.type,
+        id: rsa.id!);
   }
 }
 
@@ -84,8 +109,13 @@ class EditingRolloutStrategy {
 
   bool saved;
 
-  EditingRolloutStrategy({required this.id, required this.saved, this.percentage, this.percentageAttributes,
-      required this.attributes, this.name});
+  EditingRolloutStrategy(
+      {required this.id,
+      required this.saved,
+      this.percentage,
+      this.percentageAttributes,
+      required this.attributes,
+      this.name});
 
   double get maxPercentage => 1000000.0;
   double get percentageMultiplier => maxPercentage / 100.0;
@@ -97,7 +127,6 @@ class EditingRolloutStrategy {
   String get percentageText =>
       percentage == null ? '' : (percentage! / percentageMultiplier).toString();
 
-
   @override
   String toString() {
     return "name: $name, id: $id, percentage $percentage, percentage attr: $percentageAttributes, $attributes";
@@ -107,52 +136,97 @@ class EditingRolloutStrategy {
     return EditingRolloutStrategy(
         id: rs.id!,
         saved: true,
-        percentage: rs.percentage, percentageAttributes: rs.percentageAttributes,
+        percentage: rs.percentage,
+        percentageAttributes: rs.percentageAttributes,
         name: rs.name,
-        attributes: (rs.attributes ?? []).map((e) => EditingRolloutStrategyAttribute.fromRolloutStrategyAttribute(e)).toList()
-    );
+        attributes: (rs.attributes ?? [])
+            .map((e) =>
+                EditingRolloutStrategyAttribute.fromRolloutStrategyAttribute(e))
+            .toList());
   }
 
   RolloutStrategy? toRolloutStrategy(dynamic value) {
-    if (name == null || attributes.any((rsa) => rsa.toRolloutStrategyAttribute() == null)) return null;
-    return RolloutStrategy(id: id, name: name!, value: value, percentage: percentage, percentageAttributes: percentageAttributes, attributes: attributes.map((e) => e.toRolloutStrategyAttribute()!).toList());
+    if (name == null ||
+        attributes.any((rsa) => rsa.toRolloutStrategyAttribute() == null))
+      return null;
+    return RolloutStrategy(
+        id: id,
+        name: name!,
+        value: value,
+        percentage: percentage,
+        percentageAttributes: percentageAttributes,
+        attributes:
+            attributes.map((e) => e.toRolloutStrategyAttribute()!).toList());
   }
 
-  EditingRolloutStrategy copy({String? id, int? percentage, List<String>? percentageAttributes,
-    dynamic value, List<EditingRolloutStrategyAttribute>? attributes, String? name}) {
-    return EditingRolloutStrategy(id: id ?? this.id, saved: saved, attributes: (attributes ?? this.attributes).map((e) => e.copy()).toList(),
-        percentage: percentage ?? this.percentage, percentageAttributes: percentageAttributes ?? this.percentageAttributes, name: name ?? this.name);
+  EditingRolloutStrategy copy(
+      {String? id,
+      int? percentage,
+      List<String>? percentageAttributes,
+      dynamic value,
+      List<EditingRolloutStrategyAttribute>? attributes,
+      String? name}) {
+    return EditingRolloutStrategy(
+        id: id ?? this.id,
+        saved: saved,
+        attributes:
+            (attributes ?? this.attributes).map((e) => e.copy()).toList(),
+        percentage: percentage ?? this.percentage,
+        percentageAttributes: percentageAttributes ?? this.percentageAttributes,
+        name: name ?? this.name);
   }
 
   List<RolloutStrategyViolation> violations() {
     final violations = <RolloutStrategyViolation>[];
 
     if (name == null) {
-      violations.add(RolloutStrategyViolation(violation:  RolloutStrategyViolationType.noName));
+      violations.add(RolloutStrategyViolation(
+          violation: RolloutStrategyViolationType.noName));
     }
 
-    for (var rsa in attributes) { violations.addAll(rsa.violations()); }
+    for (var rsa in attributes) {
+      violations.addAll(rsa.violations());
+    }
 
     return violations;
   }
 
-  static EditingRolloutStrategy fromGroupRolloutStrategy(GroupRolloutStrategy rs, dynamic value) {
+  static EditingRolloutStrategy fromGroupRolloutStrategy(
+      GroupRolloutStrategy rs, dynamic value) {
     return EditingRolloutStrategy(
         id: rs.id!,
         saved: true,
-        percentage: rs.percentage, percentageAttributes: rs.percentageAttributes,
+        percentage: rs.percentage,
+        percentageAttributes: rs.percentageAttributes,
         name: rs.name,
-        attributes: (rs.attributes ?? []).map((e) => EditingRolloutStrategyAttribute.fromRolloutStrategyAttribute(e)).toList()
-    );
+        attributes: (rs.attributes ?? [])
+            .map((e) =>
+                EditingRolloutStrategyAttribute.fromRolloutStrategyAttribute(e))
+            .toList());
   }
 
   GroupRolloutStrategy? toGroupRolloutStrategy() {
-    return GroupRolloutStrategy(name: name!, id: id, percentage: percentage, percentageAttributes: percentageAttributes, attributes: attributes.map((e) => e.toRolloutStrategyAttribute()!).toList());
+    return GroupRolloutStrategy(
+        name: name!,
+        id: id,
+        percentage: percentage,
+        percentageAttributes: percentageAttributes,
+        attributes:
+            attributes.map((e) => e.toRolloutStrategyAttribute()!).toList());
   }
 
-  static EditingRolloutStrategy newStrategy({int? percentage, String? id, List<String>? percentageAttributes,
-    List<EditingRolloutStrategyAttribute>? attributes, String? name}) {
-    return EditingRolloutStrategy(id: id ?? makeStrategyId(), saved: false, attributes: attributes ?? [],
-        name: name, percentageAttributes: percentageAttributes, percentage: percentage);
+  static EditingRolloutStrategy newStrategy(
+      {int? percentage,
+      String? id,
+      List<String>? percentageAttributes,
+      List<EditingRolloutStrategyAttribute>? attributes,
+      String? name}) {
+    return EditingRolloutStrategy(
+        id: id ?? makeStrategyId(),
+        saved: false,
+        attributes: attributes ?? [],
+        name: name,
+        percentageAttributes: percentageAttributes,
+        percentage: percentage);
   }
 }

--- a/docs/modules/ROOT/pages/features.adoc
+++ b/docs/modules/ROOT/pages/features.adoc
@@ -47,8 +47,8 @@ image::fh_retire_feature.png[Retire Feature, 1500]
 
 
 == Locking a feature
-Locking provides an additional safety net per environment when deploying incomplete code into production. It locks a feature, so its value, targeting rules, "retired" statues can't be changed for a given environment.
-Typically, developers keep features locked until they are finished and ready to be set, for example when they are ready to be tested in one of the test environments. Another use case for feature locking would be when developers or testers keep it locked in production environment, indicating to release management team that it is not ready to be turned on. Only groups or service accounts with `LOCK/UNLOCK` or `CHANGE_VALUE` permission can lock or unlock the feature value.  `CHANGE_VALUE` permission supersedes the `LOCK/UNLOCK`.
+Locking provides an additional safety net for a feature changes per environment when deploying incomplete code into production. It locks a feature, to prevent any changes to its default value, strategies, strategy values or "retired" status, for a given environment.
+Typically, developers keep features locked until they are finished and ready to be used, for example when they are ready to be tested in one of the test environments. Another use case for feature locking would be when developers or testers keep it locked in production environment, indicating to release management team that it is not ready to be turned on. Only groups or service accounts with `LOCK/UNLOCK` or `CHANGE_VALUE` permission can lock or unlock the feature value.  `CHANGE_VALUE` permission supersedes the `LOCK/UNLOCK`.
 
 image::fh_lock_feature.png[Lock Feature, 1500]
 


### PR DESCRIPTION
# Description

Improvements around layout and UI in the feature editing side sheet. Also includes a fix for #1094

Fixes #1094

Fixes an issue where cancelling edits on the strategy would not reset the values back to the original

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

UI tests