### PR TITLE
Various fixes on app-settings page

### DIFF
--- a/admin-frontend/open_admin_app/lib/routes/manage_app_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/manage_app_route.dart
@@ -166,7 +166,7 @@ class ManageAppWidgetState extends State<ManageAppWidget>
         'tab': ['integrations']
       };
     }
-    bloc?.notifyExternalRouteChange(rc);
+    bloc?.swapRoutes(rc);
   }
 
   @override
@@ -309,23 +309,21 @@ class ManageAppWidgetState extends State<ManageAppWidget>
       if (routeChange?.route == '/app-settings') {
         switch (routeChange!.params['tab']![0]) {
           case 'environments':
-            _controller!.animateTo(0);
+            if (_controller?.index != 0) _controller!.animateTo(0);
             break;
           case 'group-permissions':
-            _controller!.animateTo(1);
+            if (_controller?.index != 1) _controller!.animateTo(1);
             break;
           case 'service-accounts':
-            _controller!.animateTo(2);
+            if (_controller?.index != 2) _controller!.animateTo(2);
             break;
           case 'integrations':
-            if (mrClient.identityProviders.capabilityWebhooks) {
-              _controller!.animateTo(3);
-            } else {
-              _controller!.animateTo(0);
-            }
+            final target =
+                mrClient.identityProviders.capabilityWebhooks ? 3 : 0;
+            if (_controller?.index != target) _controller!.animateTo(target);
             break;
           default:
-            _controller!.animateTo(0);
+            if (_controller?.index != 0) _controller!.animateTo(0);
             break;
         }
       }

--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -179,12 +179,27 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
     if (app == null) {
       environmentsList = [];
     } else {
-      environmentsList = app.environments;
+      environmentsList = _sortEnvironments(app.environments);
     }
 
     if (!_environmentBS.isClosed) {
       _environmentBS.add(environmentsList);
     }
+  }
+
+  List<Environment> _sortEnvironments(List<Environment> environments,
+      {String parentId = '', List<Environment>? result}) {
+    final out = result ?? <Environment>[];
+    for (final env in environments) {
+      if (env.priorEnvironmentId == null && parentId == '') {
+        out.insert(0, env);
+        _sortEnvironments(environments, parentId: env.id, result: out);
+      } else if (env.priorEnvironmentId == parentId) {
+        out.add(env);
+        _sortEnvironments(environments, parentId: env.id, result: out);
+      }
+    }
+    return out;
   }
 
   String? get selectedGroup => _selectedGroupId;
@@ -204,8 +219,12 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
         if (!_serviceAccountsBS.isClosed) {
           if (serviceAccounts.isNotEmpty) {
             _currentServiceAccountIdSource.add(null);
+            final routeSaId =
+                _mrClient.currentRoute?.params['service-account']?.first;
+            final target =
+                serviceAccounts.firstWhereOrNull((sa) => sa.id == routeSaId);
             // ignore: unawaited_futures
-            selectServiceAccount(serviceAccounts[0].id);
+            selectServiceAccount((target ?? serviceAccounts[0]).id);
           }
           _serviceAccountsBS.add(serviceAccounts);
         }
@@ -352,8 +371,8 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
 
   Future<void> updateEnvs(String appId, List<Environment> envs) async {
     try {
-      environmentsList =
-          await _environmentServiceApi.environmentOrdering(appId, envs);
+      environmentsList = _sortEnvironments(
+          await _environmentServiceApi.environmentOrdering(appId, envs));
       _environmentBS.add(environmentsList);
     } catch (e, s) {
       _mrClient.dialogError(e, s);

--- a/admin-frontend/open_admin_app/lib/widgets/apps/webhook/track_events_panel_widget.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/webhook/track_events_panel_widget.dart
@@ -93,7 +93,9 @@ class TrackingEventListViewState
               padding: const EdgeInsets.all(8.0),
               child: Row(
                 children: [
-                  Expanded(child: Text(AppLocalizations.of(context)!.messageDeliveryStatus)),
+                  Expanded(
+                      child: Text(
+                          AppLocalizations.of(context)!.messageDeliveryStatus)),
                   Padding(
                     padding: const EdgeInsets.only(left: 8.0),
                     child: TextButton.icon(
@@ -161,7 +163,8 @@ class TrackEventItemWidget extends StatelessWidget {
                 children: [
                   Row(
                     children: [
-                      SelectableText(l10n.unacknowledgedRequest(event.whenSent.toLocal().toString()))
+                      SelectableText(l10n.unacknowledgedRequest(
+                          event.whenSent.toLocal().toString()))
                     ],
                   ),
                 ],
@@ -192,7 +195,7 @@ class TrackEventItemWidget extends StatelessWidget {
     final headers = response.headers;
     return Card(
         elevation: 4.0,
-        color: Colors.orangeAccent,
+        color: Theme.of(context).snackBarTheme.backgroundColor,
         shadowColor: Colors.transparent,
         child: Padding(
             padding: const EdgeInsets.all(8.0),
@@ -200,9 +203,12 @@ class TrackEventItemWidget extends StatelessWidget {
               children: [
                 Row(
                   children: [
-                    SelectableText(l10n.deliveryStatusError(
-                        _decodeStatus(response.status, l10n),
-                        response.whenReceived.toLocal().toString())),
+                    SelectableText(
+                        l10n.deliveryStatusError(
+                            _decodeStatus(response.status, l10n),
+                            response.whenReceived.toLocal().toString()),
+                        style:
+                            Theme.of(context).snackBarTheme.contentTextStyle),
                   ],
                 ),
                 if (headers != null)


### PR DESCRIPTION
  - Darken error card colour on webhook tracking panel
  - Sync browser URL tab param when switching tabs on app-settings page; use swapRoutes instead of notifyExternalRouteChange so FHRouteDelegate updates the URL, and guard animateTo calls to break the feedback loop
  - Pre-select the correct service account when navigating from the service-accounts page via Add/Change Access; read the service-account route param in _fetchServiceAccountsFromApplication instead of always defaulting to index 0
  - Sort environments by priorEnvironmentId chain in ManageAppBloc so Group permissions and Service accounts tabs respect the same order as the Environments tab, including after a drag-reorder

