### PR TITLE
fixup: reinstate old UpdateGroup API

### DIFF
--- a/adks/e2e-sdk/app/steps/group.ts
+++ b/adks/e2e-sdk/app/steps/group.ts
@@ -111,7 +111,7 @@ When('I assign roles {string} to the group for the current environment', async f
     groupId: group.id,
     roles: roles
   }));
-  const groupResponse = await world.superuser.groupApi.updateGroupOnPortfolio(world.portfolio.id, group,
+  const groupResponse = await world.superuser.groupApi.updateGroupOnPortfolioV2(world.portfolio.id, group,
  false, false, true, false, true);
 
   expect(groupResponse.status).to.eq(200);

--- a/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/apps/manage_app_bloc.dart
@@ -292,7 +292,7 @@ class ManageAppBloc implements Bloc, ManagementRepositoryAwareBloc {
   Future<Group?> updateGroupWithEnvironmentRoles(String? gid, Group group) async {
     try {
       final updatedGroup = await _groupServiceApi
-          .updateGroupOnPortfolio(portfolio!.id, UpdateGroup(id: group.id, version: group.version,
+          .updateGroupOnPortfolioV2(portfolio!.id, UpdateGroup(id: group.id, version: group.version,
           applicationRoles: group.applicationRoles, environmentRoles: group.environmentRoles),
           includeGroupRoles: true,
           applicationId: applicationId,

--- a/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
+++ b/admin-frontend/open_admin_app/lib/widgets/group/group_bloc.dart
@@ -106,7 +106,7 @@ class GroupBloc implements Bloc {
     try {
       groupToUpdate.name = name;
 
-      final newGroup = await _groupServiceApi.updateGroupOnPortfolio(
+      final newGroup = await _groupServiceApi.updateGroupOnPortfolioV2(
           mrClient.currentPortfolio!.id, UpdateGroup(id: groupToUpdate.id, version: groupToUpdate.version, name: name),
           includeMembersV2: true);
 

--- a/backend/dacha2/pom.xml
+++ b/backend/dacha2/pom.xml
@@ -40,7 +40,6 @@
   <properties>
     <app.port>8902</app.port>
     <app.entrypoint>io.featurehub.dacha2.Application</app.entrypoint>
-    <app.baseimage>eclipse-temurin:25.0.3_9-jdk-alpine-3.23</app.baseimage>
   </properties>
 
   <licenses>

--- a/backend/mr-api/mr-api.yaml
+++ b/backend/mr-api/mr-api.yaml
@@ -365,6 +365,90 @@ paths:
         422:
           description: "Trying to save old record"
 
+  /mr-api/portfolio/{id}/v2/group:
+    parameters:
+      - name: id
+        description: "The id of the portfolio to find"
+        in: path
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - name: includePeople
+        description: "include people in each group"
+        in: query
+        schema:
+          type: boolean
+    put:
+      security:
+        - bearerAuth: [ ]
+      tags:
+        - GroupService
+      description: "Update a group"
+      operationId: updateGroupOnPortfolioV2
+      parameters:
+        - name: includeMembers
+          description: "include people in each group"
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: includeMembersV2
+          description: "include anemic people in each group with superuser"
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: includeGroupRoles
+          description: "include environment and application roles in each group"
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: updateEnvironmentGroupRoles
+          description: "update environment group roles, deleting any not passed"
+          in: query
+          schema:
+            type: boolean
+          required: false
+        - name: updateApplicationGroupRoles
+          description: "update application group roles, deleting any not passed"
+          in: query
+          schema:
+            type: boolean
+          required: false
+        - name: applicationId
+          description: "if updating the application group roles, and the application id is passed, then the changes are limited to that application"
+          in: query
+          schema:
+            type: string
+            format: uuid
+          required: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateGroup"
+      responses:
+        200:
+          description: "Resulting group"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Group"
+        400:
+          description: "Bad Request"
+        401:
+          description: "no permission"
+        403:
+          description: "forbidden"
+        404:
+          description: "not found"
+        409:
+          description: "duplicate user or duplicate group"
+        422:
+          description: "version conflict"
   /mr-api/portfolio/{id}/group:
     parameters:
       - name: id
@@ -447,27 +531,26 @@ paths:
         - bearerAuth: [ ]
       tags:
         - GroupService
-      description: "Update a group"
+      description: "Update a group. Please use updateGroupOnPortfolioV2"
+      deprecated: true
       operationId: updateGroupOnPortfolio
       parameters:
         - name: includeMembers
           description: "include people in each group"
           in: query
-          required: false
-          schema:
-            type: boolean
-        - name: includeMembersV2
-          description: "include anemic people in each group with superuser"
-          in: query
-          required: false
           schema:
             type: boolean
         - name: includeGroupRoles
           description: "include environment and application roles in each group"
           in: query
-          required: false
           schema:
             type: boolean
+        - name: updateMembers
+          description: "update members, deleting those that are not passed"
+          in: query
+          schema:
+            type: boolean
+          required: false
         - name: updateEnvironmentGroupRoles
           description: "update environment group roles, deleting any not passed"
           in: query
@@ -492,7 +575,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateGroup"
+              $ref: "#/components/schemas/Group"
       responses:
         200:
           description: "Resulting group"

--- a/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
+++ b/backend/mr-db-api/src/main/kotlin/io/featurehub/db/api/GroupApi.kt
@@ -58,4 +58,15 @@ interface GroupApi {
 
   fun findGroups(portfolioId: UUID, filter: String?, ordering: SortOrder?, opts: Opts): List<Group>
   fun updateAdminGroupForPortfolio(portfolioId: UUID, name: String)
+
+  @Throws(OptimisticLockingException::class, DuplicateGroupException::class, DuplicateUsersException::class)
+  fun updateGroupV1(
+    gid: UUID,
+    group: Group,
+    appId: UUID?,
+    updateMembers: Boolean,
+    updateApplicationGroupRoles: Boolean,
+    updateEnvironmentGroupRoles: Boolean,
+    opts: Opts
+  ): Group?
 }

--- a/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/GroupSqlApi.kt
+++ b/backend/mr-db-sql/src/main/kotlin/io/featurehub/db/services/GroupSqlApi.kt
@@ -6,7 +6,6 @@ import io.ebean.annotation.Transactional
 import io.featurehub.db.api.*
 import io.featurehub.db.model.*
 import io.featurehub.db.model.query.*
-import io.featurehub.db.model.query.QGroupMemberAgg.Alias.personId
 import io.featurehub.mr.model.*
 import io.featurehub.mr.model.RoleType
 import jakarta.inject.Inject
@@ -349,6 +348,76 @@ open class GroupSqlApi @Inject constructor(
   @Transactional
   private fun saveGroup(group: DbGroup) {
     database.save(group)
+  }
+
+  @Throws(OptimisticLockingException::class, GroupApi.DuplicateGroupException::class, DuplicateUsersException::class)
+  override fun updateGroupV1(
+    gid: UUID,
+    group: Group,
+    appId: UUID?,
+    updateMembers: Boolean,
+    updateApplicationGroupRoles: Boolean,
+    updateEnvironmentGroupRoles: Boolean,
+    opts: Opts
+  ): Group? {
+    val dbGroup = convertUtils.byGroup(gid, opts)
+
+    if (dbGroup != null && dbGroup.whenArchived == null) {
+      if (group.version == null || dbGroup.version != group.version) {
+        throw OptimisticLockingException()
+      }
+
+      group.name.let {
+        dbGroup.name = it
+      }
+
+      transactionalGroupUpdateV1(
+        group,
+        updateMembers,
+        updateApplicationGroupRoles,
+        updateEnvironmentGroupRoles,
+        dbGroup,
+        appId
+      )
+      return convertUtils.toGroup(dbGroup, opts)!!
+    }
+    return null
+  }
+
+  // there are too many updates
+  @Transactional
+  @Throws(DuplicateUsersException::class, GroupApi.DuplicateGroupException::class)
+  private fun transactionalGroupUpdateV1(
+    gp: Group,
+    updateMembers: Boolean,
+    updateApplicationGroupRoles: Boolean,
+    updateEnvironmentGroupRoles: Boolean,
+    group: DbGroup,
+    appId: UUID?
+  ) {
+    var superuserChanges: SuperuserChanges? = null
+    if (gp.members != null && updateMembers) {
+      superuserChanges = updateMembersOfGroup(gp, group)
+    }
+    var aclUpdates: AclUpdates? = null
+    gp.environmentRoles.let {
+      if (updateEnvironmentGroupRoles) {
+        aclUpdates = updateEnvironmentMembersOfGroup(it, group)
+      }
+    }
+
+    gp.applicationRoles.let { appRoles ->
+      if (updateApplicationGroupRoles) {
+        updateApplicationMembersOfGroup(appRoles, group, appId)
+      }
+    }
+
+    try {
+      updateGroup(group, aclUpdates)
+    } catch (dke: DuplicateKeyException) {
+      throw GroupApi.DuplicateGroupException()
+    }
+    superuserChanges?.let { updateSuperusersFromPortfolioGroups(it) }
   }
 
   @Throws(OptimisticLockingException::class, GroupApi.DuplicateGroupException::class, DuplicateUsersException::class)

--- a/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
+++ b/backend/mr-db-sql/src/test/groovy/io/featurehub/db/services/GroupSpec.groovy
@@ -332,7 +332,7 @@ class GroupSpec extends BaseSpec {
       ng.name == "new name"
   }
 
-  def "i add a couple of people, then remove one and then add a new one to the group"() {
+  def "using the v1 API i add a couple of people, then remove one and then add a new one to the group"() {
     given: "i have a group"
       Group g = nonAdminGroup()
     and: "some people"
@@ -342,11 +342,20 @@ class GroupSpec extends BaseSpec {
       database.save(p1)
       database.save(p2)
       database.save(p3)
-    when: "i update the group to add Sasha and Alena"
-      def g2 = groupSqlApi.addPersonsToGroup(g.id, [p1.id, p2.id], Opts.opts(FillOpts.Members))
+      when: "i update the group to add Sasha and Alena"
+      g.members = [
+        new Person().id(new PersonId().id(p1.id)),
+        new Person().id(new PersonId().id(p2.id)),
+      ]
+      def g2 = groupSqlApi.updateGroupV1(g.id, g, null, true, true, true, new Opts().add(FillOpts.Members))
     and: "I updated the group to remove Alena and add Toya"
-      groupSqlApi.deletePersonFromGroup(g.id, p2.id, Opts.empty())
-      def g3 = groupSqlApi.addPersonsToGroup(g.id, [p3.id], Opts.opts(FillOpts.Members))
+      def g2_copy = g2.copy()
+      g2_copy.members = [
+        new Person().id(new PersonId().id(p1.id)),
+        new Person().id(new PersonId().id(p3.id)),
+      ]
+      groupSqlApi.updateGroupV1(g.id, g2_copy, null, true, true, true, new Opts().add(FillOpts.Members))
+      def g3 = groupSqlApi.getGroup(g.id, new Opts().add(FillOpts.Members), superPerson)
     then:
       g2.members.size() == 2
       g2.members*.name.contains('Alena')
@@ -354,6 +363,30 @@ class GroupSpec extends BaseSpec {
       g3.members.size() == 2
       g3.members*.name.contains('Sasha')
       g3.members*.name.contains('Toya')
+  }
+
+  def "i add a couple of people, then remove one and then add a new one to the group"() {
+    given: "i have a group"
+      Group g = nonAdminGroup()
+    and: "some people"
+      DbPerson p1 = new DbPerson.Builder().name("Jan").email("jan@").build()
+      DbPerson p2 = new DbPerson.Builder().name("Jingjing").email("jingjing@").build()
+      DbPerson p3 = new DbPerson.Builder().name("Nine").email("nine@").build()
+      database.save(p1)
+      database.save(p2)
+      database.save(p3)
+    when: "i update the group to add Jan and Jingjing"
+      def g2 = groupSqlApi.addPersonsToGroup(g.id, [p1.id, p2.id], Opts.opts(FillOpts.Members))
+    and: "I updated the group to remove Jingjing and add Nine"
+      groupSqlApi.deletePersonFromGroup(g.id, p2.id, Opts.empty())
+      def g3 = groupSqlApi.addPersonsToGroup(g.id, [p3.id], Opts.opts(FillOpts.Members))
+    then:
+      g2.members.size() == 2
+      g2.members*.name.contains('Jan')
+      g2.members*.name.contains('Jingjing')
+      g3.members.size() == 2
+      g3.members*.name.contains('Jan')
+      g3.members*.name.contains('Nine')
   }
 
   def "i cannot rename a non-existent group"() {

--- a/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
+++ b/backend/mr/src/main/kotlin/io/featurehub/mr/resources/GroupResource.kt
@@ -231,10 +231,46 @@ class GroupResource @Inject constructor(
       ?: throw NotFoundException("No such group")
   }
 
+  @Deprecated("Deprecated in Java")
   override fun updateGroupOnPortfolio(
     id: UUID,
-    group: UpdateGroup,
+    group: Group,
     holder: GroupServiceDelegate.UpdateGroupOnPortfolioHolder,
+    securityContext: SecurityContext?
+  ): Group {
+    val groupHolder = GroupHolder()
+    groupCheck(group.id, authManager.from(securityContext)) { groupCheck: Group ->
+      isAdminOfGroup(groupCheck, securityContext!!, "No permission to rename group.") {
+        try {
+          groupHolder.group = groupApi.updateGroupV1(
+            group.id,
+            group,
+            holder.applicationId,
+            true == holder.updateMembers,
+            true == holder.updateApplicationGroupRoles,
+            true == holder.updateEnvironmentGroupRoles,
+            Opts().add(FillOpts.Members, holder.includeMembers).add(FillOpts.Acls, holder.includeGroupRoles)
+          )
+        } catch (e: OptimisticLockingException) {
+          throw WebApplicationException(422)
+        } catch (e: GroupApi.DuplicateGroupException) {
+          throw WebApplicationException(Response.Status.CONFLICT)
+        } catch (e: DuplicateUsersException) {
+          throw WebApplicationException(Response.Status.CONFLICT)
+        }
+      }
+    }
+    if (groupHolder.group == null) {
+      throw NotFoundException()
+    }
+
+    return groupHolder.group!!
+  }
+
+  override fun updateGroupOnPortfolioV2(
+    id: UUID,
+    group: UpdateGroup,
+    holder: GroupServiceDelegate.UpdateGroupOnPortfolioV2Holder,
     securityContext: SecurityContext?
   ): Group {
     val groupHolder = GroupHolder()

--- a/backend/mr/src/test/groovy/io/featurehub/mr/rest/GroupResourceSpec.groovy
+++ b/backend/mr/src/test/groovy/io/featurehub/mr/rest/GroupResourceSpec.groovy
@@ -288,7 +288,7 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       SecurityContext sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, pidOwner)
     when:
-      Group g = gr.updateGroupOnPortfolio(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioHolder(), sc)
+      Group g = gr.updateGroupOnPortfolioV2(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioV2Holder(), sc)
     then:
       1 * groupApi.updateGroup(groupId, { UpdateGroup g1 -> g1.name == "sausage" }, null, false, false, (Opts)_) >> new Group().name("sausage")
       g.getName() == "sausage"
@@ -299,7 +299,7 @@ class GroupResourceSpec extends Specification {
       def pidOwner = UUID.randomUUID()
       SecurityContext sc = setupGroupAndPortfoioAdmin(UUID.randomUUID(), pidOwner, adminUser)
     when:
-      Group g = gr.updateGroupOnPortfolio(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioHolder(applicationId: pidOwner), sc)
+      Group g = gr.updateGroupOnPortfolioV2(portfolioId, new UpdateGroup().id(groupId).name("sausage"), new GroupServiceDelegate.UpdateGroupOnPortfolioV2Holder(applicationId: pidOwner), sc)
     then:
       1 * groupApi.updateGroup(groupId, { UpdateGroup g1 -> g1.name == "sausage" }, pidOwner, false, false, (Opts)_) >> new Group().name("sausage")
       g.getName() == "sausage"

--- a/e2e/test/steps/AdminGroupStepdefs.dart
+++ b/e2e/test/steps/AdminGroupStepdefs.dart
@@ -94,7 +94,7 @@ class AdminGroupStepdefs {
     if (!er.roles.contains(roleType)) {
       er.roles.add(roleType!);
     }
-    await userCommon.groupService.updateGroupOnPortfolio(shared.portfolio.id, updatedGroup);
+    await userCommon.groupService.updateGroupOnPortfolioV2(shared.portfolio.id, updatedGroup);
   }
 
   @And(r'I add the shared person to the shared group')

--- a/e2e/test/steps/ApplicationStepdefs.dart
+++ b/e2e/test/steps/ApplicationStepdefs.dart
@@ -240,7 +240,7 @@ class ApplicationStepdefs {
     }
 
     await userCommon.groupService
-        .updateGroupOnPortfolio(shared.portfolio.id, updatedGroup, updateApplicationGroupRoles: true);
+        .updateGroupOnPortfolioV2(shared.portfolio.id, updatedGroup, updateApplicationGroupRoles: true);
   }
 
   @And(

--- a/e2e/test/steps/EnvironmentStepdefs.dart
+++ b/e2e/test/steps/EnvironmentStepdefs.dart
@@ -96,7 +96,7 @@ class EnvironmentStepdefs {
 
     group.environmentRoles.add(egr);
 
-    await common.groupService.updateGroupOnPortfolio(application.portfolioId!,
+    await common.groupService.updateGroupOnPortfolioV2(application.portfolioId!,
         UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true,
         updateEnvironmentGroupRoles: true);
@@ -148,7 +148,7 @@ class EnvironmentStepdefs {
         roles: [RoleType.READ, RoleType.CHANGE_VALUE, RoleType.LOCK, RoleType.UNLOCK]);
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(application.portfolioId!,
+    await common.groupService.updateGroupOnPortfolioV2(application.portfolioId!,
         UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }
@@ -180,7 +180,7 @@ class EnvironmentStepdefs {
     });
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(group.id,
+    await common.groupService.updateGroupOnPortfolioV2(group.id,
         UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }
@@ -217,7 +217,7 @@ class EnvironmentStepdefs {
       eRoles.roles.add(roleType!);
     }
 
-    await common.groupService.updateGroupOnPortfolio(shared.portfolio.id,
+    await common.groupService.updateGroupOnPortfolioV2(shared.portfolio.id,
         UpdateGroup(id: updatedGroup.id, version: updatedGroup.version, environmentRoles: updatedGroup.environmentRoles),
         updateEnvironmentGroupRoles: true);
   }
@@ -347,7 +347,7 @@ class EnvironmentStepdefs {
     egr.roles.add(RoleType.UNLOCK);
 
     group.environmentRoles.add(egr);
-    await common.groupService.updateGroupOnPortfolio(group.portfolioId!,
+    await common.groupService.updateGroupOnPortfolioV2(group.portfolioId!,
         UpdateGroup(id: group.id, version: group.version, environmentRoles: group.environmentRoles),
         includeGroupRoles: true, updateEnvironmentGroupRoles: true);
   }


### PR DESCRIPTION
# Description

Decided cannot just remove it outright as folks may depend on it.
old updateGroup has been deprecated for several versions now, new
one is cleaner.

