### PR TITLE
fixing group editing to show superusers cannot be removed from the portfolio admin group

### DIFF
--- a/adks/e2e-sdk/app/steps/dashboard.ts
+++ b/adks/e2e-sdk/app/steps/dashboard.ts
@@ -1,0 +1,17 @@
+import {Then, When} from "@cucumber/cucumber";
+import {SdkWorld} from "../support/world";
+import {expect} from "chai";
+
+When('I ask for the feature dashboard', async function() {
+  const world = this as SdkWorld;
+  expect(world.application.environments.length, `Application ${world.application.name} has no environments`).to.be.gt(0);
+  const data = await world.featureApi.findAllFeatureAndFeatureValuesForEnvironmentsByApplication(world.application.id, world.application.environments.map(e => e.id));
+  expect(data.status).to.eq(200);
+  world.dashboard = data.data;
+});
+
+Then('I should see an empty list of features and {int} environment', async function (envCount: number) {
+  const world = this as SdkWorld;
+  expect(world.dashboard.environments.length).to.eq(1);
+  expect(world.dashboard.features.length).to.eq(0);
+});

--- a/adks/e2e-sdk/app/steps/group.ts
+++ b/adks/e2e-sdk/app/steps/group.ts
@@ -52,22 +52,40 @@ When('I assign the superuser to the group', async function() {
   expect(response.data.members.find( p => p.id.id === userId)).to.not.be.undefined;
 });
 
-Then('I can delete the supergroup from the group', async function() {
+Then('I cannot delete the superuser from the group', async function() {
   const world = this as SdkWorld;
   const userResponse = await world.superuser.personApi.getPerson("self");
   const userId = (userResponse.data as Person).id.id;
-  const response = await world.superuser.groupApi.deletePersonFromGroup(world.group.id, userId, true);
-  expect(response.status).to.eq(200);
-  expect(response.data.members.find( p => p.id.id === userId)).to.be.undefined;
+  try {
+    await world.superuser.groupApi.deletePersonFromGroup(world.group.id, userId, false);
+    expect(true, `call succeeded to delete supergroup from portfolio group but should not have`).to.be.false;
+  } catch (e) {
+    expect(e.response.status).to.eq(404);
+  }
 });
 
-Then(/^the (superuser|user) is marked in the group as a (superuser|user)$/, async function(userSource: string, userType: string) {
+Then(/^the (superuser|user) (is|is not) in the group as a (superuser|user)$/, async function(userSource: string, isRule: string, userType: string) {
   const world = this as SdkWorld;
   const user = (userSource === 'superuser') ? world.superuser : world.user;
   expect(user.me).to.not.be.undefined;
   expect(world.group).to.not.be.undefined;
-  const suserValue = userType === 'superuser';
-  expect(world.group.sMembers.find(p => p.superuser === suserValue && p.person.id === user.personId))
+
+  const foundSuperuser = world.group.superMembers.find(p => p === user.personId);
+  const found = world.group.simpleMembers.find(p => p.id === user.personId);
+
+  if (userType === 'superuser') {
+    if (isRule === 'is') {
+      expect(foundSuperuser, `${userSource} not superuser in group ${world.group.name}`).to.not.be.undefined;
+    } else { // is not
+      expect(foundSuperuser, `${userSource} not superuser in in group ${world.group.name}`).to.be.undefined;
+    }
+  } else {
+    if (isRule === 'is') {
+      expect(found, `${userSource} in group ${world.group.name} and is not`).to.not.be.undefined;
+    } else { // is not
+      expect(found, `${userSource} in group ${world.group.name} and should not be`).to.be.undefined;
+    }
+  }
 });
 
 Then('I assign the new user to the new group', async function() {

--- a/adks/e2e-sdk/app/steps/group.ts
+++ b/adks/e2e-sdk/app/steps/group.ts
@@ -22,7 +22,8 @@ When('I get the portfolio admin group', async function() {
   const groups = await world.superuser.groupApi.findGroups(world.portfolio.id);
   const adminGroup = groups.data.find(g => g.admin);
   expect(adminGroup, `${JSON.stringify(groups.data)} - could not find admin group!`).to.not.be.undefined;
-  world.group = adminGroup;
+  const fullGroup = await world.superuser.groupApi.getGroup(adminGroup.id, false, true);
+  world.group = fullGroup.data;
 });
 
 When('I create a new group with application roles {string}', async function(roles: string) {
@@ -39,6 +40,34 @@ When('I create a new group with application roles {string}', async function(role
 
   expect(response.status).to.eq(200);
   world.group = response.data;
+});
+
+When('I assign the superuser to the group', async function() {
+  const world = this as SdkWorld;
+  const userResponse = await world.superuser.personApi.getPerson("self");
+  const userId = (userResponse.data as Person).id.id;
+  const response = await world.superuser.groupApi.addPersonToGroup(world.group.id,
+    userId, true);
+  expect(response.status).to.eq(200);
+  expect(response.data.members.find( p => p.id.id === userId)).to.not.be.undefined;
+});
+
+Then('I can delete the supergroup from the group', async function() {
+  const world = this as SdkWorld;
+  const userResponse = await world.superuser.personApi.getPerson("self");
+  const userId = (userResponse.data as Person).id.id;
+  const response = await world.superuser.groupApi.deletePersonFromGroup(world.group.id, userId, true);
+  expect(response.status).to.eq(200);
+  expect(response.data.members.find( p => p.id.id === userId)).to.be.undefined;
+});
+
+Then(/^the (superuser|user) is marked in the group as a (superuser|user)$/, async function(userSource: string, userType: string) {
+  const world = this as SdkWorld;
+  const user = (userSource === 'superuser') ? world.superuser : world.user;
+  expect(user.me).to.not.be.undefined;
+  expect(world.group).to.not.be.undefined;
+  const suserValue = userType === 'superuser';
+  expect(world.group.sMembers.find(p => p.superuser === suserValue && p.person.id === user.personId))
 });
 
 Then('I assign the new user to the new group', async function() {

--- a/adks/e2e-sdk/app/steps/setup.ts
+++ b/adks/e2e-sdk/app/steps/setup.ts
@@ -1,14 +1,11 @@
 import {expect} from 'chai';
 import {Given, Then, When} from '@cucumber/cucumber';
 import {
-  Application, CreateApplication,
+  CreateApplication,
   CreatePortfolio,
   Environment,
   PortfolioServiceApi,
-  RoleType,
-  ServiceAccount,
   ServiceAccountPermission,
-  ServiceAccountServiceApi,
   UpdateEnvironment
 } from '../apis/mr-service';
 import {makeid, sleep} from '../support/random';

--- a/adks/e2e-sdk/app/support/world.ts
+++ b/adks/e2e-sdk/app/support/world.ts
@@ -1,6 +1,6 @@
 import {setDefaultTimeout, setWorldConstructor, World} from '@cucumber/cucumber';
 import {
-  Application,
+  Application, ApplicationFeatureValues,
   ApplicationRolloutStrategyServiceApi,
   ApplicationServiceApi,
   AuthServiceApi,
@@ -69,6 +69,7 @@ export class ApiUser {
   public readonly applicationStrategyApi: ApplicationRolloutStrategyServiceApi;
   public readonly featureFilterApi: FeatureFilterServiceApi;
   public readonly apiKey: string;
+  public me: Person;
 
   public serviceAccounts: Array<ServiceAccount> = [];
 
@@ -80,6 +81,7 @@ export class ApiUser {
 
     this.portfolioApi = new PortfolioServiceApi(this.adminApiConfig);
     this.personApi = new PersonServiceApi(this.adminApiConfig);
+
     this.applicationApi = new ApplicationServiceApi(this.adminApiConfig);
     this.environmentApi = new EnvironmentServiceApi(this.adminApiConfig);
     this.environment2Api = new Environment2ServiceApi(this.adminApiConfig);
@@ -97,7 +99,21 @@ export class ApiUser {
     this.applicationStrategyApi = new ApplicationRolloutStrategyServiceApi(this.adminApiConfig);
     this.featureHistoryApi = new FeatureHistoryServiceApi(this.adminApiConfig);
     this.featureFilterApi = new FeatureFilterServiceApi(this.adminApiConfig);
+
+    if (apiKey) {
+      this.refreshPerson();
+    }
   }
+
+  public refreshPerson() {
+    this.personApi.getPerson('self').then((person) => {
+      this.me = person.data;
+    }).catch((_) => {
+
+    });
+  }
+
+  public get personId() { return this.me.id.id; }
 }
 
 export class SdkWorld extends World {
@@ -129,6 +145,7 @@ export class SdkWorld extends World {
   public readonly superuser: ApiUser;
   public user: ApiUser | undefined;
   public currentUser: ApiUser;
+  public dashboard: ApplicationFeatureValues | undefined;
 
   constructor(props: any) {
     super(props);
@@ -269,6 +286,8 @@ export class SdkWorld extends World {
 
   public set apiKey(val: TokenizedPerson) {
     this.adminApiConfig.accessToken = val.accessToken;
+    this.superuser.refreshPerson();
+    this.superuser.me = val.person;
     this.person = val.person;
     apiKey = val.accessToken;
     logger.info('Successfully logged in');

--- a/adks/e2e-sdk/features/permission-check.feature
+++ b/adks/e2e-sdk/features/permission-check.feature
@@ -8,12 +8,13 @@ Feature: Certain permission combinations should work as expected
     And I create a new user
     And I assign the new user to the new group
     And I get the portfolio admin group
-    And the superuser is marked in the group as a superuser
-    And the user is marked in the group as a user
+    And the superuser is in the group as a superuser
+    And the superuser is in the group as a user
+    And the user is in the group as a user
+    And the user is not in the group as a superuser
 
   @delete-superuser-from-group
   Scenario: I add the superuser to the portfolio admin group and then remove them
     Given I create a new portfolio
     And I get the portfolio admin group
-    When I assign the superuser to the group
-    Then I can delete the supergroup from the group
+    Then I cannot delete the superuser from the group

--- a/adks/e2e-sdk/features/permission-check.feature
+++ b/adks/e2e-sdk/features/permission-check.feature
@@ -1,0 +1,19 @@
+@allvariants @streamingvariants
+Feature: Certain permission combinations should work as expected
+
+  @portfolio-group
+  Scenario: The group should be able to identify who is a superuser and who is not
+    Given I create a new portfolio
+    And I get the portfolio admin group
+    And I create a new user
+    And I assign the new user to the new group
+    And I get the portfolio admin group
+    And the superuser is marked in the group as a superuser
+    And the user is marked in the group as a user
+
+  @delete-superuser-from-group
+  Scenario: I add the superuser to the portfolio admin group and then remove them
+    Given I create a new portfolio
+    And I get the portfolio admin group
+    When I assign the superuser to the group
+    Then I can delete the supergroup from the group

--- a/adks/e2e-sdk/package.json
+++ b/adks/e2e-sdk/package.json
@@ -19,7 +19,7 @@
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.0",
     "@types/triple-beam": "^1.3.2",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "chai": "^4.3.7",
     "cloudevents": "^8.0.0",
     "express": "^5.1.0",

--- a/adks/e2e-sdk/pnpm-lock.yaml
+++ b/adks/e2e-sdk/pnpm-lock.yaml
@@ -8,11 +8,15 @@ overrides:
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   diff@>=4.0.0 <4.0.4: '>=4.0.4'
+  fast-uri@<=3.1.0: ^3.1.1
+  fast-uri@<=3.1.1: ^3.1.2
+  follow-redirects@<=1.15.11: ^1.15.12
   minimatch@>=10.0.0 <10.2.1: '>=10.2.1'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
   path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
   qs@<6.14.1: '>=6.14.1'
   qs@>=6.7.0 <=6.14.1: '>=6.14.2'
+  uuid@>=11.0.0 <11.1.1: ^11.1.1
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
 
 importers:
@@ -507,8 +511,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   featurehub-cloud-event-tools@1.0.0:
     resolution: {integrity: sha512-5Vxtd0MmnXGyFgb67t7WQVME3ANlfLKcuHDqXET3XUqqAI9QMwvoKt2A8C7kzb57P7PWCesB4fJk26148Aw8lw==}
@@ -539,8 +543,8 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -794,6 +798,7 @@ packages:
   nats@2.29.3:
     resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
     engines: {node: '>= 14.0.0'}
+    deprecated: Package moved. Use @nats-io/transport-node from https://github.com/nats-io/nats.js
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -1138,12 +1143,13 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -1303,7 +1309,7 @@ snapshots:
       '@types/uuid': 10.0.0
       class-transformer: 0.5.1
       reflect-metadata: 0.2.2
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   '@cucumber/messages@29.0.1':
     dependencies:
@@ -1429,7 +1435,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1465,7 +1471,7 @@ snapshots:
 
   axios@1.15.2:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -1697,7 +1703,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   featurehub-cloud-event-tools@1.0.0:
     dependencies:
@@ -1735,7 +1741,7 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -2314,7 +2320,7 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uuid@8.3.2: {}
 

--- a/adks/e2e-sdk/pnpm-lock.yaml
+++ b/adks/e2e-sdk/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.5
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       chai:
         specifier: ^4.3.7
         version: 4.5.0
@@ -300,8 +300,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1463,7 +1463,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/adks/e2e-sdk/pnpm-workspace.yaml
+++ b/adks/e2e-sdk/pnpm-workspace.yaml
@@ -1,10 +1,19 @@
+minimumReleaseAgeExclude:
+  - follow-redirects@1.15.12
+  - uuid@11.1.1
+  - fast-uri@3.1.1
+  - fast-uri@3.1.2
 overrides:
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   diff@>=4.0.0 <4.0.4: '>=4.0.4'
+  fast-uri@<=3.1.0: ^3.1.1
+  fast-uri@<=3.1.1: ^3.1.2
+  follow-redirects@<=1.15.11: ^1.15.12
   minimatch@>=10.0.0 <10.2.1: '>=10.2.1'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
   path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
   qs@<6.14.1: '>=6.14.1'
   qs@>=6.7.0 <=6.14.1: '>=6.14.2'
+  uuid@>=11.0.0 <11.1.1: ^11.1.1
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'

--- a/admin-frontend/open_admin_app/lib/routes/manage_group_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/manage_group_route.dart
@@ -110,11 +110,13 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
               stream: bloc.groupLoaded,
               builder: (context, snapshot) {
                 if (snapshot.hasData) {
+
+                  var group = snapshot.data!;
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       if (bloc.mrClient
-                          .isPortfolioOrSuperAdmin(snapshot.data!.portfolioId))
+                          .isPortfolioOrSuperAdmin(group.portfolioId))
                         Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: FilledButton.icon(
@@ -125,7 +127,7 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                 .addOverlay((BuildContext context) {
                               return AddMembersDialogWidget(
                                 bloc: bloc,
-                                group: snapshot.data!,
+                                group: group,
                               );
                             }),
                           ),
@@ -143,14 +145,14 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                   label: Text(
                                       AppLocalizations.of(context)!.columnName),
                                   onSort: (columnIndex, ascending) {
-                                    onSortColumn(snapshot.data!.members,
+                                    onSortColumn(group.sMembers,
                                         columnIndex, ascending);
                                   }),
                               DataColumn(
                                 label: Text(
                                     AppLocalizations.of(context)!.columnEmail),
                                 onSort: (columnIndex, ascending) {
-                                  onSortColumn(snapshot.data!.members,
+                                  onSortColumn(group.sMembers,
                                       columnIndex, ascending);
                                 },
                               ),
@@ -158,7 +160,7 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                 label: Text(AppLocalizations.of(context)!
                                     .columnMemberType),
                                 onSort: (columnIndex, ascending) {
-                                  onSortColumn(snapshot.data!.members,
+                                  onSortColumn(group.sMembers,
                                       columnIndex, ascending);
                                 },
                               ),
@@ -171,24 +173,22 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                   onSort: (i, a) => {}),
                             ],
                             rows: [
-                              for (Person member in snapshot.data!.members)
+                              for (GroupPerson member in group.sMembers)
                                 DataRow(cells: [
                                   DataCell(
-                                    Text(member.name ?? ''),
+                                    Text(member.person.name ?? ''),
                                   ),
                                   DataCell(Text(
-                                      member.personType == PersonType.person
-                                          ? member.email!
+                                      member.person.type == PersonType.person
+                                          ? member.person.email!
                                           : "")),
                                   DataCell(Text(
-                                      member.personType == PersonType.person
+                                      member.person.type == PersonType.person
                                           ? AppLocalizations.of(context)!
                                               .memberTypeUser
                                           : AppLocalizations.of(context)!
                                               .memberTypeServiceAccount)),
-                                  DataCell(bloc.mrClient
-                                          .isPortfolioOrSuperAdmin(
-                                              snapshot.data!.portfolioId)
+                                  DataCell(!member.superuser
                                       ? Tooltip(
                                           message: AppLocalizations.of(context)!
                                               .removeFromGroup,
@@ -197,14 +197,14 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                             onPressed: () async {
                                               try {
                                                 await bloc.removeFromGroup(
-                                                    snapshot.data!, member);
+                                                    group, member.person.id);
                                                 if (context.mounted) {
                                                   bloc.mrClient.addSnackbar(
                                                       Text(AppLocalizations.of(
                                                               context)!
                                                           .memberRemovedFromGroup(
-                                                              member.name ?? '',
-                                                              snapshot.data!
+                                                              member.person.name,
+                                                              group
                                                                   .name)));
                                                 }
                                               } catch (e, s) {
@@ -230,39 +230,39 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
     );
   }
 
-  void onSortColumn(List<Person> people, int columnIndex, bool ascending) {
+  void onSortColumn(List<GroupPerson> people, int columnIndex, bool ascending) {
     setState(() {
       if (columnIndex == 0) {
         if (ascending) {
           people.sort((a, b) {
-            return a.name!.toLowerCase().compareTo(b.name!.toLowerCase());
+            return a.person.name.toLowerCase().compareTo(b.person.name!.toLowerCase());
           });
         } else {
           people.sort((a, b) {
-            return b.name!.toLowerCase().compareTo(a.name!.toLowerCase());
+            return b.person.name.toLowerCase().compareTo(a.person.name.toLowerCase());
           });
         }
       }
       if (columnIndex == 1) {
         if (ascending) {
           people.sort((a, b) =>
-              a.email!.toLowerCase().compareTo(b.email!.toLowerCase()));
+              a.person.email!.toLowerCase().compareTo(b.person.email!.toLowerCase()));
         } else {
           people.sort((a, b) =>
-              b.email!.toLowerCase().compareTo(a.email!.toLowerCase()));
+              b.person.email!.toLowerCase().compareTo(a.person.email!.toLowerCase()));
         }
       }
       if (columnIndex == 2) {
         if (ascending) {
-          people.sort((a, b) => a.personType
+          people.sort((a, b) => a.person.type
               .toString()
               .toLowerCase()
-              .compareTo(b.personType.toString().toLowerCase()));
+              .compareTo(b.person.type.toString().toLowerCase()));
         } else {
-          people.sort((a, b) => b.personType
+          people.sort((a, b) => b.person.type
               .toString()
               .toLowerCase()
-              .compareTo(a.personType.toString().toLowerCase()));
+              .compareTo(a.person.type.toString().toLowerCase()));
         }
       }
       if (sortColumnIndex == columnIndex) {
@@ -430,10 +430,8 @@ class _AddMembersDialogWidgetState extends State<AddMembersDialogWidget> {
               keepCase: true,
               onPressed: () async {
                 final group = widget.group;
-                group.members = List.from(group.members)..addAll(membersToAdd);
-                // remove duplicates
-                group.members = group.members.toSet().toList();
-                final success = await widget.bloc.updateGroup(group);
+
+                final success = await widget.bloc.addUsersToGroup(group, membersToAdd);
                 if (success) {
                   widget.bloc.mrClient.removeOverlay();
                   if (context.mounted) {

--- a/admin-frontend/open_admin_app/lib/routes/manage_group_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/manage_group_route.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_provider/bloc_provider.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mrapi/api.dart';
 import 'package:open_admin_app/common/ga_id.dart';
@@ -145,14 +146,14 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                   label: Text(
                                       AppLocalizations.of(context)!.columnName),
                                   onSort: (columnIndex, ascending) {
-                                    onSortColumn(group.sMembers,
+                                    onSortColumn(group.simpleMembers,
                                         columnIndex, ascending);
                                   }),
                               DataColumn(
                                 label: Text(
                                     AppLocalizations.of(context)!.columnEmail),
                                 onSort: (columnIndex, ascending) {
-                                  onSortColumn(group.sMembers,
+                                  onSortColumn(group.simpleMembers,
                                       columnIndex, ascending);
                                 },
                               ),
@@ -160,7 +161,7 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                 label: Text(AppLocalizations.of(context)!
                                     .columnMemberType),
                                 onSort: (columnIndex, ascending) {
-                                  onSortColumn(group.sMembers,
+                                  onSortColumn(group.simpleMembers,
                                       columnIndex, ascending);
                                 },
                               ),
@@ -173,22 +174,22 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                   onSort: (i, a) => {}),
                             ],
                             rows: [
-                              for (GroupPerson member in group.sMembers)
+                              for (AnemicPerson member in group.simpleMembers)
                                 DataRow(cells: [
                                   DataCell(
-                                    Text(member.person.name ?? ''),
+                                    Text(member.name),
                                   ),
                                   DataCell(Text(
-                                      member.person.type == PersonType.person
-                                          ? member.person.email!
+                                      member.type == PersonType.person
+                                          ? member.email!
                                           : "")),
                                   DataCell(Text(
-                                      member.person.type == PersonType.person
+                                      member.type == PersonType.person
                                           ? AppLocalizations.of(context)!
                                               .memberTypeUser
                                           : AppLocalizations.of(context)!
                                               .memberTypeServiceAccount)),
-                                  DataCell(!member.superuser
+                                  DataCell((group.admin != true) || group.superMembers.firstWhereOrNull((s) => s == member.id) == null
                                       ? Tooltip(
                                           message: AppLocalizations.of(context)!
                                               .removeFromGroup,
@@ -197,13 +198,13 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
                                             onPressed: () async {
                                               try {
                                                 await bloc.removeFromGroup(
-                                                    group, member.person.id);
+                                                    group, member.id);
                                                 if (context.mounted) {
                                                   bloc.mrClient.addSnackbar(
                                                       Text(AppLocalizations.of(
                                                               context)!
                                                           .memberRemovedFromGroup(
-                                                              member.person.name,
+                                                              member.name,
                                                               group
                                                                   .name)));
                                                 }
@@ -230,39 +231,39 @@ class ManageGroupRouteState extends State<ManageGroupRoute> {
     );
   }
 
-  void onSortColumn(List<GroupPerson> people, int columnIndex, bool ascending) {
+  void onSortColumn(List<AnemicPerson> people, int columnIndex, bool ascending) {
     setState(() {
       if (columnIndex == 0) {
         if (ascending) {
           people.sort((a, b) {
-            return a.person.name.toLowerCase().compareTo(b.person.name!.toLowerCase());
+            return a.name.toLowerCase().compareTo(b.name.toLowerCase());
           });
         } else {
           people.sort((a, b) {
-            return b.person.name.toLowerCase().compareTo(a.person.name.toLowerCase());
+            return b.name.toLowerCase().compareTo(a.name.toLowerCase());
           });
         }
       }
       if (columnIndex == 1) {
         if (ascending) {
           people.sort((a, b) =>
-              a.person.email!.toLowerCase().compareTo(b.person.email!.toLowerCase()));
+              a.email!.toLowerCase().compareTo(b.email!.toLowerCase()));
         } else {
           people.sort((a, b) =>
-              b.person.email!.toLowerCase().compareTo(a.person.email!.toLowerCase()));
+              b.email!.toLowerCase().compareTo(a.email!.toLowerCase()));
         }
       }
       if (columnIndex == 2) {
         if (ascending) {
-          people.sort((a, b) => a.person.type
+          people.sort((a, b) => a.type
               .toString()
               .toLowerCase()
-              .compareTo(b.person.type.toString().toLowerCase()));
+              .compareTo(b.type.toString().toLowerCase()));
         } else {
-          people.sort((a, b) => b.person.type
+          people.sort((a, b) => b.type
               .toString()
               .toLowerCase()
-              .compareTo(a.person.type.toString().toLowerCase()));
+              .compareTo(a.type.toString().toLowerCase()));
         }
       }
       if (sortColumnIndex == columnIndex) {

--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -290,15 +290,11 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
   }
 
   Future<Group?> updateGroupWithEnvironmentRoles(String? gid, Group group) async {
-    // make sure members are null or they all get removed
-    group.members = [];
-
     try {
       final updatedGroup = await _groupServiceApi
-          .updateGroupOnPortfolio(portfolio!.id, group,
+          .updateGroupOnPortfolio(portfolio!.id, UpdateGroup(id: group.id, version: group.version,
+          applicationRoles: group.applicationRoles, environmentRoles: group.environmentRoles),
           includeGroupRoles: true,
-          includeMembers: false,
-          updateMembers: false,
           applicationId: applicationId,
           updateApplicationGroupRoles: true,
           updateEnvironmentGroupRoles: true);

--- a/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
@@ -107,8 +107,8 @@ class GroupBloc implements Bloc {
       groupToUpdate.name = name;
 
       final newGroup = await _groupServiceApi.updateGroupOnPortfolio(
-          mrClient.currentPortfolio!.id, groupToUpdate,
-          includeMembersV2: true, updateMembers: false);
+          mrClient.currentPortfolio!.id, UpdateGroup(id: groupToUpdate.id, version: groupToUpdate.version, name: name),
+          includeMembersV2: true);
 
       // tell the portfolio groups to update as the name has changed.
       await getGroups(focusGroup: groupToUpdate);
@@ -121,7 +121,7 @@ class GroupBloc implements Bloc {
       await mrClient.dialogError(e, s,
           messageTitle: 'Failed to update group',
           messageBody:
-              'Failed to update group because of a duplicate or other conflict.');
+              'Failed to update group because of a duplicate or other update conflict.');
       return false;
     }
   }

--- a/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
@@ -56,7 +56,7 @@ class GroupBloc implements Bloc {
     if (groupId != null && groupId.length > 1) {
       try {
         final fetchedGroup =
-            await _groupServiceApi.getGroup(groupId, includeMembers: true);
+            await _groupServiceApi.getGroup(groupId, includeMembersV2: true);
         // publish it out...
         group = fetchedGroup;
         _groupSource.add(fetchedGroup);
@@ -69,7 +69,7 @@ class GroupBloc implements Bloc {
   Future<void> deleteGroup(String groupId, bool includeMembers) async {
     try {
       await _groupServiceApi.deleteGroup(groupId,
-          includeMembers: includeMembers);
+          includeMembersV2: includeMembers);
       group = null;
       this.groupId = null;
       _groupSource.add(null);
@@ -79,24 +79,42 @@ class GroupBloc implements Bloc {
     }
   }
 
-  Future<void> removeFromGroup(Group group, Person person) async {
+  Future<void> removeFromGroup(Group group, String personId) async {
     var data = await _groupServiceApi
-        .deletePersonFromGroup(group.id, person.id!.id, includeMembers: true);
+        .deletePersonFromGroup(group.id, personId, includeMembersV2: true);
     if (!_groupSource.isClosed) {
       _groupSource.add(data);
     }
   }
 
-  Future<bool> updateGroup(Group groupToUpdate, {String? name}) async {
+  Future<bool> addUsersToGroup(Group group, List<Person> persons) async {
     try {
-      if (name != null) {
-        groupToUpdate.name = name;
-      }
+      final fetchedGroup = await _groupServiceApi.addPersonsToGroup(group.id, personId: persons.map((p) => p.id!.id).toList(), includeMembersV2: true);
+      group = fetchedGroup;
+      _groupSource.add(fetchedGroup);
+      return true;
+    } catch (e, s) {
+      await mrClient.dialogError(e, s,
+          messageTitle: 'Failed to add users to group',
+          messageBody:
+          'Failed to update group because of a duplicate or other conflict.');
+      return false;
+    }
+  }
+
+  Future<bool> updateGroupName(Group groupToUpdate, String name) async {
+    try {
+      groupToUpdate.name = name;
+
       final newGroup = await _groupServiceApi.updateGroupOnPortfolio(
           mrClient.currentPortfolio!.id, groupToUpdate,
-          includeMembers: true, updateMembers: true);
+          includeMembersV2: true, updateMembers: false);
+
+      // tell the portfolio groups to update as the name has changed.
       await getGroups(focusGroup: groupToUpdate);
+
       group = newGroup;
+      _groupSource.add(newGroup);
       groupId = groupToUpdate.id;
       return true;
     } catch (e, s) {

--- a/admin-frontend/open_admin_app/lib/widgets/group/group_update_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/group/group_update_widget.dart
@@ -100,7 +100,7 @@ class _GroupUpdateDialogWidgetState extends State<GroupUpdateDialogWidget> {
 
   Future<void> _callUpdateGroup(String name) {
     final groupName = name.trim();
-    return widget.group == null ? widget.bloc.createGroup(groupName) : widget.bloc.updateGroup(widget.group!, name: groupName);
+    return widget.group == null ? widget.bloc.createGroup(groupName) : widget.bloc.updateGroupName(widget.group!, groupName);
   }
 }
 

--- a/backend/common-web/pom.xml
+++ b/backend/common-web/pom.xml
@@ -61,6 +61,13 @@
       <version>${otel.version}</version>
     </dependency>
 
+    <!-- we include this one because pubsub has its own version and we need to force ours -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-common</artifactId>
+      <version>${otel.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-trace</artifactId>

--- a/backend/common-web/pom.xml
+++ b/backend/common-web/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <cloudevents.version>4.0.1</cloudevents.version>
-    <otel.version>1.57.0</otel.version>
+    <otel.version>1.62.0</otel.version>
     <otel.jaeger.version>1.34.1</otel.jaeger.version>
   </properties>
 

--- a/backend/composite-db-drivers/pom.xml
+++ b/backend/composite-db-drivers/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.8</version>
+      <version>42.7.11</version>
     </dependency>
 
     <dependency>

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
@@ -203,9 +203,9 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
             log.trace("Unable to find environment id {} in serviceAccount", serviceAccount)
           }
           result
-        } catch (_: Exception) {
+        } catch (e: Exception) {
           if (log.isTraceEnabled) {
-            log.trace("failed to get service account permission {}/{}", eId, apiKey)
+            log.trace("failed to get service account permission {}/{}", eId, apiKey, e)
           }
           // this will cause an exception
           null
@@ -328,14 +328,14 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
         }
       } else serviceAccountCache.getIfPresent(sId)
 
+      // in case these keys are in the miss cache
+      serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
+
       if (existing == null) {
         return // we throw it away as we are not caching streamed updates
       }
 
       if (created) { // it was new so it is a new update and we are caching
-        // just in case we had these keys in the miss cache
-        serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
-
         // its already in serviceAccountCache, so we just have to put it in the ApiKey cache
         serviceAccountApiKeyCache.put(sa.apiKeyServerSide, sa)
         serviceAccountApiKeyCache.put(sa.apiKeyClientSide, sa)
@@ -352,7 +352,6 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
           serviceAccountApiKeyCache.invalidate(existing.apiKeyClientSide)
         }
 
-        serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
         stashServiceAccount(sa, sId)
 
         val envs = sa.permissions.associateBy { it.environmentId }

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2CacheImpl.kt
@@ -110,8 +110,6 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
         override fun load(key: String): CacheServiceAccount {
           try {
             val serviceAccount = mrDacha2Api.getServiceAccount(key, apiKey).serviceAccount
-            // every SA is actually two entries
-            fillServiceAccountCache(key, serviceAccount)
 
             serviceAccountCache.put(serviceAccount.id, serviceAccount)
             return serviceAccount
@@ -197,7 +195,7 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
         try {
           // this can cause an exception
           val serviceAccount = serviceAccountApiKeyCache.get(apiKey)
-
+          fillServiceAccountCache(apiKey, serviceAccount)
           val result = serviceAccount.permissions.find { it.environmentId == eId }
           if (result == null) {
             log.trace("Unable to find environment id {} in serviceAccount", serviceAccount)
@@ -219,6 +217,7 @@ open class Dacha2CacheImpl @Inject constructor(private val mrDacha2Api: Dacha2Se
 
       // accessing the environment-cache can cause an exception
       val serviceAccount = serviceAccountApiKeyCache.get(apiKey)
+      fillServiceAccountCache(apiKey, serviceAccount)
 
       if (allowFiltering && serviceAccount.filters != null && serviceAccount.filters!!.isNotEmpty()) {
         counterFilterUse.inc()

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2DumpOnReconnectCache.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2DumpOnReconnectCache.kt
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory
 
 
 class Dacha2DumpOnReconnectCache @Inject constructor(mrDacha2Api: Dacha2ServiceClient,
-                                                     featureValueFactory: FeatureValuesFactory) : Dacha2CacheImpl(mrDacha2Api, featureValueFactory) {
+                                                     featureValueFactory: FeatureValuesFactory) : Dacha2NewCacheImpl(mrDacha2Api, featureValueFactory) {
   private var cacheEnabled = true
   private val log: Logger = LoggerFactory.getLogger(Dacha2DumpOnReconnectCache::class.java)
 

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2NewCache.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2NewCache.kt
@@ -98,7 +98,6 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
       .build(CacheLoader { key: String ->
         try {
           val serviceAccount = mrDacha2Api.getServiceAccount(key, apiKey).serviceAccount
-          fillServiceAccountCache(key, serviceAccount)
           serviceAccountCache.put(serviceAccount.id, serviceAccount)
           serviceAccount
         } catch (nfe: NotFoundException) {
@@ -183,6 +182,7 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
       val perms = permsCache.get(comboKey) {
         try {
           val serviceAccount = serviceAccountApiKeyCache.get(apiKey)
+          fillServiceAccountCache(apiKey, serviceAccount)
           val result = serviceAccount.permissions.find { it.environmentId == eId }
           if (result == null) {
             log.trace("Unable to find environment id {} in serviceAccount", serviceAccount)
@@ -204,6 +204,7 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
 
       // accessing the environment-cache can cause an exception
       val serviceAccount = serviceAccountApiKeyCache.get(apiKey)
+      fillServiceAccountCache(apiKey, serviceAccount)
 
       if (serviceAccount.filters != null && serviceAccount.filters!!.isNotEmpty()) {
         counterFilterUse.inc()

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2NewCache.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2NewCache.kt
@@ -189,9 +189,9 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
             throw InvalidKeyException()
           }
           result
-        } catch (_: Exception) {
+        } catch (e: Exception) {
           if (log.isTraceEnabled) {
-            log.trace("failed to get service account permission {}/{}", eId, apiKey)
+            log.trace("failed to get service account permission {}/{}", eId, apiKey, e)
           }
           throw InvalidKeyException()
         }
@@ -313,14 +313,13 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
         }
       } else serviceAccountCache.getIfPresent(sId)
 
+      // just in case we had these keys in the miss cache
+      serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
       if (existing == null) {
         return // we throw it away as we are not caching streamed updates
       }
 
       if (created) { // it was new so it is a new update and we are caching
-        // just in case we had these keys in the miss cache
-        serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
-
         // its already in serviceAccountCache, so we just have to put it in the ApiKey cache
         serviceAccountApiKeyCache.put(sa.apiKeyServerSide, sa)
         serviceAccountApiKeyCache.put(sa.apiKeyClientSide, sa)
@@ -337,7 +336,6 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
           serviceAccountApiKeyCache.invalidate(existing.apiKeyClientSide)
         }
 
-        serviceAccountMissCache.invalidateAll(listOf(sa.apiKeyServerSide, sa.apiKeyClientSide))
         stashServiceAccount(sa, sId)
 
         val envs = sa.permissions.associateBy { it.environmentId }
@@ -438,7 +436,7 @@ open class Dacha2NewCacheImpl @Inject constructor(private val mrDacha2Api: Dacha
   }
 
   companion object {
-    val log: Logger = LoggerFactory.getLogger(Dacha2CacheImpl::class.java)
+    val log: Logger = LoggerFactory.getLogger(Dacha2NewCacheImpl::class.java)
 
     val gaugeServiceAccountMissCache = MetricsCollector.gauge(DACHA_2_SERVICE_ACCOUNT_MISS_CACHE, "Requests for service accounts that don't exist")
     val gaugeServiceAccountCache = MetricsCollector.gauge(DACHA_2_SERVICE_ACCOUNT_CACHE, "The size of cache for service accounts")

--- a/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2OldCacheImpl.kt
+++ b/backend/dacha2/src/main/kotlin/io/featurehub/dacha2/Dacha2OldCacheImpl.kt
@@ -1,4 +1,0 @@
-package io.featurehub.dacha2
-
-class Dacha2OldCacheImpl {
-}

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -453,11 +453,19 @@ paths:
         - name: includeMembers
           description: "include people in each group"
           in: query
+          required: false
+          schema:
+            type: boolean
+        - name: includeMembersV2
+          description: "include anemic people in each group with superuser"
+          in: query
+          required: false
           schema:
             type: boolean
         - name: includeGroupRoles
           description: "include environment and application roles in each group"
           in: query
+          required: false
           schema:
             type: boolean
         - name: updateMembers
@@ -2120,15 +2128,23 @@ paths:
           format: uuid
         required: true
       - name: includeMembers
-        description: "include people in each group"
+        description: "include people in each group (v1) - uses Members"
         in: query
         schema:
           type: boolean
+        required: false
+      - name: includeMembersV2
+        description: "include people in each group (v2) - uses GroupMember instead of Members"
+        in: query
+        schema:
+          type: boolean
+        required: false
       - name: includeGroupRoles
         description: "include environment and application roles in each group"
         in: query
         schema:
           type: boolean
+        required: false
     get:
       security:
         - bearerAuth: [ ]
@@ -2238,6 +2254,59 @@ paths:
           description: "forbidden"
         404:
           description: "not found"
+  /mr-api/group/{gid}/person:
+    parameters:
+      - name: gid
+        description: "The id of the group that we are processing"
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - name: includeMembersV2
+        description: "include anemic people in each group with superuser info"
+        in: query
+        required: false
+        schema:
+          type: boolean
+      - name: personId
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: email
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+    post:
+      tags:
+        - GroupService
+      security:
+        - bearerAuth: [ ]
+      description: "Add a persons to a group"
+      operationId: addPersonsToGroup
+      responses:
+        200:
+          description: "Resulting group"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Group"
+        400:
+          description: "Bad Request"
+        401:
+          description: "no permission"
+        403:
+          description: "forbidden"
+        404:
+          description: "group or person not found"
+
   /mr-api/group/{gid}/person/{pId}:
     parameters:
       - name: gid
@@ -2257,6 +2326,13 @@ paths:
       - name: includeMembers
         description: "include people in each group"
         in: query
+        required: false
+        schema:
+          type: boolean
+      - name: includeMembersV2
+        description: "include anemic people in each group with superuser info"
+        in: query
+        required: false
         schema:
           type: boolean
     post:
@@ -3952,6 +4028,11 @@ components:
               type: string
               minLength: 1
               maxLength: 255
+            sMembers:
+              type: array
+              default: []
+              items:
+                $ref: "#/components/schemas/GroupPerson"
             members:
               type: array
               default: []
@@ -3971,6 +4052,13 @@ components:
               nullable: true
               type: string
               format: date-time
+    GroupPerson:
+      type: object
+      properties:
+        person:
+          $ref: "#/components/schemas/AnemicPerson"
+        superuser:
+          type: boolean
     ApplicationGroupRole:
       type: object
       required:

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -468,12 +468,6 @@ paths:
           required: false
           schema:
             type: boolean
-        - name: updateMembers
-          description: "update members, deleting those that are not passed"
-          in: query
-          schema:
-            type: boolean
-          required: false
         - name: updateEnvironmentGroupRoles
           description: "update environment group roles, deleting any not passed"
           in: query
@@ -498,7 +492,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Group"
+              $ref: "#/components/schemas/UpdateGroup"
       responses:
         200:
           description: "Resulting group"
@@ -2173,65 +2167,6 @@ paths:
           description: "forbidden"
         404:
           description: "not found"
-    put:
-      deprecated: true
-      security:
-        - bearerAuth: [ ]
-      tags:
-        - GroupService
-      description: "Update a group"
-      operationId: updateGroup
-      parameters:
-        - name: updateMembers
-          description: "update members, deleting those that are not passed"
-          in: query
-          schema:
-            type: boolean
-          required: false
-        - name: updateEnvironmentGroupRoles
-          description: "update environment group roles, deleting any not passed"
-          in: query
-          schema:
-            type: boolean
-          required: false
-        - name: updateApplicationGroupRoles
-          description: "update application group roles, deleting any not passed"
-          in: query
-          schema:
-            type: boolean
-          required: false
-        - name: applicationId
-          description: "if updating the application group roles, and the application id is passed, then the changes are limited to that application"
-          in: query
-          schema:
-            type: string
-            format: uuid
-          required: false
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Group"
-      responses:
-        200:
-          description: "Resulting group"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Group"
-        400:
-          description: "Bad Request"
-        401:
-          description: "no permission"
-        403:
-          description: "forbidden"
-        404:
-          description: "not found"
-        409:
-          description: "duplicate user or duplicate group"
-        422:
-          description: "version conflict"
     delete:
       security:
         - bearerAuth: [ ]
@@ -3996,6 +3931,34 @@ components:
           default: []
           items:
             $ref: "#/components/schemas/ApplicationGroupRole"
+    UpdateGroup:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: false
+        name:
+          type: string
+          maxLength: 255
+          nullable: true
+        version:
+          type: integer
+          format: int64
+          nullable: false
+        applicationRoles:
+          nullable: true
+          type: array
+          default: []
+          items:
+            $ref: "#/components/schemas/ApplicationGroupRole"
+        environmentRoles:
+          type: array
+          default: []
+          items:
+            $ref: "#/components/schemas/EnvironmentGroupRole"
     Group:
       allOf:
         - $ref: "#/components/schemas/Audit"
@@ -4028,11 +3991,18 @@ components:
               type: string
               minLength: 1
               maxLength: 255
-            sMembers:
+            superMembers:
+              description: "This indicates which ids in the simpleMembers are superusers. It is a read only field and is ignored if it is passed back."
               type: array
               default: []
               items:
-                $ref: "#/components/schemas/GroupPerson"
+                type: string
+                format: uuid
+            simpleMembers:
+              type: array
+              default: []
+              items:
+                $ref: "#/components/schemas/AnemicPerson"
             members:
               type: array
               default: []

--- a/backend/mr-db-api/src/main/java/io/featurehub/db/api/FillOpts.java
+++ b/backend/mr-db-api/src/main/java/io/featurehub/db/api/FillOpts.java
@@ -10,6 +10,7 @@ public enum FillOpts {
   Portfolios,
   PortfolioIds,
   Members,
+  MembersV2, // also whether a person is a superuser
   Groups,
   Acls,
   Features,

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
@@ -1,6 +1,11 @@
 package io.featurehub.db.api
 
-import io.featurehub.mr.model.*
+import io.featurehub.mr.model.CreateGroup
+import io.featurehub.mr.model.Group
+import io.featurehub.mr.model.Organization
+import io.featurehub.mr.model.Person
+import io.featurehub.mr.model.SortOrder
+import io.featurehub.mr.model.UpdateGroup
 import java.util.*
 
 interface GroupApi {
@@ -33,7 +38,7 @@ interface GroupApi {
    * @param opts
    * @return Group with the group id - default. Or plus opts if provided
    */
-  fun addPersonToGroup(groupId: UUID, personId: UUID, opts: Opts): Group?
+  fun addPersonsToGroup(groupId: UUID, personIds: List<UUID>, opts: Opts): Group?
   fun getGroup(gid: UUID, opts: Opts, person: Person): Group?
   fun findPortfolioAdminGroup(portfolioId: UUID, opts: Opts): Group?
   fun findOrganizationAdminGroup(orgId: UUID, opts: Opts): Group?
@@ -44,9 +49,8 @@ interface GroupApi {
   @Throws(OptimisticLockingException::class, DuplicateGroupException::class, DuplicateUsersException::class)
   fun updateGroup(
     gid: UUID,
-    group: Group,
+    group: UpdateGroup,
     appId: UUID?,
-    updateMembers: Boolean,
     updateApplicationGroupRoles: Boolean,
     updateEnvironmentGroupRoles: Boolean,
     opts: Opts

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/PersonApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/PersonApi.kt
@@ -38,4 +38,5 @@ interface PersonApi {
   fun delete(email: String, deleteGroups: Boolean): Boolean
 
   fun updateV2(personId: UUID, updatePerson: UpdatePerson, updatedBy: UUID): UUID?
+  fun findPeople(ids: List<UUID>, emailAddresses: List<String>): Set<UUID>
 }

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -433,18 +433,18 @@ open class ConvertUtils @Inject constructor(
     }
 
     if (opts.contains(FillOpts.MembersV2)) {
-      val admins = QDbGroupMember()
+      group.superMembers(QDbGroupMember()
         .select(QDbGroupMember.Alias.person.id)
         .group.owningOrganization.id.eq(group.organizationId)
         .group.owningPortfolio.isNull
-        .group.adminGroup.isTrue.findList().associateBy { it.person.id }
+        .group.adminGroup.isTrue.findList().map { it.person.id })
 
-      group.sMembers(QDbPerson()
+      group.simpleMembers(QDbPerson()
         .select(QDbPerson.Alias.id)
         .orderBy().name.asc()
         .whenArchived.isNull
         .groupMembers.group.eq(dbg).findList().map { p ->
-          GroupPerson().person(AnemicPerson().id(p.id).name(p.name).email(p.email).type(p.personType)).superuser(admins.contains(p.id))
+          AnemicPerson().id(p.id).name(p.name).email(p.email).type(p.personType)
         })
     }
 

--- a/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
+++ b/backend/mr-db-services/src/main/kotlin/io/featurehub/db/services/ConvertUtils.kt
@@ -30,6 +30,8 @@ import io.featurehub.db.model.query.QDbPortfolio
 import io.featurehub.db.model.query.QDbServiceAccountEnvironment
 import io.featurehub.encryption.WebhookEncryptionService
 import io.featurehub.db.model.DbFeatureFilter
+import io.featurehub.db.model.query.QDbGroupMember
+import io.featurehub.mr.model.AnemicPerson
 import io.featurehub.mr.model.Application
 import io.featurehub.mr.model.ApplicationGroupRole
 import io.featurehub.mr.model.ApplicationRoleType
@@ -42,6 +44,7 @@ import io.featurehub.mr.model.FeatureFilter
 import io.featurehub.mr.model.FeatureValue
 import io.featurehub.mr.model.FeatureValueType
 import io.featurehub.mr.model.Group
+import io.featurehub.mr.model.GroupPerson
 import io.featurehub.mr.model.OptionalAnemicPerson
 import io.featurehub.mr.model.Organization
 import io.featurehub.mr.model.Person
@@ -428,6 +431,23 @@ open class ConvertUtils @Inject constructor(
           )
         }
     }
+
+    if (opts.contains(FillOpts.MembersV2)) {
+      val admins = QDbGroupMember()
+        .select(QDbGroupMember.Alias.person.id)
+        .group.owningOrganization.id.eq(group.organizationId)
+        .group.owningPortfolio.isNull
+        .group.adminGroup.isTrue.findList().associateBy { it.person.id }
+
+      group.sMembers(QDbPerson()
+        .select(QDbPerson.Alias.id)
+        .orderBy().name.asc()
+        .whenArchived.isNull
+        .groupMembers.group.eq(dbg).findList().map { p ->
+          GroupPerson().person(AnemicPerson().id(p.id).name(p.name).email(p.email).type(p.personType)).superuser(admins.contains(p.id))
+        })
+    }
+
     if (opts.contains(FillOpts.Acls)) {
       val appIdFilter = opts.id(FilterOptType.Application)
       var aclQuery = QDbAcl().group.eq(dbg)

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/GroupSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/GroupSqlApi.kt
@@ -6,6 +6,7 @@ import io.ebean.annotation.Transactional
 import io.featurehub.db.api.*
 import io.featurehub.db.model.*
 import io.featurehub.db.model.query.*
+import io.featurehub.db.model.query.QGroupMemberAgg.Alias.personId
 import io.featurehub.mr.model.*
 import io.featurehub.mr.model.RoleType
 import jakarta.inject.Inject
@@ -194,44 +195,48 @@ open class GroupSqlApi @Inject constructor(
       }
   }
 
-  override fun addPersonToGroup(groupId: UUID, personId: UUID, opts: Opts): Group? {
-    val dbGroup = QDbGroup().id
-      .eq(groupId).whenArchived
-      .isNull
-      .findOne() // no adding people to archived groups
+  // the GroupResource has pre-checked these personIds belong to this organisation
+  override fun addPersonsToGroup(groupId: UUID, personIds: List<UUID>, opts: Opts): Group? {
+    val dbGroup = QDbGroup()
+      .select(QDbGroup.Alias.id, QDbGroup.Alias.owningPortfolio.id,
+        QDbGroup.Alias.adminGroup, QDbGroup.Alias.owningPortfolio)
+      .id.eq(groupId)
+      .whenArchived.isNull
+      .findOne() ?: return null
+    // no adding people to archived groups
 
-    if (dbGroup != null) {
-      val person = QDbPerson().id.eq(personId).whenArchived.isNull.findOne()
-      if (person != null) {
-        val groupFinder = QDbGroup().id.eq(groupId).groupMembers.person.id.eq(personId)
-        if (opts.contains(FillOpts.Members)) {
-          groupFinder.groupMembers.person.fetch() // ensure we prefetch the users in the group
-        }
-        val one = groupFinder.findOne()
-        return if (one == null) {
-          // ebean ensures this is never null
-          updateGroupMembership(dbGroup, person)
-          convertUtils.toGroup(dbGroup, opts)!!
-        } else { // they are already in the group
-          convertUtils.toGroup(one, opts)!!
-        }
-      }
+    val uniqueIds = personIds.toSet().toMutableSet()
+    // remove folks who are already in this group
+    QDbGroupMember()
+      .select(QDbGroupMember.Alias.person.id)
+      .person.id.`in`(personIds)
+      .group.id.eq(groupId)
+      .findList().forEach { personId -> uniqueIds.remove(personId.person.id) }
+
+    val realIds = QDbPerson().select(QDbPerson.Alias.id).id.`in`(uniqueIds).findList().map { it.id }
+
+    if (realIds.isNotEmpty()) {
+      updateGroupMembership(dbGroup, realIds)
     }
 
-    return null
+    // we don't optimize for children or parents
+    return convertUtils.toGroup(QDbGroup()
+      .owningPortfolio.fetch(QDbPortfolio.Alias.id)
+      .owningOrganization.fetch(QDbOrganization.Alias.id)
+      .id.eq(groupId).findOne()!!, opts)
   }
 
   @Transactional
-  private fun updateGroupMembership(dbGroup: DbGroup, person: DbPerson) {
-    if (!QDbGroupMember().person.id.eq(person.id).group.id.eq(dbGroup.id).exists()) {
-      DbGroupMember(DbGroupMemberKey(person.id, dbGroup.id)).save()
+  private fun updateGroupMembership(dbGroup: DbGroup, uniqueIds: Iterable<UUID>) {
+    uniqueIds.forEach { personId ->
+     DbGroupMember(DbGroupMemberKey(personId, dbGroup.id)).save()
     }
 
     // they actually got added from the superusers group, so
     // lets update the portfolios
     if (dbGroup.isAdminGroup && dbGroup.owningPortfolio == null) {
       val sc = SuperuserChanges(dbGroup.owningOrganization)
-      sc.addedSuperusers.add(person)
+      sc.addedSuperuserPersonIds.addAll(uniqueIds)
       sc.ignoredGroups.add(dbGroup.id)
       updateSuperusersFromPortfolioGroups(sc)
     }
@@ -349,9 +354,8 @@ open class GroupSqlApi @Inject constructor(
   @Throws(OptimisticLockingException::class, GroupApi.DuplicateGroupException::class, DuplicateUsersException::class)
   override fun updateGroup(
     gid: UUID,
-    group: Group,
+    group: UpdateGroup,
     appId: UUID?,
-    updateMembers: Boolean,
     updateApplicationGroupRoles: Boolean,
     updateEnvironmentGroupRoles: Boolean,
     opts: Opts
@@ -359,17 +363,21 @@ open class GroupSqlApi @Inject constructor(
     val dbGroup = convertUtils.byGroup(gid, opts)
 
     if (dbGroup != null && dbGroup.whenArchived == null) {
-      if (group.version == null || dbGroup.version != group.version) {
+      if (dbGroup.version != group.version) {
         throw OptimisticLockingException()
       }
 
-      group.name.let {
-        dbGroup.name = it
+      group.name.let { groupName ->
+        if (groupName != null) {
+          val trimmed = groupName.trim()
+          if (!trimmed.isEmpty()) {
+            dbGroup.name = trimmed
+          }
+        }
       }
 
       transactionalGroupUpdate(
         group,
-        updateMembers,
         updateApplicationGroupRoles,
         updateEnvironmentGroupRoles,
         dbGroup,
@@ -384,17 +392,12 @@ open class GroupSqlApi @Inject constructor(
   @Transactional
   @Throws(DuplicateUsersException::class, GroupApi.DuplicateGroupException::class)
   private fun transactionalGroupUpdate(
-    gp: Group,
-    updateMembers: Boolean,
+    gp: UpdateGroup,
     updateApplicationGroupRoles: Boolean,
     updateEnvironmentGroupRoles: Boolean,
     group: DbGroup,
     appId: UUID?
   ) {
-    var superuserChanges: SuperuserChanges? = null
-    if (gp.members != null && updateMembers) {
-      superuserChanges = updateMembersOfGroup(gp, group)
-    }
     var aclUpdates: AclUpdates? = null
     gp.environmentRoles.let {
       if (updateEnvironmentGroupRoles) {
@@ -402,10 +405,8 @@ open class GroupSqlApi @Inject constructor(
       }
     }
 
-    gp.applicationRoles.let { appRoles ->
-      if (updateApplicationGroupRoles) {
-        updateApplicationMembersOfGroup(appRoles, group, appId)
-      }
+    if (updateApplicationGroupRoles) {
+      updateApplicationMembersOfGroup(gp.applicationRoles ?: listOf(), group, appId)
     }
 
     try {
@@ -413,7 +414,6 @@ open class GroupSqlApi @Inject constructor(
     } catch (dke: DuplicateKeyException) {
       throw GroupApi.DuplicateGroupException()
     }
-    superuserChanges?.let { updateSuperusersFromPortfolioGroups(it) }
   }
 
   // now we have to walk all the way down and remove these people from all admin portfolio groups
@@ -471,11 +471,11 @@ open class GroupSqlApi @Inject constructor(
   }
 
   private fun updateApplicationMembersOfGroup(
-    updatedApplicationRoles: List<ApplicationGroupRole>?, group: DbGroup, appId: UUID?
+    updatedApplicationRoles: List<ApplicationGroupRole>, group: DbGroup, appId: UUID?
   ) {
     val desiredApplications: MutableMap<UUID, ApplicationGroupRole> = HashMap()
     val addedApplications: MutableSet<UUID> = HashSet()
-    updatedApplicationRoles!!
+    updatedApplicationRoles
       .forEach { role: ApplicationGroupRole ->
         if (appId == null || role.applicationId == appId) {
           desiredApplications[role.applicationId] = role

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/PersonSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/PersonSqlApi.kt
@@ -274,6 +274,19 @@ open class PersonSqlApi @Inject constructor(
         it.personId to it.counter
       }
 
+  override fun findPeople(
+    ids: List<UUID>,
+    emailAddresses: List<String>
+  ): Set<UUID> {
+    return QDbPerson()
+      .select(QDbPerson.Alias.id)
+      .or()
+      .email.`in`(emailAddresses.map { it.lowercase() })
+      .id.`in`(ids)
+      .endOr()
+      .findList().map { it.id }.toSet()
+  }
+
   override fun get(email: String, opts: Opts): Person? {
     if (email.contains("@")) {
       var search = QDbPerson().email.eq(email.lowercase(Locale.getDefault()))

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/PortfolioSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/PortfolioSqlApi.kt
@@ -44,9 +44,9 @@ class PortfolioSqlApi @Inject constructor(
 
     if (ordering != null) {
       if (ordering == SortOrder.ASC) {
-        pFinder = pFinder.order().name.asc()
+        pFinder = pFinder.orderBy().name.asc()
       } else if (ordering == SortOrder.DESC) {
-        pFinder = pFinder.order().name.desc()
+        pFinder = pFinder.orderBy().name.desc()
       }
     }
     val personIsNotSuperAdmin = convertUtils.personIsNotSuperAdmin(personDoingFind)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ApplicationSpec.groovy
@@ -104,11 +104,11 @@ class ApplicationSpec extends BaseSpec {
       def notInAnyGroupsAccess = appApi.findApplications(portfolio1.id, 'envtest-app', null, Opts.empty(), person, false)
     and: "then we give them access to a portfolio group that still has no access"
       Group group = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("envtest-appX1"), superPerson)
-      group = groupSqlApi.addPersonToGroup(group.id, person.id.id, Opts.opts(FillOpts.Members))
+      group = groupSqlApi.addPersonsToGroup(group.id, [person.id.id], Opts.opts(FillOpts.Members))
       def portfoliosNoPerms = portfolioApi.findPortfolios(null, SortOrder.ASC, Opts.opts(FillOpts.Applications), person.id.id)
     and: "the superuser adds to a group as well"
       Group superuserGroup = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("envtest-appSuperuser"), superPerson)
-      superuserGroup = groupSqlApi.addPersonToGroup(superuserGroup.id, superPerson.id.id, Opts.opts(FillOpts.Members))
+      superuserGroup = groupSqlApi.addPersonsToGroup(superuserGroup.id, [superPerson.id.id], Opts.opts(FillOpts.Members))
     and: "with no environment access the two groups have no visibility to applications"
       def stillNotInAnyGroupsPerson = appApi.findApplications(portfolio1.id, 'envtest-app', null, Opts.empty(), person, false)
       def stillNotInAnyGroupsSuperuser = appApi.findApplications(portfolio1.id, 'envtest-app', null, Opts.empty(), superPerson, false)
@@ -116,13 +116,13 @@ class ApplicationSpec extends BaseSpec {
     and: "i add an environment to each application and add group permissions"
       def app1Env1 = environmentSqlApi.create(new CreateEnvironment().description("x").name("dev"), app1.id, superPerson)
       def app2Env1 = environmentSqlApi.create(new CreateEnvironment().description("x").name("dev"), app2.id, superPerson)
-      group = groupSqlApi.updateGroup(group.id, group.environmentRoles([
+      group = groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group.version).environmentRoles([
 	      new EnvironmentGroupRole().environmentId(app1Env1.id).roles([RoleType.READ]),
 	      new EnvironmentGroupRole().environmentId(app2Env1.id).roles([RoleType.READ])
-      ]), null, true, true, true, Opts.opts(FillOpts.Members))
-      superuserGroup = groupSqlApi.updateGroup(superuserGroup.id, superuserGroup.environmentRoles([
+      ]), null, true, true, Opts.opts(FillOpts.Members))
+      superuserGroup = groupSqlApi.updateGroup(superuserGroup.id, new UpdateGroup().version(superuserGroup.version).environmentRoles([
 	      new EnvironmentGroupRole().environmentId(app1Env1.id).roles([RoleType.READ])
-      ]), null, true, true, true, Opts.opts(FillOpts.Members))
+      ]), null, true, true, Opts.opts(FillOpts.Members))
       def summaryApp1Perms = appApi.getApplicationSummary(app1.id)
       def portfoliosPerms = portfolioApi.findPortfolios(null, SortOrder.ASC, Opts.opts(FillOpts.Applications), person.id.id)
     and: "person should now be able to see two groups"
@@ -178,17 +178,17 @@ class ApplicationSpec extends BaseSpec {
       def group = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("loicoudot"), superPerson)
     when:
       def group1 = groupSqlApi.updateGroup(group.id,
-        group.applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_EDIT])]),
+        new UpdateGroup().version(group.version).applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_EDIT])]),
         app1.id,
-        false, true, false, Opts.opts(FillOpts.Acls))
+        true, false, Opts.opts(FillOpts.Acls))
     and:
       def group2 = groupSqlApi.getGroup(group1.id, Opts.empty(), superPerson)
       group2.applicationRoles.add(new ApplicationGroupRole().applicationId(app2.id).roles([ApplicationRoleType.FEATURE_EDIT]))
-      def group3 = groupSqlApi.updateGroup(group.id, group2, app2.id, false, true, false,
+      def group3 = groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group2.version).applicationRoles(group2.applicationRoles), app2.id, true, false,
         Opts.opts(FillOpts.Acls))
     and: "i delete the role but just from application 2"
       def group4 = groupSqlApi.getGroup(group1.id, Opts.empty(), superPerson)
-      def group5 = groupSqlApi.updateGroup(group.id, group4, app2.id, false, true, false,
+      def group5 = groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group4.version), app2.id, true, false,
         Opts.opts(FillOpts.Acls))
     then:
       group3.applicationRoles.size() == 2
@@ -219,13 +219,13 @@ class ApplicationSpec extends BaseSpec {
       database.save(deepme)
       def personIsCreator0 = appApi.personIsFeatureCreator(app1.id, deepme.id)
       def personIsEditor0 = appApi.personIsFeatureEditor(app1.id, deepme.id)
-      createdGroup.addMembersItem(new Person().id(new PersonId().id(deepme.id)))
-      def group = groupSqlApi.updateGroup(createdGroup.id, createdGroup, null, true, false, false, Opts.opts(FillOpts.Acls))
+      groupSqlApi.addPersonsToGroup(createdGroup.id, [deepme.id], Opts.empty())
+      def group = createdGroup.addMembersItem(new Person().id(new PersonId().id(deepme.id)))
     when: "i add create permissions for the app to the group"
       def groupWithCreatePerms = groupSqlApi.updateGroup(group.id,
-        group.applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_CREATE])]),
+        new UpdateGroup().version(group.version).applicationRoles([new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_CREATE])]),
         app1.id,
-        false, true, false, Opts.opts(FillOpts.Acls))
+        true, false, Opts.opts(FillOpts.Acls))
       def creators1 = appApi.findFeatureCreators(app1.id)
       def editors1 = appApi.findFeatureEditors(app1.id)
       def personIsCreator1 = appApi.personIsFeatureCreator(app1.id, deepme.id)
@@ -233,7 +233,7 @@ class ApplicationSpec extends BaseSpec {
     and: "i add edit permissions"
       def group2 = groupSqlApi.getGroup(group.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app1.id), superPerson)
       group2.applicationRoles[0].roles.add(ApplicationRoleType.FEATURE_EDIT_AND_DELETE)
-      def groupWithEditAndCreatePerms = groupSqlApi.updateGroup(group.id, group2, app1.id, false,
+      def groupWithEditAndCreatePerms = groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group2.version).applicationRoles(group2.applicationRoles), app1.id,
         true, false, Opts.opts(FillOpts.Acls))
       def creators2 = appApi.findFeatureCreators(app1.id)
       def editors2 = appApi.findFeatureEditors(app1.id)
@@ -242,7 +242,8 @@ class ApplicationSpec extends BaseSpec {
     and: "i remove the create role"
       def group3 = groupSqlApi.getGroup(group.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app1.id), superPerson)
       group3.applicationRoles[0].roles.removeIf { it == ApplicationRoleType.FEATURE_EDIT_AND_DELETE }
-      def groupWithEditPerms = groupSqlApi.updateGroup(group.id, group3, app1.id, false, true, false, Opts.opts(FillOpts.Acls))
+      def groupWithEditPerms = groupSqlApi.updateGroup(group.id,
+        new UpdateGroup().version(group3.version).applicationRoles(group3.applicationRoles), app1.id, true, false, Opts.opts(FillOpts.Acls))
       def creators3 = appApi.findFeatureCreators(app1.id)
       def editors3 = appApi.findFeatureEditors(app1.id)
       def personIsCreator3 = appApi.personIsFeatureCreator(app1.id, deepme.id)
@@ -282,8 +283,7 @@ class ApplicationSpec extends BaseSpec {
       database.save(prilipko)
       def prilipkoPortfolioAdmin = convertUtils.toPerson(prilipko)
       def g = groupSqlApi.getGroup(p1AdminGroup.id, Opts.opts(FillOpts.Members), superPerson)
-      g.members.add(prilipkoPortfolioAdmin)
-      groupSqlApi.updateGroup(p1AdminGroup.id, g, null, true, false, false, Opts.empty())
+      groupSqlApi.addPersonsToGroup(g.id, [prilipkoPortfolioAdmin.id.id], Opts.empty())
     and: "I create a new portfolio group and add in Golodryga by he has no permission to an application"
       def golodryga = new DbPerson.Builder().email("Golodryga@m.com").name("Golodryga").build()
       database.save(golodryga)
@@ -296,14 +296,14 @@ class ApplicationSpec extends BaseSpec {
       database.save(sverbylo)
       def sverbyloHasReadAccess = convertUtils.toPerson(sverbylo)
       def iGroup = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("Itchy Group"), superPerson)
-      iGroup = groupSqlApi.updateGroup(iGroup.id, iGroup.members([sverbyloHasReadAccess]), null, true, false, false, Opts.empty())
+      iGroup = groupSqlApi.addPersonsToGroup(iGroup.id, [sverbyloHasReadAccess.id.id], Opts.empty())
     when: "i create a new application"
       def newApp = appApi.createApplication(portfolio1.id, new CreateApplication().description("x").name("app-perm-check-appl1"), superPerson)
     and: "a new environment"
       def env = environmentSqlApi.create(new CreateEnvironment().description("x").name("production").production(true), newApp.id, superPerson)
     and: "i grant the iGroup access to it"
-      groupSqlApi.updateGroup(iGroup.id, iGroup.environmentRoles(
-        [new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(env.id)]), null, false, false, true, Opts.empty())
+      groupSqlApi.updateGroup(iGroup.id, new UpdateGroup().version(iGroup.version).environmentRoles(
+        [new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(env.id)]), null, false, true, Opts.empty())
     then: "Prilipko is a portfolio admin and can see read the application even with no app direct access"
       appApi.personIsFeatureReader(newApp.id, prilipkoPortfolioAdmin.id.id)
      and: "Golodryga cannot see the application's features"
@@ -335,11 +335,11 @@ class ApplicationSpec extends BaseSpec {
       def group = groupSqlApi.createGroup(portfolio.id,
         new CreateGroup().name("creators-" + RandomStringUtils.randomAlphabetic(6)).admin(false),
         superPerson)
-      groupSqlApi.addPersonToGroup(group.id, person.id.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(group.id, [person.id.id], Opts.empty())
       groupSqlApi.updateGroup(group.id,
-        group.applicationRoles([
+        new UpdateGroup().version(group.version).applicationRoles([
           new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_EDIT])
-        ]), app1.id, false, true, false, Opts.opts(FillOpts.Acls))
+        ]), app1.id, true, false, Opts.opts(FillOpts.Acls))
     when:
       def result = appApi.personIsFeatureCreatorInPortfolio(portfolio.id, person.id.id)
     then:
@@ -366,11 +366,11 @@ class ApplicationSpec extends BaseSpec {
       def group = groupSqlApi.createGroup(portfolio.id,
         new CreateGroup().name("readers-" + RandomStringUtils.randomAlphabetic(6)).admin(false),
         superPerson)
-      groupSqlApi.addPersonToGroup(group.id, person.id.id, Opts.empty())
+      group = groupSqlApi.addPersonsToGroup(group.id, [person.id.id], Opts.empty())
       groupSqlApi.updateGroup(group.id,
-        group.applicationRoles([
+        new UpdateGroup().version(group.version).applicationRoles([
           new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_EDIT])
-        ]), app1.id, false, true, false, Opts.opts(FillOpts.Acls))
+        ]), app1.id, true, false, Opts.opts(FillOpts.Acls))
     when:
       def result = appApi.personIsFeatureReaderInPortfolio(portfolio.id, person.id.id)
     then:

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/AuthenticationSpec.groovy
@@ -235,8 +235,7 @@ class AuthenticationSpec extends BaseSpec {
         new CreateGroup().name("admin-group").admin(true)
           .applicationRoles([new ApplicationGroupRole().applicationId(app1.id)
                                .roles([ApplicationRoleType.FEATURE_EDIT])]), superPerson)
-      groupSqlApi.updateGroup(portfolioGroup.id, portfolioGroup.members([p2]), null,
-        true, false, false, Opts.empty())
+      groupSqlApi.addPersonsToGroup(portfolioGroup.id, [p2.id.id], Opts.empty())
     when: "i login"
       def user = auth.login(p2.email, "hooray")
     then: "i have the application role permission to the portfolio"

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Base2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Base2Spec.groovy
@@ -69,7 +69,7 @@ class Base2Spec extends DbSpecification {
       adminGroup = groupSqlApi.findOrganizationAdminGroup(org.id, Opts.empty())
     }
 
-    groupSqlApi.addPersonToGroup(adminGroup.id, superuser, Opts.empty())
+    groupSqlApi.addPersonsToGroup(adminGroup.id, [superuser], Opts.empty())
   }
 
   @CompileStatic

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Base3Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Base3Spec.groovy
@@ -89,7 +89,7 @@ class Base3Spec extends Specification {
       adminGroup = groupSqlApi.findOrganizationAdminGroup(org.id, Opts.empty())
     }
 
-    groupSqlApi.addPersonToGroup(adminGroup.id, superuser, Opts.empty())
+    groupSqlApi.addPersonsToGroup(adminGroup.id, [superuser], Opts.empty())
 
     rsValidator = Mock()
     rsValidator.validateStrategies(_, _, _) >> new RolloutStrategyValidator.ValidationFailure()

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/BaseSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/BaseSpec.groovy
@@ -73,6 +73,6 @@ class BaseSpec extends Specification {
       adminGroup = groupSqlApi.createOrgAdminGroup(org.id, 'admin group', superPerson)
     }
 
-    groupSqlApi.addPersonToGroup(adminGroup.id, superuser, Opts.empty())
+    groupSqlApi.addPersonsToGroup(adminGroup.id, [superuser], Opts.empty())
   }
 }

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/Environment2Spec.groovy
@@ -25,6 +25,7 @@ import io.featurehub.mr.model.Group
 import io.featurehub.mr.model.RoleType
 import io.featurehub.mr.model.UpdateEnvironment
 import io.featurehub.mr.model.UpdateEnvironmentV2
+import io.featurehub.mr.model.UpdateGroup
 import org.apache.commons.lang3.RandomStringUtils
 import org.jetbrains.annotations.Nullable
 
@@ -60,7 +61,7 @@ class Environment2Spec extends Base2Spec {
 
     // create the portfolio group
     groupInPortfolio1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("p1-app-1-env1-portfolio-group").admin(true), superPerson)
-    groupSqlApi.addPersonToGroup(groupInPortfolio1.id, superPerson.id.id, Opts.empty())
+    groupSqlApi.addPersonsToGroup(groupInPortfolio1.id, [superPerson.id.id], Opts.empty())
 
     app1 = appApi.createApplication(portfolio1.id, new CreateApplication().description("x").name('app-1-env'), superPerson)
     assert app1 != null && app1.id != null
@@ -300,7 +301,7 @@ class Environment2Spec extends Base2Spec {
       db.save(averageJoe)
       def averageJoeMemberOfPortfolio1 = convertUtils.toPerson(averageJoe)
     and: "i create a general (non-admin) portfolio group"
-      groupSqlApi.addPersonToGroup(groupInPortfolio1.id, averageJoeMemberOfPortfolio1.id.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(groupInPortfolio1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
     when: 'i ask for environment access'
       def averageJoAccess = envApi.getEnvironmentsUserCanAccess(app1.id, averageJoe.id)
     then:
@@ -315,7 +316,7 @@ class Environment2Spec extends Base2Spec {
       def averageJoeMemberOfPortfolio1 = convertUtils.toPerson(averageJoe)
     and: "i create a general (non-admin) portfolio group"
       groupInPortfolio1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("envspec-p1-plain-portfolio-group"), superPerson)
-      groupSqlApi.addPersonToGroup(groupInPortfolio1.id, averageJoeMemberOfPortfolio1.id.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(groupInPortfolio1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
     and: "i have an environment"
       def env = envApi.create(new CreateEnvironment().name("env-1-perm-1").description("1"), app1.id, superPerson)
     when: "i find out of the superuser has permissions to the environment"
@@ -336,7 +337,7 @@ class Environment2Spec extends Base2Spec {
       def g = groupSqlApi.getGroup(groupInPortfolio1.id, Opts.opts(FillOpts.Members), superPerson)
 //      g.members.add(averageJoeMemberOfPortfolio1)
       g.environmentRoles.add(new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.CHANGE_VALUE]))
-      groupSqlApi.updateGroup(g.id, g, null, false, false, true, Opts.empty())
+      groupSqlApi.updateGroup(g.id, new UpdateGroup().version(g.version).environmentRoles(g.environmentRoles), null, false, true, Opts.empty())
       def permsAverageJoeAfterAddingPerms = envApi.personRoles(averageJoeMemberOfPortfolio1, env.id)
       def permsAdmin = envApi.personRoles(superPerson, env.id)
       appPermsJoe = appApi.findApplicationPermissions(app1.id, averageJoe.id)
@@ -356,7 +357,7 @@ class Environment2Spec extends Base2Spec {
     when: "I make average joe a feature creator"
       g = groupSqlApi.getGroup(groupInPortfolio1.id, Opts.opts(FillOpts.Acls), superPerson)
       g.applicationRoles.add(new ApplicationGroupRole().applicationId(app1.id).roles([ApplicationRoleType.FEATURE_CREATE]))
-      def permsAverageJoeAfterAdminOfApp1 = groupSqlApi.updateGroup(g.id, g, app1.id, false, true, false, Opts.opts(FillOpts.Acls))
+      def permsAverageJoeAfterAdminOfApp1 = groupSqlApi.updateGroup(g.id, new UpdateGroup().version(g.version).applicationRoles(g.applicationRoles), app1.id, true, false, Opts.opts(FillOpts.Acls))
       averageJoAccess = envApi.getEnvironmentsUserCanAccess(app1.id, averageJoe.id)
       appPermsJoe = appApi.findApplicationPermissions(app1.id, averageJoe.id)
     then: "the permissions to the portfolio are empty"

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/FeatureSpec.groovy
@@ -36,6 +36,7 @@ import io.featurehub.mr.model.RolloutStrategyAttributeConditional
 import io.featurehub.mr.model.RolloutStrategyFieldType
 import io.featurehub.mr.model.ServiceAccountPermission
 import io.featurehub.mr.model.SortOrder
+import io.featurehub.mr.model.UpdateGroup
 import org.apache.commons.lang3.RandomStringUtils
 
 class FeatureSpec extends Base2Spec {
@@ -100,7 +101,7 @@ class FeatureSpec extends Base2Spec {
     db.save(averageJoe)
     averageJoeMemberOfPortfolio1 = convertUtils.toPerson(averageJoe)
     groupInPortfolio1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("fsspec-1-p1"), superPerson)
-    groupSqlApi.addPersonToGroup(groupInPortfolio1.id, averageJoeMemberOfPortfolio1.id.id, Opts.empty())
+    groupSqlApi.addPersonsToGroup(groupInPortfolio1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
 
     def averageIrina = new DbPerson.Builder().email(ranName() +"averageirina@featurehub.io").name("Average Irina").build()
     db.save(averageIrina)
@@ -111,7 +112,7 @@ class FeatureSpec extends Base2Spec {
     portfolioAdminOfPortfolio1 = convertUtils.toPerson(portfolioAdmin)
 
     adminGroupInPortfolio1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().admin(true).name(ranName()), superPerson)
-    groupSqlApi.addPersonToGroup(adminGroupInPortfolio1.id, portfolioAdminOfPortfolio1.id.id, Opts.empty())
+    groupSqlApi.addPersonsToGroup(adminGroupInPortfolio1.id, [portfolioAdminOfPortfolio1.id.id], Opts.empty())
 
     if (db.currentTransaction() != null && db.currentTransaction().active) {
       db.currentTransaction().commit()
@@ -459,13 +460,13 @@ class FeatureSpec extends Base2Spec {
       def env1 = environmentSqlApi.create(new CreateEnvironment().description("x").name("production"), app2Id, superPerson)
     and: "i allow average joe access to access the environment"
       Group g1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("app2-f1-test"), superPerson)
-      g1.environmentRoles([
-        new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]).environmentId(env1.id),
-      ])
-      g1.members = [averageJoeMemberOfPortfolio1]
-      groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, Opts.empty());
+      g1 = groupSqlApi.addPersonsToGroup(g1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
+      groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(g1.version)
+        .environmentRoles([new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]).environmentId(env1.id)]),
+        null, false, true, Opts.empty());
     when: 'application features with null filter'
-      ApplicationFeatureValues withNull = featureSqlApi.findAllFeatureAndFeatureValuesForEnvironmentsByApplication(app2Id, averageJoeMemberOfPortfolio1, null, null, null, null, null, null, [])
+      ApplicationFeatureValues withNull = featureSqlApi.findAllFeatureAndFeatureValuesForEnvironmentsByApplication(app2Id, averageJoeMemberOfPortfolio1,
+        null, null, null, null, null, null, [])
     then:
       1 * mockCacheSourceFeatureGroupApi.collectStrategiesFromEnvironmentsWithFeatures([env1.id], _) >> []
       withNull.environments.size() == 1
@@ -486,11 +487,10 @@ class FeatureSpec extends Base2Spec {
       appApi.createApplicationFeature(app2Id, new CreateFeature().description("x").name('not').key('FEATURE_ALEX').description('not').valueType(FeatureValueType.BOOLEAN), superPerson, Opts.empty())
     and: "i allow average joe access to access the environment"
       Group g1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("app2-f1-test"), superPerson)
-      g1.environmentRoles([
+      g1 = groupSqlApi.addPersonsToGroup(g1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
+      groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(g1.version).environmentRoles([
         new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]).environmentId(env1.id),
-      ])
-      g1.members = [averageJoeMemberOfPortfolio1]
-      groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, Opts.empty());
+      ]), null, false, true, Opts.empty());
     when: "i request application features for 'desc'"
       ApplicationFeatureValues withDesc = featureSqlApi.findAllFeatureAndFeatureValuesForEnvironmentsByApplication(app2Id, averageJoeMemberOfPortfolio1, 'desc', null, null, null, null, null, [])
     and: 'application features with null'
@@ -529,13 +529,12 @@ class FeatureSpec extends Base2Spec {
         Opts.empty())
     and: "i allow average joe access to two of the three environments"
       Group g1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("app2-f1-test"), superPerson)
-      g1.environmentRoles([
+      g1 = groupSqlApi.addPersonsToGroup(g1.id, [averageJoeMemberOfPortfolio1.id.id], Opts.empty())
+      groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(g1.version).environmentRoles([
         new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]).environmentId(env1.id),
         new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE, RoleType.LOCK]).environmentId(env3.id),
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(env2.id)
-      ])
-      g1.members = [averageJoeMemberOfPortfolio1]
-      groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, Opts.empty());
+      ]), null, false, true, Opts.empty());
     and: "i create a feature value called FEATURE_BUNCH and unlock the feature in all branches"
       String k = 'FEATURE_BUNCH'
       appApi.createApplicationFeature(app2Id, new CreateFeature().description("x").name(k).key(k).valueType(FeatureValueType.BOOLEAN), superPerson, Opts.empty())
@@ -670,9 +669,10 @@ class FeatureSpec extends Base2Spec {
     and: "a group in the current portfolio"
       def group = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("lockunlock group"), superPerson)
     and: "i add permissions and members to the group"
-      group.environmentRoles([new EnvironmentGroupRole().environmentId(env1.id).roles([RoleType.LOCK, RoleType.UNLOCK, RoleType.READ])])
-      group.members([person])
-      group = groupSqlApi.updateGroup(group.id, group, null, true, false, true, Opts.empty())
+      groupSqlApi.addPersonsToGroup(group.id, [person.id.id], Opts.empty())
+      groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group.version).environmentRoles([
+        new EnvironmentGroupRole().roles([RoleType.READ, RoleType.LOCK, RoleType.UNLOCK]).environmentId(env1.id),
+      ]), null, false, true, Opts.empty());
     when: "i try and unlock the feature with the person, it will let me"
       def fv = featureSqlApi.getFeatureValueForEnvironment(env1.id, key)
       if (fv == null) {

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
@@ -26,6 +26,7 @@ import io.featurehub.mr.model.PersonId
 import io.featurehub.mr.model.Portfolio
 import io.featurehub.mr.model.RoleType
 import io.featurehub.mr.model.SortOrder
+import io.featurehub.mr.model.UpdateGroup
 import spock.lang.Shared
 
 class GroupSpec extends BaseSpec {
@@ -71,11 +72,11 @@ class GroupSpec extends BaseSpec {
     and: "create a new group"
       def group = groupSqlApi.createGroup(commonPortfolio.id, new CreateGroup().name("acl-test-filter-group"), superPerson)
     and: "i create permissions in the group for both environments"
-      def groupUpdated = groupSqlApi.updateGroup(group.id, group.environmentRoles([
+      def groupUpdated = groupSqlApi.updateGroup(group.id, new UpdateGroup().version(group.version).environmentRoles([
         new EnvironmentGroupRole().environmentId(env1App1.id).roles([RoleType.UNLOCK]),
         new EnvironmentGroupRole().environmentId(env2.id).roles([RoleType.CHANGE_VALUE])
       ]), null,
-        false, false, true, Opts.opts(FillOpts.Acls))
+        false, true, Opts.opts(FillOpts.Acls))
     when: "i ask for the permissions only for application 2"
       def groupApp2 = groupSqlApi.getGroup(group.id, Opts.opts(FillOpts.Acls).add(FilterOptType.Application, app2.id), superPerson)
     then:
@@ -94,10 +95,10 @@ class GroupSpec extends BaseSpec {
     and: "i create a new group in the common portfolio"
       Group g = groupSqlApi.createGroup(commonPortfolio.id, new CreateGroup().name("plain-bob-group"), superPerson)
     and: "i update it with the basic user"
-      groupSqlApi.updateGroup(g.id, g.members([bob]), null, true, false, false, Opts.empty())
+      groupSqlApi.addPersonsToGroup(g.id, [bob.id.id], Opts.empty())
     when: "i add jane as a portfolio admin"
       def latestGroup = groupSqlApi.getGroup(portfolioAdminGroup.id, Opts.opts(FillOpts.Members), superPerson)
-      groupSqlApi.updateGroup(portfolioAdminGroup.id, portfolioAdminGroup.addMembersItem(jane), null, true, false, false, Opts.empty())
+      groupSqlApi.addPersonsToGroup(g.id, [jane.id.id], Opts.empty())
     then: "bob can get the group"
       groupSqlApi.getGroup(g.id, Opts.opts(FillOpts.Members), bob)
     and: "jane can get the group"
@@ -166,7 +167,7 @@ class GroupSpec extends BaseSpec {
 
   def "i can only add users to a group that exists"() {
     when:
-      Group g = groupSqlApi.addPersonToGroup(UUID.randomUUID(), superuser, Opts.empty())
+      Group g = groupSqlApi.addPersonsToGroup(UUID.randomUUID(), [superuser], Opts.empty())
     then:
       g == null
   }
@@ -183,10 +184,11 @@ class GroupSpec extends BaseSpec {
   def "i can't add non existent people to a group"() {
     given: "i have a group"
       Group g = nonAdminGroup()
+      def randomUser = UUID.randomUUID()
     when: "i add a non existent person"
-      Group ng = groupSqlApi.addPersonToGroup(g.id, UUID.randomUUID(), Opts.empty())
+      Group ng = groupSqlApi.addPersonsToGroup(g.id, [randomUser], Opts.opts(FillOpts.Members))
     then:
-      ng == null
+      ng.members.find(p -> p.id.id == randomUser) == null
   }
 
   def "i can't create the same portfolio group name twice"() {
@@ -203,7 +205,7 @@ class GroupSpec extends BaseSpec {
       groupSqlApi.createGroup(commonPortfolio.id, new CreateGroup().name("update-ecks"), superPerson)
     when: "i try and create another group with the same name"
       def g = groupSqlApi.createGroup(commonPortfolio.id, new CreateGroup().name("update-ecks1"), superPerson)
-      groupSqlApi.updateGroup(g.id, g.name("update-ecks"), null, true, true, true, Opts.empty())
+      groupSqlApi.updateGroup(g.id, new UpdateGroup().version(g.version).name("update-ecks"), null, false, false, Opts.empty())
     then: "it throws a DuplicateGroupException"
       thrown(GroupApi.DuplicateGroupException)
   }
@@ -217,9 +219,9 @@ class GroupSpec extends BaseSpec {
       database.save(person)
       def personId = person.id
     when: "i add a person to the group"
-      Group ng = groupSqlApi.addPersonToGroup(g.id, personId, Opts.empty())
+      Group ng = groupSqlApi.addPersonsToGroup(g.id, [personId], Opts.empty())
     and: "i add the person to the group again"
-      Group sng = groupSqlApi.addPersonToGroup(g.id, personId, Opts.opts(FillOpts.Members))
+      Group sng = groupSqlApi.addPersonsToGroup(g.id, [personId], Opts.opts(FillOpts.Members))
     and: "i check the org admin groups this generic person is part of"
       def adminGroups = groupSqlApi.groupsPersonOrgAdminOf(personId)
     then:
@@ -241,7 +243,7 @@ class GroupSpec extends BaseSpec {
     when: "i add all people to the group"
       Group group
       people.each { DbPerson p ->
-        group = groupSqlApi.addPersonToGroup(g.id, p.id, Opts.opts(FillOpts.Members))
+        group = groupSqlApi.addPersonsToGroup(g.id, [p.id], Opts.opts(FillOpts.Members))
       }
     then:
       group != null
@@ -278,7 +280,7 @@ class GroupSpec extends BaseSpec {
     and: "i am not a member of the portfolio"
       boolean amNotMember = !groupSqlApi.isPersonMemberOfPortfolioGroup(g.portfolioId, person.id)
     when: "i add a person to the group"
-      Group addedToGroup = groupSqlApi.addPersonToGroup(g.id, person.id, Opts.opts(FillOpts.Members))
+      Group addedToGroup = groupSqlApi.addPersonsToGroup(g.id, [person.id], Opts.opts(FillOpts.Members))
     and: "i am confirmed to be a portfolio member"
       boolean amMember = groupSqlApi.isPersonMemberOfPortfolioGroup(g.portfolioId, person.id)
     and: "i delete the person from the group"
@@ -321,9 +323,9 @@ class GroupSpec extends BaseSpec {
 
   def "i rename a group"() {
     given: "i have a group"
-      Group g = nonAdminGroup().name("new name")
+      Group g = nonAdminGroup()
     when: "i rename it"
-      groupSqlApi.updateGroup(g.id, g, null, true, true, true, Opts.empty())
+      groupSqlApi.updateGroup(g.id, new UpdateGroup().version(g.version).name("new name"), null, false, false, Opts.empty())
     and: "find it again"
       Group ng = groupSqlApi.getGroup(g.id, Opts.empty(), superPerson)
     then:
@@ -341,19 +343,10 @@ class GroupSpec extends BaseSpec {
       database.save(p2)
       database.save(p3)
     when: "i update the group to add Sasha and Alena"
-      g.members = [
-        new Person().id(new PersonId().id(p1.id)),
-        new Person().id(new PersonId().id(p2.id)),
-      ]
-      def g2 = groupSqlApi.updateGroup(g.id, g, null, true, true, true, new Opts().add(FillOpts.Members))
+      def g2 = groupSqlApi.addPersonsToGroup(g.id, [p1.id, p2.id], Opts.opts(FillOpts.Members))
     and: "I updated the group to remove Alena and add Toya"
-      def g2_copy = g2.copy()
-      g2_copy.members = [
-        new Person().id(new PersonId().id(p1.id)),
-        new Person().id(new PersonId().id(p3.id)),
-      ]
-      groupSqlApi.updateGroup(g.id, g2_copy, null, true, true, true, new Opts().add(FillOpts.Members))
-      def g3 = groupSqlApi.getGroup(g.id, new Opts().add(FillOpts.Members), superPerson)
+      groupSqlApi.deletePersonFromGroup(g.id, p2.id, Opts.empty())
+      def g3 = groupSqlApi.addPersonsToGroup(g.id, [p3.id], Opts.opts(FillOpts.Members))
     then:
       g2.members.size() == 2
       g2.members*.name.contains('Alena')
@@ -365,8 +358,8 @@ class GroupSpec extends BaseSpec {
 
   def "i cannot rename a non-existent group"() {
     when: "i rename it"
-      Group g = groupSqlApi.updateGroup(UUID.randomUUID(), new Group().name("new name"), null,
-        true, true, true, Opts.empty())
+      Group g = groupSqlApi.updateGroup(UUID.randomUUID(), new UpdateGroup().version(1).name("new name"), null,
+        true, true, Opts.empty())
     then:
       g == null
   }
@@ -413,8 +406,8 @@ class GroupSpec extends BaseSpec {
     and: "i add a person to this group"
       DbPerson user = new DbPerson.Builder().email("bob-test@featurehub.io").name("Rob test").build();
       database.save(user);
-      groupSqlApi.addPersonToGroup(g1.id, user.id, Opts.empty())
-      groupSqlApi.addPersonToGroup(g3.id, user.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(g1.id, [user.id], Opts.empty())
+      groupSqlApi.addPersonsToGroup(g3.id, [user.id], Opts.empty())
     when: "i get their admin groups"
       List<Group> groups = groupSqlApi.groupsWherePersonIsAnAdminMember(user.id)
     then:
@@ -441,23 +434,27 @@ class GroupSpec extends BaseSpec {
       DbEnvironment env3 = new DbEnvironment.Builder().name("gp-acl-3").parentApplication(app).whoCreated(user).build()
       database.save(env3)
     when: "I update the group to include acls"
-      g1.environmentRoles = [new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.CHANGE_VALUE, RoleType.LOCK])]
-      def updGroup = groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, new Opts().add(FillOpts.Acls))
+      def updGroup = groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(g1.version).environmentRoles(
+        [new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.CHANGE_VALUE, RoleType.LOCK])]
+      ), null, false, true, new Opts().add(FillOpts.Acls))
     and: "i get the group with acls requested"
       def getUpd = groupSqlApi.getGroup(g1.id, new Opts().add(FillOpts.Acls), superPerson)
     and: "the i update the roles"
-      g1.environmentRoles = [
-                new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.LOCK, RoleType.READ]),
-                new EnvironmentGroupRole().environmentId(env3.id)]
-      def updGroup1 = groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, new Opts().add(FillOpts.Acls))
+      def updGroup1 = groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(getUpd.version).environmentRoles(
+      [
+        new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.LOCK, RoleType.READ]),
+        new EnvironmentGroupRole().environmentId(env3.id)]
+      ), null, false, true, new Opts().add(FillOpts.Acls))
     and: "then i add another environment role and remove the first"
-      g1.environmentRoles = [new EnvironmentGroupRole().environmentId(env2.id).roles([RoleType.UNLOCK]), // READ implicit
-                             new EnvironmentGroupRole().environmentId(env.id),
-                             new EnvironmentGroupRole().environmentId(env3.id) ]
-      def updGroup2 = groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, new Opts().add(FillOpts.Acls))
+      def updGroup2 = groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(updGroup1.version).environmentRoles(
+        [new EnvironmentGroupRole().environmentId(env2.id).roles([RoleType.UNLOCK]), // READ implicit
+         new EnvironmentGroupRole().environmentId(env.id),
+         new EnvironmentGroupRole().environmentId(env3.id) ]
+      ), null, false, true, new Opts().add(FillOpts.Acls))
     and: "then i add back in just environment 1 but it should preserve environment 2"
-      g1.environmentRoles = [new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.LOCK])] // READ implicit
-      def updGroup3 = groupSqlApi.updateGroup(g1.id, g1, null, true, true, true, new Opts().add(FillOpts.Acls))
+      def updGroup3 = groupSqlApi.updateGroup(g1.id, new UpdateGroup().version(updGroup2.version).environmentRoles(
+        [new EnvironmentGroupRole().environmentId(env.id).roles([RoleType.LOCK])] // READ implicit
+      ), null, false, true, new Opts().add(FillOpts.Acls))
     and: "i get the env2 with its group roles"
       def fullEnv2 = environmentSqlApi.get(env2.id, Opts.opts(FillOpts.Acls), superPerson)
     then:
@@ -487,12 +484,15 @@ class GroupSpec extends BaseSpec {
     and: "i find the group including the acls"
       def found = groupSqlApi.getGroup(g1.id, Opts.opts(FillOpts.Acls), superPerson)
     and: "i update the group to include environment acls"
-      def updating = found.copy()
-      updating.environmentRoles = [
-        new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE]).environmentId(env1App1.id).groupId(g1.id)
-      ]
-      updating.applicationRoles.add(new ApplicationGroupRole().roles([ApplicationRoleType.FEATURE_EDIT]).applicationId(commonApplication2.id))
-      def up1 = groupSqlApi.updateGroup(g1.id, updating, null, true, true, true, Opts.opts(FillOpts.Acls))
+      def upd = new UpdateGroup().version(g1.version)
+        .environmentRoles([
+          new EnvironmentGroupRole().roles([RoleType.CHANGE_VALUE]).environmentId(env1App1.id).groupId(g1.id)
+        ]).applicationRoles([
+        new ApplicationGroupRole().roles([ApplicationRoleType.FEATURE_EDIT]).applicationId(commonApplication2.id),
+      ])
+      upd.applicationRoles.addAll(found.applicationRoles)
+      def up1 = groupSqlApi.updateGroup(g1.id, upd,
+         null, true, true, Opts.opts(FillOpts.Acls))
     when: "i find the group"
       def found1 = groupSqlApi.getGroup(g1.id, Opts.opts(FillOpts.Acls), superPerson)
     then:
@@ -506,7 +506,7 @@ class GroupSpec extends BaseSpec {
       def iSuperPerson = new DbPerson.Builder().email("irushka@featurehub.io").name("Irina").build()
       database.save(iSuperPerson)
       def adminGroup = groupSqlApi.findOrganizationAdminGroup(org.id, Opts.empty())
-      groupSqlApi.addPersonToGroup(adminGroup.id, iSuperPerson.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(adminGroup.id, [iSuperPerson.id], Opts.empty())
     and: "i get the person"
       def person = personApi.get(iSuperPerson.id, Opts.opts(FillOpts.Groups))
     when: "i update the person to remove the superuser group"

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/PersonSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/PersonSpec.groovy
@@ -120,7 +120,7 @@ class PersonSpec extends BaseSpec {
     and: "add the person to the group"
       g1.members.add(pers)
       g1.members.add(pers2)
-      def group = groupSqlApi.updateGroup(g1.id, g1, null, true, false, false, Opts.opts(FillOpts.Members))
+      def group = groupSqlApi.addPersonsToGroup(g1.id, [pers.id.id, pers2.id.id], Opts.opts(FillOpts.Members))
     when:
       personSqlApi.delete(person.email, true)
     and:
@@ -252,7 +252,7 @@ class PersonSpec extends BaseSpec {
       def pAdmin = new DbPerson.Builder().name("Frederick Von Brinkenstorm").email("freddy@mailinator.com").build()
       database.save(pAdmin)
       def pAdminId = pAdmin.id
-      def adminPersonAddedToGroup = groupSqlApi.addPersonToGroup(gPortfolioAdmin.id, pAdminId, Opts.empty())
+      def adminPersonAddedToGroup = groupSqlApi.addPersonsToGroup(gPortfolioAdmin.id, [pAdminId], Opts.empty())
     when: "the portfolio admin updates the person to add the two groups, but only have access to 1"
       def originalPerson = personSqlApi.get(person.id, Opts.empty())
       def resultingPerson = personSqlApi.update(person.id,
@@ -293,7 +293,7 @@ class PersonSpec extends BaseSpec {
       def pAdmin = new DbPerson.Builder().name("Frederick Von Brinkenstorm").email(RandomStringUtils.randomAlphabetic(4) + "freddy@mailinator.com").build()
       database.save(pAdmin)
       def pAdminId = pAdmin.id
-      def adminPersonAddedToGroup = groupSqlApi.addPersonToGroup(gPortfolioAdmin.id, pAdminId, Opts.empty())
+      def adminPersonAddedToGroup = groupSqlApi.addPersonsToGroup(gPortfolioAdmin.id, [pAdminId], Opts.empty())
     when: "the portfolio admin updates the person to add the two groups, but only have access to 1"
       def originalPerson = personSqlApi.get(person.id, Opts.empty())
       def resultingPerson = personSqlApi.updateV2(person.id, new UpdatePerson().version(originalPerson.version)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/PortfolioSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/PortfolioSpec.groovy
@@ -55,7 +55,7 @@ class PortfolioSpec extends BaseSpec {
     when: "superuser creates a group"
       Portfolio created = portfolioApi.createPortfolio(new CreatePortfolio().name("normal-port-check1"), Opts.empty(), superuser)
       Group group = groupSqlApi.createGroup(created.id, new CreateGroup().name(created.name), superPerson)
-      groupSqlApi.addPersonToGroup(group.id, normalPerson.id.id, Opts.empty())
+      groupSqlApi.addPersonsToGroup(group.id, [normalPerson.id.id], Opts.empty())
     then:
       created != null
       portfolioApi.getPortfolio(created.id, Opts.empty(), normalPerson.id.id).name == created.name

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ServiceAccount2Spec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/ServiceAccount2Spec.groovy
@@ -24,6 +24,7 @@ import io.featurehub.mr.model.PersonType
 import io.featurehub.mr.model.RoleType
 import io.featurehub.mr.model.ServiceAccount
 import io.featurehub.mr.model.ServiceAccountPermission
+import io.featurehub.mr.model.UpdateGroup
 import org.apache.commons.lang3.RandomStringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -69,13 +70,13 @@ class ServiceAccount2Spec extends Base2Spec {
 
     environmentApi = new EnvironmentSqlApi(db, convertUtils, cacheSource, archiveStrategy, internalFeatureApi, Mock(WebhookEncryptionService))
 
-    groupSqlApi.updateGroup(portfolioGroup.id, portfolioGroup.environmentRoles(
+    groupSqlApi.updateGroup(portfolioGroup.id, new UpdateGroup().version(portfolioGroup.version).environmentRoles(
       [
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(environment1.id),
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(environment2.id),
         new EnvironmentGroupRole().roles([RoleType.READ]).environmentId(environment3.id),
       ]
-    ), null, false, false, true, Opts.empty())
+    ), null, false, true, Opts.empty())
 
     if (db.currentTransaction() != null && db.currentTransaction().active) {
       db.currentTransaction().commitAndContinue()

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/UserStateSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/UserStateSpec.groovy
@@ -41,7 +41,7 @@ class UserStateSpec extends BaseSpec {
 
     // create the portfolio group
     groupInPortfolio1 = groupSqlApi.createGroup(portfolio1.id, new CreateGroup().name("p1-user-spec-admin").admin(true), superPerson)
-    groupSqlApi.addPersonToGroup(groupInPortfolio1.id, superPerson.id.id, Opts.empty())
+    groupSqlApi.addPersonsToGroup(groupInPortfolio1.id, [superPerson.id.id], Opts.empty())
 
     app1 = appApi.createApplication(portfolio1.id, new CreateApplication().description("x").name('app1-user-spec'), superPerson)
     assert app1 != null && app1.id != null

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
@@ -8,6 +8,7 @@ import io.featurehub.mr.model.CreateGroup
 import io.featurehub.mr.model.Group
 import io.featurehub.mr.model.Person
 import io.featurehub.mr.model.PersonId
+import io.featurehub.mr.model.UpdateGroup
 import jakarta.inject.Inject
 import jakarta.ws.rs.ForbiddenException
 import jakarta.ws.rs.NotFoundException
@@ -22,7 +23,7 @@ class GroupResource @Inject constructor(
   private val groupApi: GroupApi,
   private val authManager: AuthManagerService
 ) : GroupServiceDelegate {
-  internal inner class GroupHolder {
+  internal class GroupHolder {
     var group: Group? = null
     var delete = false
   }
@@ -36,6 +37,14 @@ class GroupResource @Inject constructor(
     val person = personApi[id, Opts.empty()] ?: throw NotFoundException("No such person")
     action.accept(person)
     return person
+  }
+
+  private fun personCheck(ids: List<UUID>, emailAddresses: List<String>, action: Consumer<Set<UUID>>): Set<UUID> {
+    val matchedPersons = personApi.findPeople(ids, emailAddresses)
+    if (matchedPersons.isNotEmpty()) {
+      action.accept(matchedPersons)
+    }
+    return matchedPersons
   }
 
   private fun isAdminOfGroup(
@@ -83,8 +92,37 @@ class GroupResource @Inject constructor(
           "No permission to add user to group."
         ) {
           groupHolder.group =
-            groupApi.addPersonToGroup(gid, personId, Opts()
+            groupApi.addPersonsToGroup(gid, listOf(personId), Opts()
               .add(FillOpts.Members, holder.includeMembers)
+              .add(FillOpts.MembersV2, holder.includeMembersV2)
+            )
+        }
+      }
+    }
+    if (groupHolder.group == null) {
+      throw NotFoundException()
+    }
+    return groupHolder.group!!
+  }
+
+  override fun addPersonsToGroup(
+    gid: UUID,
+    holder: GroupServiceDelegate.AddPersonsToGroupHolder,
+    securityContext: SecurityContext
+  ): Group {
+    val groupHolder = GroupHolder()
+    groupCheck(
+      gid,
+      authManager.from(securityContext)
+    ) { group: Group ->
+      personCheck(holder.personId ?: emptyList(), holder.email ?: emptyList()) { personIds ->
+        isAdminOfGroup(
+          group,
+          securityContext,
+          "No permission to add user to group."
+        ) {
+          groupHolder.group =
+            groupApi.addPersonsToGroup(gid, personIds.toList(), Opts()
               .add(FillOpts.MembersV2, holder.includeMembersV2)
             )
         }
@@ -106,7 +144,7 @@ class GroupResource @Inject constructor(
     if (authManager.isPortfolioAdmin(id, current, null)) {
       return try {
         groupApi.createGroup(id, createGroup, current) ?: throw NotFoundException()
-      } catch (e: GroupApi.DuplicateGroupException) {
+      } catch (_: GroupApi.DuplicateGroupException) {
         throw WebApplicationException(Response.Status.CONFLICT)
       }
     }
@@ -195,7 +233,7 @@ class GroupResource @Inject constructor(
 
   override fun updateGroupOnPortfolio(
     id: UUID,
-    group: Group,
+    group: UpdateGroup,
     holder: GroupServiceDelegate.UpdateGroupOnPortfolioHolder,
     securityContext: SecurityContext?
   ): Group {
@@ -207,7 +245,6 @@ class GroupResource @Inject constructor(
             group.id,
             group,
             holder.applicationId,
-            true == holder.updateMembers,
             true == holder.updateApplicationGroupRoles,
             true == holder.updateEnvironmentGroupRoles,
             Opts()
@@ -215,11 +252,11 @@ class GroupResource @Inject constructor(
               .add(FillOpts.MembersV2, holder.includeMembersV2)
               .add(FillOpts.Acls, holder.includeGroupRoles)
           )
-        } catch (e: OptimisticLockingException) {
+        } catch (_: OptimisticLockingException) {
           throw WebApplicationException(422)
-        } catch (e: GroupApi.DuplicateGroupException) {
+        } catch (_: GroupApi.DuplicateGroupException) {
           throw WebApplicationException(Response.Status.CONFLICT)
-        } catch (e: DuplicateUsersException) {
+        } catch (_: DuplicateUsersException) {
           throw WebApplicationException(Response.Status.CONFLICT)
         }
       }
@@ -229,40 +266,5 @@ class GroupResource @Inject constructor(
     }
     return groupHolder.group!!
 
-  }
-
-  @Deprecated("Deprecated in Java")
-  override fun updateGroup(
-    gid: UUID,
-    renameDetails: Group,
-    holder: GroupServiceDelegate.UpdateGroupHolder,
-    securityContext: SecurityContext
-  ): Group {
-    val groupHolder = GroupHolder()
-    groupCheck(gid, authManager.from(securityContext)) { group: Group ->
-      isAdminOfGroup(group, securityContext, "No permission to rename group.") {
-        try {
-          groupHolder.group = groupApi.updateGroup(
-            gid,
-            renameDetails,
-            holder.applicationId,
-            java.lang.Boolean.TRUE == holder.updateMembers,
-            java.lang.Boolean.TRUE == holder.updateApplicationGroupRoles,
-            java.lang.Boolean.TRUE == holder.updateEnvironmentGroupRoles,
-            Opts().add(FillOpts.Members, holder.includeMembers).add(FillOpts.Acls, holder.includeGroupRoles)
-          )
-        } catch (e: OptimisticLockingException) {
-          throw WebApplicationException(422)
-        } catch (e: GroupApi.DuplicateGroupException) {
-          throw WebApplicationException(Response.Status.CONFLICT)
-        } catch (e: DuplicateUsersException) {
-          throw WebApplicationException(Response.Status.CONFLICT)
-        }
-      }
-    }
-    if (groupHolder.group == null) {
-      throw NotFoundException()
-    }
-    return groupHolder.group!!
   }
 }

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
@@ -83,7 +83,10 @@ class GroupResource @Inject constructor(
           "No permission to add user to group."
         ) {
           groupHolder.group =
-            groupApi.addPersonToGroup(gid, personId, Opts().add(FillOpts.Members, holder.includeMembers))
+            groupApi.addPersonToGroup(gid, personId, Opts()
+              .add(FillOpts.Members, holder.includeMembers)
+              .add(FillOpts.MembersV2, holder.includeMembersV2)
+            )
         }
       }
     }
@@ -143,7 +146,9 @@ class GroupResource @Inject constructor(
           groupHolder.group = groupApi.deletePersonFromGroup(
             gid,
             personId,
-            Opts().add(FillOpts.Members, holder.includeMembers)
+            Opts()
+              .add(FillOpts.Members, holder.includeMembers)
+              .add(FillOpts.MembersV2, holder.includeMembersV2)
           )
         }
       }
@@ -178,10 +183,12 @@ class GroupResource @Inject constructor(
   ): Group {
     val opts =
       Opts().add(FillOpts.Acls, holder.includeGroupRoles).add(FilterOptType.Application, holder.byApplicationId)
+        .add(FillOpts.MembersV2, holder.includeMembersV2)
     if (java.lang.Boolean.TRUE == holder.includeMembers) {
       opts.add(FillOpts.People)
       opts.add(FillOpts.Members)
     }
+
     return groupApi.getGroup(gid, opts, authManager.from(securityContext))
       ?: throw NotFoundException("No such group")
   }
@@ -203,7 +210,10 @@ class GroupResource @Inject constructor(
             true == holder.updateMembers,
             true == holder.updateApplicationGroupRoles,
             true == holder.updateEnvironmentGroupRoles,
-            Opts().add(FillOpts.Members, holder.includeMembers).add(FillOpts.Acls, holder.includeGroupRoles)
+            Opts()
+              .add(FillOpts.Members, holder.includeMembers)
+              .add(FillOpts.MembersV2, holder.includeMembersV2)
+              .add(FillOpts.Acls, holder.includeGroupRoles)
           )
         } catch (e: OptimisticLockingException) {
           throw WebApplicationException(422)

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/PersonResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/PersonResource.kt
@@ -61,7 +61,7 @@ class PersonResource @Inject constructor(
       }
 
       createPersonDetails.groupIds?.forEach { id ->
-        groupApi.addPersonToGroup(id, person.id, Opts.empty())
+        groupApi.addPersonsToGroup(id, listOf(person.id), Opts.empty())
       }
 
       //return registration url
@@ -74,7 +74,7 @@ class PersonResource @Inject constructor(
           )
         ) // hard code the return value, it will be ignored by the client from now on
         .token(person.token)
-    } catch (e: PersonApi.DuplicatePersonException) {
+    } catch (_: PersonApi.DuplicatePersonException) {
       throw WebApplicationException(Response.status(Response.Status.CONFLICT).build())
     }
   }
@@ -94,7 +94,7 @@ class PersonResource @Inject constructor(
     val servicePersonId = person.id!!.id
 
     createPersonDetails.groupIds?.forEach { id ->
-      groupApi.addPersonToGroup(id, servicePersonId, Opts.empty())
+      groupApi.addPersonsToGroup(id, listOf(servicePersonId), Opts.empty())
     }
 
     // return registration url
@@ -227,9 +227,9 @@ class PersonResource @Inject constructor(
           peopleOpts(holder.includeAcls, holder.includeGroups),
           from.id!!.id
         )
-      } catch (e: OptimisticLockingException) {
+      } catch (_: OptimisticLockingException) {
         throw WebApplicationException(422)
-      } catch (iae: IllegalArgumentException) {
+      } catch (_: IllegalArgumentException) {
         throw BadRequestException()
       } ?: throw NotFoundException()
     }

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/SetupResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/SetupResource.kt
@@ -156,7 +156,7 @@ class SetupResource @Inject constructor(
 
     //create the group and add admin to the group - any preference on group name here?
     val group = groupApi.createOrgAdminGroup(organization.id!!, "org_admin", person!!)
-    groupApi.addPersonToGroup(group!!.id, person.id!!.id, Opts.empty())
+    groupApi.addPersonsToGroup(group!!.id, listOf(person.id!!.id), Opts.empty())
     person = personApi[person.id!!.id, Opts.opts(FillOpts.Groups, FillOpts.Acls)]
 
     // the capability needing to be returned is a unique problem of using username/password and

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/oauth2/OAuth2MRAdapter.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/oauth2/OAuth2MRAdapter.kt
@@ -99,7 +99,7 @@ class OAuth2MRAdapter @Inject constructor(
       val organization = organizationApi.get()
       // create the superuser group and add admin to the group -
       val group = groupApi.createOrgAdminGroup(organization.id, "org_admin", person)
-      groupApi.addPersonToGroup(group!!.id, person.id!!.id, Opts.empty())
+      groupApi.addPersonsToGroup(group!!.id, listOf(person.id!!.id), Opts.empty())
 
       // find the only portfolio and update its members to include this one
       val portfolio = portfolioApi.findPortfolios(

--- a/backend/mr/src/test/groovy/io/featurehub/mr/rest/GroupResourceSpec.groovy
+++ b/backend/mr/src/test/groovy/io/featurehub/mr/rest/GroupResourceSpec.groovy
@@ -11,6 +11,7 @@ import io.featurehub.mr.model.Group
 import io.featurehub.mr.model.Person
 import io.featurehub.mr.model.PersonId
 import io.featurehub.mr.model.SortOrder
+import io.featurehub.mr.model.UpdateGroup
 import io.featurehub.mr.resources.GroupResource
 import jakarta.ws.rs.ForbiddenException
 import jakarta.ws.rs.NotFoundException
@@ -23,8 +24,8 @@ class GroupResourceSpec extends Specification {
   GroupResource gr
   AuthManagerService authManager
   SecurityContext sc
-  UUID gid
-  UUID pId // portfolio id
+  UUID groupId
+  UUID portfolioId // portfolio id
   UUID personId
   Person person
   UUID adminUser
@@ -34,8 +35,8 @@ class GroupResourceSpec extends Specification {
     personApi = Mock(PersonApi)
     authManager = Mock(AuthManagerService)
     gr = new GroupResource(personApi, groupApi, authManager)
-    gid = UUID.randomUUID()
-    pId = UUID.randomUUID()
+    groupId = UUID.randomUUID()
+    portfolioId = UUID.randomUUID()
     adminUser = UUID.randomUUID()
     personId = UUID.randomUUID()
     sc = Mock()
@@ -46,22 +47,22 @@ class GroupResourceSpec extends Specification {
 
   def "cannot add a person to a non-existent group"() {
     given: "the group does not exist"
-      groupApi.getGroup(gid, (Opts) _, _) >> null
+      groupApi.getGroup(groupId, (Opts) _, _) >> null
     when: "i try and add a person to the group"
-      gr.addPersonToGroup(gid, UUID.randomUUID(), new GroupServiceDelegate.AddPersonToGroupHolder(includeMembers: true), sc)
+      gr.addPersonToGroup(groupId, UUID.randomUUID(), new GroupServiceDelegate.AddPersonToGroupHolder(includeMembers: true), sc)
     then:
       thrown(NotFoundException)
   }
 
   def "if you are a portfolio admin you can create a group"() {
     given: "i am a portfolio admin"
-      authManager.isPortfolioAdmin(pId, person, null) >> true
+      authManager.isPortfolioAdmin(portfolioId, person, null) >> true
     and: "i have a group"
       def group = new CreateGroup()
     when: "i attempt to create said Group"
-      gr.createGroup(pId, group, new GroupServiceDelegate.CreateGroupHolder(includePeople: true), sc)
+      gr.createGroup(portfolioId, group, new GroupServiceDelegate.CreateGroupHolder(includePeople: true), sc)
     then:
-      1 * groupApi.createGroup(pId, group, person) >> new Group().id(gid)
+      1 * groupApi.createGroup(portfolioId, group, person) >> new Group().id(groupId)
   }
 
   def "findGroups works"() {
@@ -71,19 +72,19 @@ class GroupResourceSpec extends Specification {
       authManager.from(sc) >> person
       authManager.isOrgAdmin(person) >> true
     when: "i find groups"
-      gr.findGroups(gid, new GroupServiceDelegate.FindGroupsHolder(includePeople: true, order: SortOrder.DESC, filter: "turn"), sc)
+      gr.findGroups(groupId, new GroupServiceDelegate.FindGroupsHolder(includePeople: true, order: SortOrder.DESC, filter: "turn"), sc)
     then:
-      1 * groupApi.findGroups(gid, "turn", SortOrder.DESC, Opts.opts(FillOpts.People)) >> []
+      1 * groupApi.findGroups(groupId, "turn", SortOrder.DESC, Opts.opts(FillOpts.People)) >> []
   }
 
 
   def "if you are not a portfolio admin, you cannot create a group"() {
     given: "i am not a portfolio admin"
-      authManager.isPortfolioAdmin(pId, person, null) >> false
+      authManager.isPortfolioAdmin(portfolioId, person, null) >> false
     and: "i have a group"
       def group = new CreateGroup()
     when: "i attempt to create a group"
-      gr.createGroup(gid, group, new GroupServiceDelegate.CreateGroupHolder(includePeople: true), sc)
+      gr.createGroup(groupId, group, new GroupServiceDelegate.CreateGroupHolder(includePeople: true), sc)
     then:
       thrown(ForbiddenException)
   }
@@ -93,10 +94,10 @@ class GroupResourceSpec extends Specification {
       personIdInAdminGroup = adminUser
     }
     UUID orgId = UUID.randomUUID()
-    groupApi.getGroup(gid, (Opts) _, _) >> new Group().id(gid).portfolioId(portfolioId).admin(groupIsAdmin).organizationId(orgId)
+    groupApi.getGroup(groupId, (Opts) _, _) >> new Group().id(groupId).portfolioId(portfolioId).admin(groupIsAdmin).organizationId(orgId)
     def sc = Mock(SecurityContext)
-    groupApi.findPortfolioAdminGroup(portfolioId, (Opts)_) >> new Group().id(gid).admin(true).members([new Person().id(new PersonId().id(idPersonInChargeOfPortfolioAdminGroup))])
-    groupApi.findOrganizationAdminGroup(orgId, (Opts)_) >> new Group().id(gid).admin(true).members([new Person().id(new PersonId().id(personIdInAdminGroup))])
+    groupApi.findPortfolioAdminGroup(portfolioId, (Opts)_) >> new Group().id(groupId).admin(true).members([new Person().id(new PersonId().id(idPersonInChargeOfPortfolioAdminGroup))])
+    groupApi.findOrganizationAdminGroup(orgId, (Opts)_) >> new Group().id(groupId).admin(true).members([new Person().id(new PersonId().id(personIdInAdminGroup))])
     authManager.from(sc) >> new Person().id(new PersonId().id(currentPersonId))
     return sc
   }
@@ -107,7 +108,7 @@ class GroupResourceSpec extends Specification {
     and: "the person to be added exists"
       personApi.get(personId, (Opts)_) >> new Person()
     when:
-      gr.addPersonToGroup(gid, personId, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
+      gr.addPersonToGroup(groupId, personId, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
     then: "not allowed to add a person to the group"
       thrown(ForbiddenException)
   }
@@ -119,9 +120,9 @@ class GroupResourceSpec extends Specification {
     and: "the person to be added exists"
       personApi.get(personId, (Opts)_) >> new Person()
     when:
-      gr.addPersonToGroup(gid, personId, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
+      gr.addPersonToGroup(groupId, personId, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
     then: "the person is added to the group"
-      1 * groupApi.addPersonToGroup(gid, personId, (Opts)_) >> new Group()
+      1 * groupApi.addPersonsToGroup(groupId, [personId], (Opts)_) >> new Group()
   }
 
   def "a superadmin can change a portfolio group"() {
@@ -131,14 +132,14 @@ class GroupResourceSpec extends Specification {
     and: "the person to be added exists"
       personApi.get(personInChargeOfPortfolioAdminGroup, (Opts)_) >> new Person()
     when:
-      gr.addPersonToGroup(gid, personInChargeOfPortfolioAdminGroup, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
+      gr.addPersonToGroup(groupId, personInChargeOfPortfolioAdminGroup, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
     then: "the person is added to the group"
-      1 * groupApi.addPersonToGroup(gid, personInChargeOfPortfolioAdminGroup, (Opts)_) >> new Group()
+      1 * groupApi.addPersonsToGroup(groupId, [personInChargeOfPortfolioAdminGroup], (Opts)_) >> new Group()
   }
 
   def "cannot add a person to an known group"() {
     when:
-      gr.addPersonToGroup(gid, UUID.randomUUID(), new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
+      gr.addPersonToGroup(groupId, UUID.randomUUID(), new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
@@ -148,7 +149,7 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), UUID.randomUUID(), pidOwner)
     when:
-      gr.addPersonToGroup(gid, pidOwner, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
+      gr.addPersonToGroup(groupId, pidOwner, new GroupServiceDelegate.AddPersonToGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
@@ -161,7 +162,7 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, pidOwner, true)
     when:
-      gr.deleteGroup(gid, new GroupServiceDelegate.DeleteGroupHolder(), sc)
+      gr.deleteGroup(groupId, new GroupServiceDelegate.DeleteGroupHolder(), sc)
     then:
       thrown(ForbiddenException)
   }
@@ -171,9 +172,9 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, pidOwner)
     when:
-      gr.deleteGroup(gid, new GroupServiceDelegate.DeleteGroupHolder(), sc)
+      gr.deleteGroup(groupId, new GroupServiceDelegate.DeleteGroupHolder(), sc)
     then:
-      1 * groupApi.deleteGroup(gid)
+      1 * groupApi.deleteGroup(groupId)
   }
 
   def "a super-admin can delete groups in any portfolio"() {
@@ -182,9 +183,9 @@ class GroupResourceSpec extends Specification {
       def admin = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, adminUser)
     when:
-      gr.deleteGroup(gid, new GroupServiceDelegate.DeleteGroupHolder(), sc)
+      gr.deleteGroup(groupId, new GroupServiceDelegate.DeleteGroupHolder(), sc)
     then:
-      1 * groupApi.deleteGroup(gid)
+      1 * groupApi.deleteGroup(groupId)
   }
 
   def "a generic person cannot delete groups in a portfolio"() {
@@ -193,14 +194,14 @@ class GroupResourceSpec extends Specification {
       def piddle = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, piddle)
     when:
-      gr.deleteGroup(gid, new GroupServiceDelegate.DeleteGroupHolder(), sc)
+      gr.deleteGroup(groupId, new GroupServiceDelegate.DeleteGroupHolder(), sc)
     then:
       thrown(ForbiddenException)
   }
 
   def "cannot delete an unknown group"() {
     when: "i try and delete an unknown group"
-      gr.deleteGroup(gid, new GroupServiceDelegate.DeleteGroupHolder(), sc)
+      gr.deleteGroup(groupId, new GroupServiceDelegate.DeleteGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
@@ -218,7 +219,7 @@ class GroupResourceSpec extends Specification {
     and: "the person to be deleted exists"
       personApi.get(piddle, (Opts)_) >> new Person()
     when:
-      gr.deletePersonFromGroup(gid, piddle, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
+      gr.deletePersonFromGroup(groupId, piddle, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
     then:
       thrown(ForbiddenException)
   }
@@ -230,9 +231,9 @@ class GroupResourceSpec extends Specification {
     and: "the person to be deleted exists"
       personApi.get(pidOwner, (Opts)_) >> new Person()
     when:
-      gr.deletePersonFromGroup(gid, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
+      gr.deletePersonFromGroup(groupId, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
     then:
-      1 * groupApi.deletePersonFromGroup(gid, pidOwner, (Opts)_)  >> new Group()
+      1 * groupApi.deletePersonFromGroup(groupId, pidOwner, (Opts)_)  >> new Group()
   }
 
   def "can delete a person from a group if you are the super-admin"() {
@@ -242,14 +243,14 @@ class GroupResourceSpec extends Specification {
     and: "the person to be deleted exists"
       personApi.get(pidOwner, (Opts)_) >> new Person()
     when:
-      gr.deletePersonFromGroup(gid, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
+      gr.deletePersonFromGroup(groupId, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
     then:
-      1 * groupApi.deletePersonFromGroup(gid, pidOwner, (Opts)_)  >> new Group()
+      1 * groupApi.deletePersonFromGroup(groupId, pidOwner, (Opts)_)  >> new Group()
   }
 
   def "cannot delete person from non-existent group"() {
     when:
-      gr.deletePersonFromGroup(gid, UUID.randomUUID(), new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
+      gr.deletePersonFromGroup(groupId, UUID.randomUUID(), new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
@@ -259,7 +260,7 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       def sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, pidOwner)
     when: "known group, known current user, unknown person deleted"
-      gr.deletePersonFromGroup(gid, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
+      gr.deletePersonFromGroup(groupId, pidOwner, new GroupServiceDelegate.DeletePersonFromGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
@@ -268,16 +269,16 @@ class GroupResourceSpec extends Specification {
 
   def "non existent group cannot get"() {
     when:
-      gr.getGroup(gid, new GroupServiceDelegate.GetGroupHolder(), sc)
+      gr.getGroup(groupId, new GroupServiceDelegate.GetGroupHolder(), sc)
     then:
       thrown(NotFoundException)
   }
 
   def "can get existing group"() {
     when:
-      gr.getGroup(gid, new GroupServiceDelegate.GetGroupHolder(), sc)
+      gr.getGroup(groupId, new GroupServiceDelegate.GetGroupHolder(), sc)
     then:
-      1 * groupApi.getGroup(gid, (Opts) _, _) >> new Group()
+      1 * groupApi.getGroup(groupId, (Opts) _, _) >> new Group()
   }
 
   /// ------- rename group
@@ -287,9 +288,9 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       SecurityContext sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, pidOwner)
     when:
-      Group g = gr.updateGroup(gid, new Group().name("sausage"), new GroupServiceDelegate.UpdateGroupHolder(), sc)
+      Group g = gr.updateGroupOnPortfolio(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioHolder(), sc)
     then:
-      1 * groupApi.updateGroup(gid, { Group g1 -> g1.name == "sausage" }, null, false, false, false, (Opts)_) >> new Group().name("sausage")
+      1 * groupApi.updateGroup(groupId, { UpdateGroup g1 -> g1.name == "sausage" }, null, false, false, (Opts)_) >> new Group().name("sausage")
       g.getName() == "sausage"
   }
 
@@ -298,9 +299,9 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       SecurityContext sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, adminUser)
     when:
-      Group g = gr.updateGroup(gid, new Group().name("sausage"), new GroupServiceDelegate.UpdateGroupHolder(updateMembers: true, applicationId: pidOwner), sc)
+      Group g = gr.updateGroupOnPortfolio(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioHolder(applicationId: pidOwner), sc)
     then:
-      1 * groupApi.updateGroup(gid, { Group g1 -> g1.name == "sausage" }, pidOwner, true, false, false, (Opts)_) >> new Group().name("sausage")
+      1 * groupApi.updateGroup(groupId, { UpdateGroup g1 -> g1.name == "sausage" }, pidOwner, false, false, (Opts)_) >> new Group().name("sausage")
       g.getName() == "sausage"
   }
 }

--- a/backend/mr/src/test/groovy/io/featurehub/mr/rest/PersonResourceSpec.groovy
+++ b/backend/mr/src/test/groovy/io/featurehub/mr/rest/PersonResourceSpec.groovy
@@ -88,8 +88,8 @@ class PersonResourceSpec extends Specification {
       RegistrationUrl url = resource.createPerson(cpd, new PersonServiceDelegate.CreatePersonHolder(), ctx)
     then:
       url.registrationUrl == "fred"
-      1 * groupApi.addPersonToGroup(cpd.groupIds.get(0), token.id, (Opts)_)
-      1 * groupApi.addPersonToGroup(cpd.groupIds.get(1), token.id, (Opts)_)
+      1 * groupApi.addPersonsToGroup(cpd.groupIds.get(0), [token.id], (Opts)_)
+      1 * groupApi.addPersonsToGroup(cpd.groupIds.get(1), [token.id], (Opts)_)
   }
 
   def "a person who is not an admin cannot search"() {

--- a/backend/tile-java/tile.xml
+++ b/backend/tile-java/tile.xml
@@ -13,24 +13,6 @@
   <build>
     <plugins>
       <plugin>
-        <!-- if including source jars, use the no-fork goals
-             otherwise both the Groovy sources and Java stub sources
-             will get included in your jar -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <!-- source plugin \> = 2.1 is required to use the no-fork goals -->
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-              <goal>test-jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <version>2.3.0</version>
@@ -116,7 +98,7 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
         <executions>
           <execution>
             <goals>
@@ -130,6 +112,23 @@
         <configuration>
           <invokeDynamic>true</invokeDynamic>
         </configuration>
+      </plugin>
+      <plugin>
+        <!-- if including source jars, use the no-fork goals
+             otherwise both the Groovy sources and Java stub sources
+             will get included in your jar -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <!-- source plugin \> = 2.1 is required to use the no-fork goals -->
+        <version>3.4.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <!-- files ending in spec or test -->
       <plugin>

--- a/backend/webhook-api/pom.xml
+++ b/backend/webhook-api/pom.xml
@@ -76,6 +76,9 @@
               <generateApis>false</generateApis>
               <generatorName>jersey3-api</generatorName>
               <enablePostProcessFile>true</enablePostProcessFile>
+              <additionalProperties>
+                <additionalProperty>openApiNullable=false</additionalProperty>
+              </additionalProperties>
             </configuration>
           </execution>
         </executions>
@@ -93,7 +96,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources/api/src/gen</source>
+                <source>${project.build.directory}/generated-sources/api/src/gen/java</source>
               </sources>
             </configuration>
           </execution>

--- a/backend/webhook-feature-update/src/main/kotlin/io/features/webhooks/features/WebhookFeature.kt
+++ b/backend/webhook-feature-update/src/main/kotlin/io/features/webhooks/features/WebhookFeature.kt
@@ -1,7 +1,5 @@
 package io.features.webhooks.features
 
-import cd.connect.app.config.ConfigKey
-import cd.connect.app.config.DeclaredConfigResolver
 import cd.connect.jersey.common.LoggingConfiguration
 import io.cloudevents.CloudEvent
 import io.cloudevents.core.v1.CloudEventBuilder
@@ -36,10 +34,6 @@ import java.time.OffsetDateTime
 class WebhookFeature : Feature {
   private val log: Logger = LoggerFactory.getLogger(WebhookFeature::class.java)
 
-  init {
-    DeclaredConfigResolver.resolve(this)
-  }
-
   override fun configure(context: FeatureContext): Boolean {
     if (enabled) {
       log.info("webhooks: registering for outbound feature webhook processing")
@@ -53,7 +47,6 @@ class WebhookFeature : Feature {
 
   companion object {
     val enabled: Boolean = FallbackPropertyConfig.getConfig("webhooks.features.enabled")?.lowercase() != "false"
-
   }
 }
 
@@ -66,22 +59,17 @@ class WebhookEnricherListener @Inject constructor(
   ) : LifecycleListener {
   private val client: Client
 
-  @ConfigKey("webhooks.features.timeout.connect")
-  var connectTimeout: Int? = 4000
+  var connectTimeout = FallbackPropertyConfig.getConfig("webhooks.features.timeout.connect", "4000").toInt()
 
-  @ConfigKey("webhooks.features.timeout.read")
-  var readTimeout: Int? = 4000
+  var readTimeout = FallbackPropertyConfig.getConfig("webhooks.features.timeout.read", "4000").toInt()
 
-  @ConfigKey("webhooks.features.cloudevent-source")
-  var cloudEventSource: String? = "https://featurehub.io"
+  var cloudEventSource = FallbackPropertyConfig.getConfig("webhooks.features.cloudevent-source", "https://featurehub.io");
 
   private val replySource = URI.create(SOURCE_SYSTEM)
 
   private val log: Logger = LoggerFactory.getLogger(WebhookEnricherListener::class.java)
 
   init {
-    DeclaredConfigResolver.resolve(this)
-
     log.debug("listening for webhooks on enriched feature channel")
     cloudEventReceiverRegistry.listen(EnrichedFeatures::class.java, this::process)
 

--- a/e2e/test/features/groups_and_superusers.feature
+++ b/e2e/test/features/groups_and_superusers.feature
@@ -41,11 +41,3 @@ Feature: This set of scenarios focuses on supers being added to portfolios and n
     When I remove the shared person to the superuser group via the group membership
     Then the portfolio admin group does not contain the current user
 
-  Scenario: When a portfolio is created all superusers get added to that portfolio group and cannot be removed via the group members api
-    Given the first superuser is used for authentication
-    And I have a randomly named portfolio with the prefix "superuser_admin_5"
-    And I have a randomly generated superuser with the start of name "Wotcha"
-    And the first superuser is used for authentication
-    And I attempt to remove the superuser from the shared portfolio group via the group membership
-    And The portfolio admin group contains the current user
-

--- a/e2e/test/features/person_group.feature
+++ b/e2e/test/features/person_group.feature
@@ -31,7 +31,7 @@ Feature: This tests a persons interaction with groups
       | portfolio | group         | appName | appDesc   | envName | envDesc    | email                |
       | Italians  | made in italy | Cars    | cool cars | prod    | production | romeo@mailinator.com |
 
-    @superuser
+    @superuser-group
   Scenario Outline: Ensure that a person in an application role in one group and a read in another group has expected access
     And the first superuser is used for authentication
     Given I ensure a portfolio named "<portfolio>" with description "Alpha users" exists

--- a/e2e/test/steps/AdminGroupStepdefs.dart
+++ b/e2e/test/steps/AdminGroupStepdefs.dart
@@ -81,19 +81,20 @@ class AdminGroupStepdefs {
         await userCommon.findExactEnvironment(envName, shared.application.id);
     assert(env != null, 'env must exist and doesnt $envName');
 
-    var er = group!.environmentRoles
+    var updatedGroup = UpdateGroup(id: group!.id, version: group.version, environmentRoles: group.environmentRoles);
+    var er = updatedGroup.environmentRoles
         .firstWhereOrNull((er) => er.environmentId == env!.id);
     if (er == null) {
       er = EnvironmentGroupRole(
           environmentId: env!.id, groupId: group.id, roles: []);
 
-      group.environmentRoles.add(er);
+      updatedGroup.environmentRoles.add(er);
     }
     final roleType = RoleTypeExtension.fromJson(perm);
     if (!er.roles.contains(roleType)) {
       er.roles.add(roleType!);
     }
-    await userCommon.groupService.updateGroupOnPortfolio(shared.portfolio.id, group);
+    await userCommon.groupService.updateGroupOnPortfolio(shared.portfolio.id, updatedGroup);
   }
 
   @And(r'I add the shared person to the shared group')

--- a/e2e/test/steps/ApplicationStepdefs.dart
+++ b/e2e/test/steps/ApplicationStepdefs.dart
@@ -219,12 +219,17 @@ class ApplicationStepdefs {
     final group =
         await userCommon.findExactGroup(groupName, shared.portfolio.id);
     assert(group != null, 'Unable to find group');
-    var agr = group!.applicationRoles
+
+    final appRoles = group!.applicationRoles.toList();
+    var updatedGroup = UpdateGroup(id: group.id, version: group.version,
+        applicationRoles: appRoles);
+
+    var agr = appRoles
         .firstWhereOrNull((agr) => agr.applicationId == shared.application.id);
     if (agr == null) {
       agr = api.ApplicationGroupRole(
           applicationId: shared.application.id, groupId: group.id, roles: []);
-      group.applicationRoles.add(agr);
+      appRoles.add(agr);
     }
 
     api.ApplicationRoleType? desiredRole =
@@ -235,7 +240,7 @@ class ApplicationStepdefs {
     }
 
     await userCommon.groupService
-        .updateGroupOnPortfolio(shared.portfolio.id, group, updateApplicationGroupRoles: true);
+        .updateGroupOnPortfolio(shared.portfolio.id, updatedGroup, updateApplicationGroupRoles: true);
   }
 
   @And(

--- a/e2e/test/steps/EnvironmentStepdefs.dart
+++ b/e2e/test/steps/EnvironmentStepdefs.dart
@@ -84,6 +84,7 @@ class EnvironmentStepdefs {
       String portfolioName) async {
     Application application = await _findApplication(portfolioName, appName);
     Group group = await _findGroup(portfolioName, groupName, true);
+
     var environment =
         await common.findExactEnvironment(environmentName, application.id);
     EnvironmentGroupRole egr = EnvironmentGroupRole(
@@ -95,10 +96,10 @@ class EnvironmentStepdefs {
 
     group.environmentRoles.add(egr);
 
-    await common.groupService.updateGroupOnPortfolio(application.portfolioId!, group,
+    await common.groupService.updateGroupOnPortfolio(application.portfolioId!,
+        UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true,
-        updateEnvironmentGroupRoles: true,
-        updateApplicationGroupRoles: true);
+        updateEnvironmentGroupRoles: true);
 
     shared.application = application;
   }
@@ -147,7 +148,8 @@ class EnvironmentStepdefs {
         roles: [RoleType.READ, RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]);
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(application.portfolioId!, group,
+    await common.groupService.updateGroupOnPortfolio(application.portfolioId!,
+        UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }
 
@@ -178,7 +180,8 @@ class EnvironmentStepdefs {
     });
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(group.id, group,
+    await common.groupService.updateGroupOnPortfolio(group.id,
+        UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }
 
@@ -214,7 +217,8 @@ class EnvironmentStepdefs {
       eRoles.roles.add(roleType!);
     }
 
-    await common.groupService.updateGroupOnPortfolio(shared.portfolio.id, updatedGroup,
+    await common.groupService.updateGroupOnPortfolio(shared.portfolio.id,
+        UpdateGroup(id: updatedGroup.id, version: updatedGroup.version, environmentRoles: updatedGroup.environmentRoles),
         updateEnvironmentGroupRoles: true);
   }
 
@@ -343,7 +347,8 @@ class EnvironmentStepdefs {
     egr.roles.add(RoleType.UNLOCK);
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(group.portfolioId!, group,
+    await common.groupService.updateGroupOnPortfolio(group.portfolioId!,
+        UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }
 }

--- a/e2e/test/steps/GroupStepdefs.dart
+++ b/e2e/test/steps/GroupStepdefs.dart
@@ -107,15 +107,6 @@ class GroupStepdefs {
     await userCommon.groupService.deletePersonFromGroup(superuserGroup.id, shared.person.id!.id);
   }
 
-  @And(
-      r'I attempt to remove the superuser from the shared portfolio group via the group membership')
-  void
-      iAttemptToRemoveTheSuperuserFromTheSharedPortfolioGroupViaTheGroupMembership() async {
-    final group = await findCurrentPortfolioGroup();
-    group.members.retainWhere((m) => m.id!.id != shared.person.id!.id);
-    await userCommon.groupService.updateGroupOnPortfolio(group.portfolioId!, group, updateMembers: true);
-  }
-
   @And(r'I add the shared user to the current portfolio admin group')
   void iAddTheSharedUserToTheCurrentPortfolioAdminGroup() async {
     final group = await findCurrentPortfolioGroup();


### PR DESCRIPTION
# Description

APIs have been updated to force changes in how group management works to signal superusers who cannot be removed from portfolio (admin) groups.


