### PR TITLE
fix overflow in the DataTable on feature filters table

### DIFF
--- a/admin-frontend/open_admin_app/lib/routes/feature_filters_route.dart
+++ b/admin-frontend/open_admin_app/lib/routes/feature_filters_route.dart
@@ -87,6 +87,11 @@ class _FeatureFiltersRouteState extends State<FeatureFiltersRoute> {
                 padding: const EdgeInsets.all(16.0),
                 child: Card(
                   child: DataTable(
+                    // Rows must grow to fit filters used by multiple
+                    // applications/service accounts; the default fixed row
+                    // height clips and overlaps multi-line cells.
+                    dataRowMinHeight: kMinInteractiveDimension,
+                    dataRowMaxHeight: double.infinity,
                     columns: [
                       DataColumn(label: Text(l10n.columnName)),
                       DataColumn(label: Text(l10n.filterTableDescriptionLabel)),


### PR DESCRIPTION
# Description

Fix an issue reported via Slack, whereby feature filters table has an overflow when more than 2 apps use a strategy. 