### PR TITLE
fix: update UI to make searching for features nicer

### DIFF
--- a/adks/e2e-sdk/features/demo-feature.feature
+++ b/adks/e2e-sdk/features/demo-feature.feature
@@ -1,0 +1,30 @@
+Feature: support for creating data for use in diagnosing issues
+
+  @demo-two-apps
+  Scenario: I create a Portfolio with 2 applications and several flags
+    Given I create a new portfolio
+    And I create a new feature filter called "client"
+    And I create a new feature filter called "server"
+    And I create a new feature filter called "marketing"
+    And I create a new feature filter called "billing"
+    And I create an application "char-siu"
+    When I create a feature flag "uppercase_text" with the filters "client,server"
+    When I create a feature flag "jira-1-flag" with the filters "client"
+    When I create a feature flag "jira-2-flag" with the filters "client"
+    When I create a feature flag "jira-3-flag" with the filters "client"
+    When I create a feature flag "jira-33-flag" with the filters "client,server"
+    When I create a feature flag "jira-4-flag" with the filters "client"
+    When I create a feature flag "jira-5-flag" with the filters "client"
+    When I create a feature flag "jira-6-flag" with the filters "client"
+    When I create a feature flag "jira-66-flag" with the filters "client"
+    And I create an application "tofu"
+    When I create a feature flag "uppercase_text" with the filters "marketing,server"
+    When I create a feature flag "gyro-1-flag" with the filters "marketing"
+    When I create a feature flag "gyro-2-flag" with the filters "marketing"
+    When I create a feature flag "gyro-3-flag" with the filters "marketing"
+    When I create a feature flag "gyro-33-flag" with the filters "marketing,server"
+    When I create a feature flag "gyro-4-flag" with the filters "marketing"
+    When I create a feature flag "gyro-5-flag" with the filters "marketing"
+    When I create a feature flag "gyro-6-flag" with the filters "marketing"
+    When I create a feature flag "gyro-66-flag" with the filters "marketing"
+

--- a/admin-frontend/open_admin_app/lib/widgets/features/feature-data-table/features_data_table.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/features/feature-data-table/features_data_table.dart
@@ -27,13 +27,13 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
   late FeaturesDataSource _featuresDataSource;
   List<FeatureStatusFeatures> featuresList = [];
 
-  String _searchTerm = '';
   int _maxFeatures = 0;
   int _pageIndex = 0;
   List<FeatureValueType> _selectedFeatureTypes = [];
   List<String> _selectedEnvironmentList = [];
   List<String> _selectedFeatureFilterIds = [];
   final CustomColumnSizer _customColumnSizer = CustomColumnSizer();
+  final TextEditingController _searchTermController = TextEditingController(text: '');
   late FeatureFilterBloc _filterBloc;
 
   @override
@@ -51,7 +51,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
           _selectedFeatureTypes = bloc.selectedFeatureTypesByUser;
           _selectedFeatureFilterIds = bloc.selectedFeatureFilterIdsByUser;
           _featuresDataSource = FeaturesDataSource(featuresList, bloc,
-              _searchTerm, _selectedFeatureTypes, bloc.currentRowsPerPage);
+              _searchTermController.text, _selectedFeatureTypes, bloc.currentRowsPerPage);
           _maxFeatures = features.applicationFeatureValues.maxFeatures;
           _pageIndex = bloc.currentPageIndex - 1;
         });
@@ -99,7 +99,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
             _featuresDataSource = FeaturesDataSource(
                 featuresList,
                 widget.bloc,
-                _searchTerm,
+                _searchTermController.text,
                 _selectedFeatureTypes,
                 widget.bloc.currentRowsPerPage);
             _maxFeatures = snapshot.data!.applicationFeatureValues.maxFeatures;
@@ -119,7 +119,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                       children: [
                         Container(
                           constraints: const BoxConstraints(
-                              maxWidth: 400, maxHeight: 40),
+                              maxWidth: 400, maxHeight: 45),
                           child: FHMultiSelect(
                               hint: Text(AppLocalizations.of(context)!.selectEnvironmentsToDisplay,
                                   style:
@@ -146,7 +146,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                         Container(
                           constraints: const BoxConstraints(
                             maxWidth: 300,
-                            maxHeight: 40,
+                            maxHeight: 45,
                             minWidth: 30,
                           ),
                           child: FHMultiSelect(
@@ -164,7 +164,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                               });
                               widget.bloc.getApplicationFeatureValuesData(
                                   widget.bloc.applicationId!,
-                                  _searchTerm,
+                                  _searchTermController.text,
                                   _selectedFeatureTypes,
                                   widget.bloc.currentRowsPerPage,
                                   _pageIndex,
@@ -189,7 +189,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                             return Container(
                               constraints: const BoxConstraints(
                                 maxWidth: 300,
-                                maxHeight: 40,
+                                maxHeight: 45,
                                 minWidth: 30,
                               ),
                               child: FHMultiSelect<SearchFeatureFilterItem>(
@@ -213,7 +213,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                                   });
                                   widget.bloc.getApplicationFeatureValuesData(
                                       widget.bloc.applicationId!,
-                                      _searchTerm,
+                                      _searchTermController.text,
                                       _selectedFeatureTypes,
                                       widget.bloc.currentRowsPerPage,
                                       _pageIndex,
@@ -225,26 +225,29 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                         ),
                         Container(
                           constraints: const BoxConstraints(
-                              maxWidth: 300, minWidth: 150, maxHeight: 40),
+                              maxWidth: 300, minWidth: 150),
                           child: TextField(
+                            minLines: 1,
+                            maxLines: 1,
+                            controller: _searchTermController,
                             decoration: InputDecoration(
+                              isDense: true,
                               hintText: AppLocalizations.of(context)!.searchFeatures,
                               hintStyle: Theme.of(context).textTheme.bodyMedium,
-                              suffixIcon: const Icon(Icons.search, size: 18),
+                                suffixIcon: _searchTermController.text.isEmpty
+                                    ? const Icon(Icons.search, size: 18) // show search if empty
+                                    : IconButton(
+                                  icon: Icon(Icons.clear),
+                                  onPressed: () {
+                                    _searchTermController.clear();
+                                    _bounceSearchTerm();
+                                  },
+                                ),
                               border: const OutlineInputBorder(),
                             ),
                             onChanged: (val) {
                               debouncer.run(() {
-                                setState(() {
-                                  _searchTerm = val;
-                                  widget.bloc.getApplicationFeatureValuesData(
-                                      widget.bloc.applicationId!,
-                                      _searchTerm,
-                                      _selectedFeatureTypes,
-                                      widget.bloc.currentRowsPerPage,
-                                      _pageIndex,
-                                      featureFilterIds: _selectedFeatureFilterIds);
-                                });
+                                _bounceSearchTerm();
                               });
                             },
                           ),
@@ -310,7 +313,7 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
                           widget.bloc.currentRowsPerPage = rpp!;
                           widget.bloc.getApplicationFeatureValuesData(
                               widget.bloc.applicationId!,
-                              _searchTerm,
+                              _searchTermController.text,
                               _selectedFeatureTypes,
                               widget.bloc.currentRowsPerPage,
                               _pageIndex);
@@ -329,6 +332,24 @@ class FeaturesDataTableState extends State<FeaturesDataTable> {
             );
           }
         });
+  }
+
+  void _bounceSearchTerm() {
+    setState(() {
+      widget.bloc.getApplicationFeatureValuesData(
+          widget.bloc.applicationId!,
+          _searchTermController.text,
+          _selectedFeatureTypes,
+          widget.bloc.currentRowsPerPage,
+          _pageIndex,
+          featureFilterIds: _selectedFeatureFilterIds);
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchTermController.dispose();
+    super.dispose();
   }
 }
 


### PR DESCRIPTION
# Description

Initially the experience of swapping between feature searching and between applications once you had searched for a feature was a bit awkward. The desire was to clear the field once you swapped Applications, but a better solution was to make the clearing easy if you want it and follow better UI standards around this.

- replaces the search icon with an X when there is text, leaves search icon when empty
- hint text provides information it is a search field but Irina may want to keep a fixed search icon near it
- allows for easy clearing of a field
- makes the field more dense and increase available space so that when the text of the search gets long it doesn't cut off.

